### PR TITLE
Correct 'old' option string text

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -107,7 +107,7 @@ $i = 0;
 				array(
 					'current_or_waiting_or_fuzzy_or_untranslated' => __( 'Current/waiting/fuzzy + untranslated (All)', 'glotpress' ),
 					'current' => __( 'Current only', 'glotpress' ),
-					'old' => __( 'Approved, but obsoleted by another string', 'glotpress' ),
+					'old' => __( 'Approved, but obsoleted by another translation', 'glotpress' ),
 					'waiting' => __( 'Waiting approval', 'glotpress' ),
 					'rejected' => __( 'Rejected', 'glotpress' ),
 					'untranslated' => __( 'Without current translation', 'glotpress' ),


### PR DESCRIPTION
A string turns obsoleted (old) when a new translation exists, not by the existence of another different/similar string.