### PR TITLE
681: Copy from original: UI improvements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,6 +445,28 @@ span.morethan90 {
 	font-weight: bold;
 }
 
+.editor .copy {
+	position: relative;
+	top: -50px;
+	left: 6px;
+	border: 1px solid #ccc;
+	display: inline-block;
+	padding: 2px 4px;
+	color: #333;
+	background: #fbfbfb;
+	float: left;
+	text-decoration: none;
+}
+
+.editor .copy:hover {
+	background: #fff;
+}
+
+.editor .copy:active {
+	border-style: inset;
+	padding: 2px 4px 2px 3px;
+}
+
 /*
  * JavaScript, errors and notices.
  */

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -85,7 +85,9 @@ $gp.editor = (
 					.on( 'click', 'button.reject', $gp.editor.hooks.set_status_rejected )
 					.on( 'click', 'button.fuzzy', $gp.editor.hooks.set_status_fuzzy )
 					.on( 'click', 'button.ok', $gp.editor.hooks.ok )
-					.on( 'keydown', 'tr.editor textarea', $gp.editor.hooks.keydown );
+					.on( 'keydown', 'tr.editor textarea', $gp.editor.hooks.keydown )
+					.on( 'input', 'tr.editor textarea', $gp.editor.hooks.textarea_edit );
+
 				$( '#translations' ).tooltip( {
 					items: '.glossary-word',
 					content: function() {
@@ -339,7 +341,17 @@ $gp.editor = (
 
 				original_text = original_text.text();
 				original_text = original_text.replace( /<span class=.invisibles.*?<\/span>/g, '' );
-				link.parents( '.textareas' ).find( 'textarea' ).val( original_text ).focus();
+				link.parents( '.textareas' ).find( 'textarea' ).val( original_text ).trigger( 'input' ).focus();
+
+			},
+			textarea_edit: function( textarea ) {
+				var isEmpty = ! $.trim( textarea.val() );
+				var $copylink = textarea.next( 'p' ).find( '.copy' );
+				if ( ! isEmpty ) {
+					$copylink.hide();
+				} else {
+					$copylink.show();
+				}
 			},
 			hooks: {
 				show: function() {
@@ -379,6 +391,10 @@ $gp.editor = (
 				},
 				set_priority: function() {
 					$gp.editor.set_priority( $( this ) );
+					return false;
+				},
+				textarea_edit: function() {
+					$gp.editor.textarea_edit( $( this ) );
 					return false;
 				}
 			}


### PR DESCRIPTION
Make the link look like a button inside the textrea, but hide that button if the contents of the textarea have changed.

Gif:
![nz9rjxwohe](https://cloud.githubusercontent.com/assets/844866/23586057/103771da-0196-11e7-8cb7-eb9baf62d39b.gif)

I didn't actually change the html element to a button - but I don't mind doing that if there's demand.

Fixes #681
