### PR TITLE
704: Alternate add glossary tooltips after editing a row.

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -253,6 +253,8 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
+		$glossary = $this->get_extended_glossary( $translation_set, $project );
+
 		$output = array();
 		foreach( gp_post( 'translation', array() ) as $original_id => $translations) {
 			$data = compact('original_id');

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -563,6 +563,8 @@ class GP_Route_Translation extends GP_Route_Main {
 			return $this->die_with_404();
 		}
 
+		$glossary = $this->get_extended_glossary( $translation_set, $project );
+		
 		$translation = GP::$translation->get( gp_post( 'translation_id' ) );
 
 		if ( ! $translation ) {

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -564,7 +564,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		$glossary = $this->get_extended_glossary( $translation_set, $project );
-		
+
 		$translation = GP::$translation->get( gp_post( 'translation_id' ) );
 
 		if ( ! $translation ) {

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -60,14 +60,14 @@ function gp_prepare_translation_textarea( $text ) {
 	return $text;
 }
 
-/*
+/**
  * Sort a set of glossary entries by length for use in map_glossary_entries_to_translation_originals().
  *
  * @param array $glossary_entries An array of glossary entries to sort.
  *
  * @return array The sorted entries.
  */
-function sort_glossary_entries_terms( $glossary_entries ) {
+function gp_sort_glossary_entries_terms( $glossary_entries ) {
 	if ( empty ( $glossary_entries ) ) {
 		return;
 	}
@@ -98,27 +98,29 @@ function sort_glossary_entries_terms( $glossary_entries ) {
 	}
 
 	uasort( $glossary_entries_terms, function( $a, $b ) { return gp_strlen($a) < gp_strlen($b); } );
-	
+
 	return $glossary_entries_terms;
 }
 
 /**
  * Add markup to a translation original to identify the glossary terms.
  *
- * @param obj $glossary_entry An array of glossary entries to sort.
+ * @param GP_Translation $translation            A GP Translation object.
+ * @param GP_Glossary    $glossary               A GP Glossary object.
+ * @param array          $glossary_entries_terms A list of terms to highligh.
  *
  * @return obj The marked up translation entry.
  */
 function map_glossary_entries_to_translation_originals( $translation, $glossary, $glossary_entries_terms = null ) {
 	$glossary_entries = $glossary->get_entries();
-	if ( empty ( $glossary_entries ) ) {
+	if ( empty( $glossary_entries ) ) {
 		return $translation;
 	}
 
-	if( null === $glossary_entries_terms || ! is_array( $glossary_entries_terms ) ) {
-		$glossary_entries_terms = sort_glossary_entries_terms( $glossary_entries );
+	if ( null === $glossary_entries_terms || ! is_array( $glossary_entries_terms ) ) {
+		$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
 	}
-	
+
 	// Save our current singular/plural strings before attempting any markup change. Also escape now, since we're going to add some html.
 	$translation->singular_glossary_markup = esc_translation( $translation->singular );
 	$translation->plural_glossary_markup   = esc_translation( $translation->plural );
@@ -135,7 +137,12 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 				$locale_entry = _x( 'Locale Glossary', 'Bubble', 'glotpress' );
 			}
 
-			$matching_entries[ $m[1] ][] = array( 'translation' => $glossary_entry->translation, 'pos' => $glossary_entry->part_of_speech, 'comment' => $glossary_entry->comment, 'locale_entry' => $locale_entry );
+			$matching_entries[ $m[1] ][] = array(
+				'translation' => $glossary_entry->translation,
+				'pos'         => $glossary_entry->part_of_speech,
+				'comment'     => $glossary_entry->comment,
+				'locale_entry' => $locale_entry,
+				);
 		}
 	}
 

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -40,6 +40,13 @@ $more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history 
  */
 $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $t );
 
+if( ! isset( $glossary_entries_terms ) ) {
+	$glossary_entries = $glossary->get_entries();
+	$glossary_entries_terms = sort_glossary_entries_terms( $glossary_entries );
+}
+
+$t = map_glossary_entries_to_translation_originals( $t, $glossary, $glossary_entries_terms );
+
 ?>
 
 <tr class="preview <?php gp_translation_row_classes( $t ); ?>" id="preview-<?php echo esc_attr( $t->row_id ) ?>" row="<?php echo esc_attr( $t->row_id ); ?>">

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -40,9 +40,9 @@ $more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history 
  */
 $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $t );
 
-if( ! isset( $glossary_entries_terms ) ) {
+if ( ! isset( $glossary_entries_terms ) ) {
 	$glossary_entries = $glossary->get_entries();
-	$glossary_entries_terms = sort_glossary_entries_terms( $glossary_entries );
+	$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
 }
 
 $t = map_glossary_entries_to_translation_originals( $t, $glossary, $glossary_entries_terms );

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -40,12 +40,14 @@ $more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history 
  */
 $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $t );
 
-if ( ! isset( $glossary_entries_terms ) ) {
-	$glossary_entries = $glossary->get_entries();
-	$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
-}
+if ( is_object( $glossary ) ) {
+	if ( ! isset( $glossary_entries_terms ) ) {
+		$glossary_entries = $glossary->get_entries();
+		$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
+	}
 
-$t = map_glossary_entries_to_translation_originals( $t, $glossary, $glossary_entries_terms );
+	$t = map_glossary_entries_to_translation_originals( $t, $glossary, $glossary_entries_terms );
+}
 
 ?>
 

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -196,7 +196,8 @@ $i = 0;
 	</thead>
 <?php
 	if ( $glossary ) {
-		$translations = map_glossary_entries_to_translations_originals( $translations, $glossary );
+		$glossary_entries = $glossary->get_entries();
+		$glossary_entries_terms = sort_glossary_entries_terms( $glossary_entries );
 	}
 ?>
 <?php foreach( $translations as $t ):

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -197,7 +197,7 @@ $i = 0;
 <?php
 	if ( $glossary ) {
 		$glossary_entries = $glossary->get_entries();
-		$glossary_entries_terms = sort_glossary_entries_terms( $glossary_entries );
+		$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
 	}
 ?>
 <?php foreach( $translations as $t ):

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -109,8 +109,11 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 			$this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => $original, 'plural' => $original, ) );
 		}
 
-		$translations = GP::$translation->for_translation( $set->project, $set, 'no-limit' );
-		$translations = map_glossary_entries_to_translations_originals( $translations, $glossary );
+		$translations = array();
+		$temp_translations = GP::$translation->for_translation( $set->project, $set, 'no-limit' );
+		foreach ( $temp_translations as $t ) {
+			$translations[] = map_glossary_entries_to_translation_originals( $t, $glossary );
+		}
 
 		foreach ( $translations as $translation ) {
 			foreach ( $originals[ $translation->singular ] as $term ) {


### PR DESCRIPTION
This is an alternate solution to #704.

This splits the previous `map_glossary_entries_to_translations_originals()` function in two:
- `map_glossary_entries_to_translation_originals()`
- `sort_glossary_entries_terms()`

And adds an additional parameter to allow for the entries_terms to be passed in so they can be processed once when generating the full translation page instead of per row that would otherwise be required.

`sort_glossary_entries_terms()` is called either in the translations template or the translations-row template as required.

Then `map_glossary_entries_to_translation_originals()` is called in the translations-row template to allow for the glossary terms to be marked up from either the main translations page or via the ajax call to the translations-row entry.

If we were to be concerned for backwards compatibility with modified template files, we could add a shim to put `map_glossary_entries_to_translations_originals()` back in the helper file.

Resolves #704.