### PR TITLE
New format for NGX-Translate

### DIFF
--- a/gp-settings.php
+++ b/gp-settings.php
@@ -120,6 +120,7 @@ require_once GP_PATH . GP_INC . 'formats/format-strings.php';
 require_once GP_PATH . GP_INC . 'formats/format-properties.php';
 require_once GP_PATH . GP_INC . 'formats/format-json.php';
 require_once GP_PATH . GP_INC . 'formats/format-jed1x.php';
+require_once GP_PATH . GP_INC . 'formats/format-ngx.php';
 
 // Let's do it again, there are more variables added since last time we called it.
 gp_set_globals( get_defined_vars() );


### PR DESCRIPTION
Hi, i tried to use the json format to be able to import/export json files for NGX-Translate (used in Ionic and Angular mobile application development).
Unfortunately, the json format produced is not exactly the same for NGX-translate.
I wrote the format class to be able to manage NGX-Translate json files.
It should be useful to include this format for the growing Ionic/Angular developers population

Thanks a lot !