### PR TITLE
687: Allow users that can import glossaries to flush them at import

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -275,7 +275,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		}
 
 		$replace = gp_post( 'import-flush' );
-		if ( 'on' === $replace && $this->can( 'write', 'project', $project->id ) ) {
+		if ( 'on' === $replace && $this->can( 'approve', 'translation-set', $translation_set->id ) ) {
 			GP::$glossary_entry->delete_many( array( 'glossary_id' => $glossary->id ) );
 		}
 

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -236,7 +236,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return;
 		}
 
-		$can_write = $this->can( 'write', 'project', $project->id );
+		$can_edit = $this->can( 'approve', 'translation-set', $translation_set->id );
 
 		$this->tmpl( 'glossary-import', get_defined_vars() );
 	}

--- a/gp-templates/glossary-import.php
+++ b/gp-templates/glossary-import.php
@@ -19,7 +19,7 @@ gp_tmpl_header();
 		<label for="import-file"><?php _e( 'Import File:', 'glotpress' ); ?></label>
 		<input type="file" name="import-file" id="import-file" />
 	</p>
-	<?php if ( $can_write ) : ?>
+	<?php if ( $can_edit ) : ?>
 		<p>
 			<label for="import-flush">
 				<input type="checkbox" id="import-flush" name="import-flush" />


### PR DESCRIPTION
It would be great if users that are able to import glossaries to also be able to flush them at import.

If users with the right permissions are not able to flush at import, it's quite a mess. If the import file contains entries that are already in the glossary these will be added once again at each import.

For reference, the Romanian Team uses an exported file from Google SpreadSheets to update the glossary. Since there is no way to flush at import or to delete the glossary we're facing lots of duplicates: https://translate.wordpress.org/locale/ro/default/glossary. Furthermore there is no bulk-action to delete the entries, which makes the cleanup process quite hard.

IMHO, allowing users that can import glossaries to also flush them is the best approach.

Fixes #687.