### PR TITLE
New feature - Add format for NGX-Translate (used in Ionic and Angular projects)

### DIFF
--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -52,7 +52,7 @@ class GP_Format_NGX extends GP_Format {
 		/* @var Translation_Entry $entry */
 		foreach ( $entries as $entry ) {
 			
-			$key = $entry->singular;
+			$key = $entry->context;
 			$arrayKeyIndex = strpos( $key, "[" );
 			if ( false !== $arrayKeyIndex ) {
 				$entryKey = substr( $key, 0, $arrayKeyIndex);
@@ -110,30 +110,17 @@ class GP_Format_NGX extends GP_Format {
 					if ( isset( $valueElem['key'] )
 					  && isset( $valueElem['translation'] )) {   					
 						$args = array(
-							'singular' => $key . "[" . $valueElem['key'] . "]",
+							'singular' => $valueElem['translation'],
+							'context' => $key . "[" . $valueElem['key'] . "]",
 						);
-/*						if ( false !== strpos( $key, chr( 4 ) ) ) {
-							$key              = explode( chr( 4 ), $key );
-							$args['context']  = $key[0];
-							$args['singular'] = $key[1] . "[" . $valueElem['key'] . "]";
-						}*/
-						if ( isset( $valueElem ) ) {
-							$args['translations'][0] = $valueElem['translation'];
-						}
 						$entries->add_entry( new Translation_Entry( $args ) );
 					}		
 				};
 			} else {			
 				$args = array(
-					'singular' => $key,
+					'singular' => $value,
+					'context' => $key,
 				);
-
-				if ( false !== strpos( $key, chr( 4 ) ) ) {
-					$key              = explode( chr( 4 ), $key );
-					$args['context']  = $key[0];
-					$args['singular'] = $key[1];
-				}
-				$args['translations'][0] = $value;
 				$entries->add_entry( new Translation_Entry( $args ) );
 			}
 
@@ -141,27 +128,6 @@ class GP_Format_NGX extends GP_Format {
 		return $entries;
 	}
 
-	/**
-	 * Reads a set of translations from a JSON file.
-	 *
-	 * @since 2.3.0
-	 *
-	 * @param string     $file_name The name of the uploaded properties file.
-	 * @param GP_Project $project   Unused. The project object to read the translations into.
-	 * @return Translations|bool The extracted translations on success, false on failure.
-	 */
-	public function read_translations_from_file( $file_name, $project = null ) {
-		return $this->read_originals_from_file( $file_name );
-	}
-
-	/**
-	 * Loads a given JSON file and decodes its content.
-	 *
-	 * @since 2.3.0
-	 *
-	 * @param string $file_name The name of the JSON file to parse.
-	 * @return array|false The encoded value or false on failure.
-	 */
 	protected function decode_json_file( $file_name ) {
 		if ( ! file_exists( $file_name ) ) {
 			return false;

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -33,7 +33,7 @@ class GP_Format_NGX extends GP_Format {
 
 	/**
 	 * Generates a string the contains the $entries to export in the JSON file format.
-	 * 
+	 *
 	 * @since 2.4.0
 	 *
 	 * @param GP_Project         $project         The project the strings are being exported for, not used

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -2,7 +2,7 @@
 /**
  * GlotPress Format NGX Translate class
  *
- * @since 2.3.0
+ * @since 2.4.0
  *
  * @package GlotPress
  */
@@ -10,13 +10,13 @@
 /**
  * Format class used to support NGX Translate JSON file format.
  *
- * @since 2.3.0
+ * @since 2.4.0
  */
 class GP_Format_NGX extends GP_Format {
 	/**
 	 * Name of file format, used in file format dropdowns.
 	 *
-	 * @since 2.3.0
+	 * @since 2.4.0
 	 *
 	 * @var string
 	 */
@@ -25,7 +25,7 @@ class GP_Format_NGX extends GP_Format {
 	/**
 	 * File extension of the file format, used to autodetect formats and when creating the output file names.
 	 *
-	 * @since 2.3.0
+	 * @since 2.4.0
 	 *
 	 * @var string
 	 */
@@ -34,7 +34,7 @@ class GP_Format_NGX extends GP_Format {
 	/**
 	 * Generates a string the contains the $entries to export in the JSON file format.
 	 *
-	 * @since 2.3.0
+	 * @since 2.4.0
 	 *
 	 * @param GP_Project         $project         The project the strings are being exported for, not used
 	 *                                            in this format but part of the scaffold of the parent object.
@@ -73,7 +73,7 @@ class GP_Format_NGX extends GP_Format {
 		/**
 		 * Filter whether the exported JSON should be pretty printed.
 		 *
-		 * @since 2.3.0
+		 * @since 2.4.0
 		 *
 		 * @param bool $pretty_print Whether pretty print should be enabled or not. Default false.
 		 */
@@ -85,7 +85,7 @@ class GP_Format_NGX extends GP_Format {
 	/**
 	 * Reads a set of original strings from a JSON file.
 	 *
-	 * @since 2.3.0
+	 * @since 2.4.0
 	 *
 	 * @param string $file_name The name of the uploaded JSON file.
 	 * @return Translations|bool The extracted originals on success, false on failure.

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -51,24 +51,24 @@ class GP_Format_NGX extends GP_Format {
 
 		/* @var Translation_Entry $entry */
 		foreach ( $entries as $entry ) {
-			
 			$key = $entry->context;
-			$arrayKeyIndex = strpos( $key, "[" );
-			if ( false !== $arrayKeyIndex ) {
-				$entryKey = substr( $key, 0, $arrayKeyIndex);
- 				$keyPair = substr( $key, $arrayKeyIndex + 1, strlen($key) - $arrayKeyIndex - 2 );
-				$valuePair = array( 'key' => $keyPair, 'translation' => $entry->translations[0] );
-				if ( is_array( $result[ $entryKey ] ) ) {
-					array_push( $result[ $entryKey ], $valuePair);
+			$arraykeyindex = strpos( $key, '[' );
+			if ( false !== $arraykeyindex ) {
+				$entrykey = substr( $key, 0, $arraykeyindex );
+				$keypair = substr( $key, $arraykeyindex + 1, strlen( $key ) - $arraykeyindex - 2 );
+				$valuepair = array( 
+					'key' => $keypair,
+					'translation' => $entry->translations[ 0 ] );
+				if ( is_array( $result[ $entrykey ] ) ) {
+					array_push( $result[ $entrykey ], $valuepair );
 				} else {
-					$result[ $entryKey ] = array();
-					array_push( $result[ $entryKey ], $valuePair);
+					$result[ $entrykey ] = array();
+					array_push( $result[ $entrykey ], $valuepair );
 				}
 			} else {
-				$result[ $key ] = $entry->translations[0];
+				$result[ $key ] = $entry->translations[ 0 ];
 			}
-
-		} 
+		}
 
 		/**
 		 * Filter whether the exported JSON should be pretty printed.
@@ -92,31 +92,26 @@ class GP_Format_NGX extends GP_Format {
 	 */
 	public function read_originals_from_file( $file_name ) {
 		$json = $this->decode_json_file( $file_name );
-
 		if ( ! $json ) {
 			return false;
 		}
-
 		$entries = new Translations();
-
 		foreach ( $json as $key => $value ) {
-			
 			if ( '' === $key ) {
 				continue;
 			}
-
 			if ( is_array( $value ) ) {
-			 	foreach ( $value as $keyElem => $valueElem) { 
-					if ( isset( $valueElem['key'] )
-					  && isset( $valueElem['translation'] )) {   					
+			 	foreach ( $value as $keyelem => $valueelem) {
+					if ( isset( $valueelem[ 'key' ] )
+					  && isset( $valueelem[ 'translation' ] ) ) {
 						$args = array(
-							'singular' => $valueElem['translation'],
-							'context' => $key . "[" . $valueElem['key'] . "]",
+							'singular' => $valueelem[ 'translation' ],
+							'context' => $key . '[' . $valueelem[ 'key' ] . ']',
 						);
 						$entries->add_entry( new Translation_Entry( $args ) );
-					}		
+					}
 				};
-			} else {			
+			} else {
 				$args = array(
 					'singular' => $value,
 					'context' => $key,
@@ -127,24 +122,20 @@ class GP_Format_NGX extends GP_Format {
 		}
 		return $entries;
 	}
-
 	protected function decode_json_file( $file_name ) {
 		if ( ! file_exists( $file_name ) ) {
 			return false;
 		}
-
 		$file = file_get_contents( $file_name );
 
 		if ( ! $file ) {
 			return false;
 		}
-
 		$json = json_decode( $file, true );
 
 		if ( null === $json ) {
 			return false;
 		}
-
 		return $json;
 	}
 }

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -58,7 +58,8 @@ class GP_Format_NGX extends GP_Format {
 				$keypair = substr( $key, $arraykeyindex + 1, strlen( $key ) - $arraykeyindex - 2 );
 				$valuepair = array(
 					'key' => $keypair,
-					'translation' => $entry->translations[0], );
+					'translation' => $entry->translations[0],
+				);
 				if ( is_array( $result[ $entrykey ] ) ) {
 					array_push( $result[ $entrykey ], $valuepair );
 				} else {
@@ -101,12 +102,12 @@ class GP_Format_NGX extends GP_Format {
 				continue;
 			}
 			if ( is_array( $value ) ) {
-			 	foreach ( $value as $keyelem => $valueelem) {
+				foreach ( $value as $keyelem => $valueelem ) {
 					if ( isset( $valueelem['key'] )
 					  && isset( $valueelem['translation'] ) ) {
 						$args = array(
-							'singular' => $valueelem[ 'translation' ],
-							'context' => $key . '[' . $valueelem[ 'key' ] . ']',
+							'singular' => $valueelem['translation'],
+							'context' => $key . '[' . $valueelem['key'] . ']',
 						);
 						$entries->add_entry( new Translation_Entry( $args ) );
 					}
@@ -118,7 +119,6 @@ class GP_Format_NGX extends GP_Format {
 				);
 				$entries->add_entry( new Translation_Entry( $args ) );
 			}
-
 		}
 		return $entries;
 	}

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -56,9 +56,9 @@ class GP_Format_NGX extends GP_Format {
 			if ( false !== $arraykeyindex ) {
 				$entrykey = substr( $key, 0, $arraykeyindex );
 				$keypair = substr( $key, $arraykeyindex + 1, strlen( $key ) - $arraykeyindex - 2 );
-				$valuepair = array( 
+				$valuepair = array(
 					'key' => $keypair,
-					'translation' => $entry->translations[ 0 ] );
+					'translation' => $entry->translations[0], );
 				if ( is_array( $result[ $entrykey ] ) ) {
 					array_push( $result[ $entrykey ], $valuepair );
 				} else {
@@ -66,7 +66,7 @@ class GP_Format_NGX extends GP_Format {
 					array_push( $result[ $entrykey ], $valuepair );
 				}
 			} else {
-				$result[ $key ] = $entry->translations[ 0 ];
+				$result[ $key ] = $entry->translations[0];
 			}
 		}
 
@@ -102,8 +102,8 @@ class GP_Format_NGX extends GP_Format {
 			}
 			if ( is_array( $value ) ) {
 			 	foreach ( $value as $keyelem => $valueelem) {
-					if ( isset( $valueelem[ 'key' ] )
-					  && isset( $valueelem[ 'translation' ] ) ) {
+					if ( isset( $valueelem['key'] )
+					  && isset( $valueelem['translation'] ) ) {
 						$args = array(
 							'singular' => $valueelem[ 'translation' ],
 							'context' => $key . '[' . $valueelem[ 'key' ] . ']',

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -33,7 +33,7 @@ class GP_Format_NGX extends GP_Format {
 
 	/**
 	 * Generates a string the contains the $entries to export in the JSON file format.
-	 *
+	 * 
 	 * @since 2.4.0
 	 *
 	 * @param GP_Project         $project         The project the strings are being exported for, not used

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -122,6 +122,15 @@ class GP_Format_NGX extends GP_Format {
 		}
 		return $entries;
 	}
+	
+	/**
+	 * Decode a JSON file.
+	 *
+	 * @since 2.4.0
+	 *
+	 * @param string $file_name The name of the JSON file to decode.
+	 * @return decode JSON file as an array.
+	 */
 	protected function decode_json_file( $file_name ) {
 		if ( ! file_exists( $file_name ) ) {
 			return false;

--- a/gp-includes/formats/format-ngx.php
+++ b/gp-includes/formats/format-ngx.php
@@ -122,7 +122,6 @@ class GP_Format_NGX extends GP_Format {
 		}
 		return $entries;
 	}
-	
 	/**
 	 * Decode a JSON file.
 	 *

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -120,6 +120,7 @@ require_once GP_PATH . GP_INC . 'formats/format-strings.php';
 require_once GP_PATH . GP_INC . 'formats/format-properties.php';
 require_once GP_PATH . GP_INC . 'formats/format-json.php';
 require_once GP_PATH . GP_INC . 'formats/format-jed1x.php';
+require_once GP_PATH . GP_INC . 'formats/format-ngx.php';
 
 // Let's do it again, there are more variables added since last time we called it.
 gp_set_globals( get_defined_vars() );

--- a/tests/phpunit/data/originals-ngx.json
+++ b/tests/phpunit/data/originals-ngx.json
@@ -1,0 +1,9 @@
+{
+  "ORIGINAL1": "This file is too big. Files must be less than %d KB in size.",
+  "ORIGINAL2": "%d Theme Update",
+  "ORIGINAL3": "password strength",
+  "ORIGINAL4": "taxonomy singular name",
+  "ORIGINAL5": "post type general name",
+  "ORIGINAL6": [{ "key": "1", "translation": "on" },
+                { "key": "2", "translation": "off" }]
+}

--- a/tests/phpunit/data/translation-ngx.json
+++ b/tests/phpunit/data/translation-ngx.json
@@ -1,0 +1,9 @@
+{
+  "ORIGINAL1": "Ce fichier est trop grang. Les fichiers doivent avoir une taille plus petite que %d KB.",
+  "ORIGINAL2": "%d Mise \u00e0 jour de th\u00e8me",
+  "ORIGINAL3": "Force du mot de passe",
+  "ORIGINAL4": "Nom de la taxonomie au singulier",
+  "ORIGINAL5": "Nom g\u00e9n\u00e9rique pour les posts",
+  "ORIGINAL6": [{ "key": "1", "translation": "actif" },
+                { "key": "2", "translation": "inactif" }]
+}

--- a/tests/phpunit/testcases/test_format_ngx.php
+++ b/tests/phpunit/testcases/test_format_ngx.php
@@ -1,0 +1,171 @@
+<?php
+
+class GP_Test_Format_JSON extends GP_UnitTestCase {
+	/**
+	 * @var GP_Translation_Set
+	 */
+	protected $translation_set;
+
+	/**
+	 * @var GP_Locale
+	 */
+	protected $locale;
+
+	/**
+	 * @var string
+	 */
+	protected $format = 'ngx';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->translation_set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'name' => 'foo_project' ) );
+
+		$this->locale = new GP_Locale( array(
+			'slug'              => $this->translation_set->locale,
+			'nplurals'          => 2,
+			'plural_expression' => 'n != 1',
+		) );
+	}
+
+	public function test_format_name() {
+		$this->assertSame( 'NGX-Translate (.json)', GP::$formats[ $this->format ]->name );
+	}
+
+	public function test_format_extension() {
+		$this->assertSame( 'json', GP::$formats[ $this->format ]->extension );
+	}
+
+	public function test_print_exported_file_can_be_decoded() {
+		$entries = array(
+			new Translation_Entry( array( 'singular' => 'foo', 'translations' => array( 'foox' ) ) ),
+		);
+
+		$json = GP::$formats[ $this->format ]->print_exported_file( $this->translation_set->project, $this->locale, $this->translation_set, $entries );
+
+		$this->assertNotNull( json_decode( $json, true ) );
+	}
+
+	public function test_print_exported_file_has_valid_format() {
+		$entries = array(
+			new Translation_Entry( array( 'singular' => 'foo', 'context' => 'STG1', 'translations' => 'bar' ) ),
+			new Translation_Entry( array( 'singular' => 'bar', 'context' => 'STG2', 'translations' => 'baz' ) ),
+		);
+
+		$json = GP::$formats[ $this->format ]->print_exported_file( $this->translation_set->project, $this->locale, $this->translation_set, $entries );
+
+		$actual = json_decode( $json, true );
+
+		$this->assertEquals( array(
+			'STG1' => 'bar',
+			'STG2' => 'baz',
+		), $actual );
+	}
+
+	public function test_read_originals_from_file_non_existent_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/foo.json' ) );
+	}
+
+	public function test_read_originals_from_file_invalid_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
+	}
+
+	public function test_read_originals_from_file() {
+		$expected = $this->data_example_originals();
+
+		/* @var Translations $actual */
+		$actual = GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/originals-ngx.json' );
+		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_read_translations_from_file_non_existent_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/foo.json' ) );
+	}
+
+	public function test_read_translations_from_file_invalid_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
+	}
+
+	public function test_read_translations_from_file() {
+		$expected = $this->data_example_translations();
+
+		/* @var Translations $actual */
+		$actual = GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/translation-ngx.json' );
+
+		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Returns the expected data for the parsed example-untranslated.json file.
+	 */
+	public function data_example_originals() {
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'This file is too big. Files must be less than %d KB in size.',
+			'context'  => 'ORIGINAL1',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => '%d Theme Update',
+			'context'  => 'ORIGINAL2',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'password strength',
+			'context'  => 'ORIGINAL3',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'taxonomy singular name',
+			'context'  => 'ORIGINAL4',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'post type general name',
+			'context'  => 'ORIGINAL5',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'on',
+			'context'  => 'ORIGINAL6[1]',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'off',
+			'context'  => 'ORIGINAL6[2]',
+		) ) );
+		return $translations;
+	}
+
+	/**
+	 * Returns the expected data for the parsed example-untranslated.json file.
+	 */
+	public function data_example_translations() {
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Ce fichier est trop grang. Les fichiers doivent avoir une taille plus petite que %d KB.',
+			'context'  => 'ORIGINAL1',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => '%d Mise \u00e0 jour de th\u00e8me',
+			'context'  => 'ORIGINAL2',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Force du mot de passe',
+			'context'  => 'ORIGINAL3',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Nom de la taxonomie au singulier',
+			'context'  => 'ORIGINAL4',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Nom générique pour les posts',
+			'context'  => 'ORIGINAL5',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'actif',
+			'context'  => 'ORIGINAL6[1]',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'inactif',
+			'context'  => 'ORIGINAL6[2]',
+		) ) );
+		return $translations;
+	}
+}

--- a/tests/phpunit/testcases/tests_formats/test_format_ngx.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_ngx.php
@@ -1,0 +1,171 @@
+<?php
+
+class GP_Test_Format_JSON extends GP_UnitTestCase {
+	/**
+	 * @var GP_Translation_Set
+	 */
+	protected $translation_set;
+
+	/**
+	 * @var GP_Locale
+	 */
+	protected $locale;
+
+	/**
+	 * @var string
+	 */
+	protected $format = 'ngx';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->translation_set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'name' => 'foo_project' ) );
+
+		$this->locale = new GP_Locale( array(
+			'slug'              => $this->translation_set->locale,
+			'nplurals'          => 2,
+			'plural_expression' => 'n != 1',
+		) );
+	}
+
+	public function test_format_name() {
+		$this->assertSame( 'NGX-Translate (.json)', GP::$formats[ $this->format ]->name );
+	}
+
+	public function test_format_extension() {
+		$this->assertSame( 'json', GP::$formats[ $this->format ]->extension );
+	}
+
+	public function test_print_exported_file_can_be_decoded() {
+		$entries = array(
+			new Translation_Entry( array( 'singular' => 'foo', 'translations' => array( 'foox' ) ) ),
+		);
+
+		$json = GP::$formats[ $this->format ]->print_exported_file( $this->translation_set->project, $this->locale, $this->translation_set, $entries );
+
+		$this->assertNotNull( json_decode( $json, true ) );
+	}
+
+	public function test_print_exported_file_has_valid_format() {
+		$entries = array(
+			new Translation_Entry( array( 'singular' => 'foo', 'translations' => array( 'bar' ) ) ),
+			new Translation_Entry( array( 'singular' => 'bar', 'translations' => array( 'baz' ) ) ),
+		);
+
+		$json = GP::$formats[ $this->format ]->print_exported_file( $this->translation_set->project, $this->locale, $this->translation_set, $entries );
+
+		$actual = json_decode( $json, true );
+
+		$this->assertEquals( array(
+			'foo' => array( 'bar' ),
+			'bar' => array( 'baz' ),
+		), $actual );
+	}
+
+	public function test_read_originals_from_file_non_existent_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/foo.json' ) );
+	}
+
+	public function test_read_originals_from_file_invalid_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
+	}
+
+	public function test_read_originals_from_file() {
+		$expected = $this->data_example_originals();
+
+		/* @var Translations $actual */
+		$actual = GP::$formats[ $this->format ]->read_originals_from_file( GP_DIR_TESTDATA . '/originals-ngx.json' );
+		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_read_translations_from_file_non_existent_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/foo.json' ) );
+	}
+
+	public function test_read_translations_from_file_invalid_file() {
+		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
+	}
+
+	public function test_read_translations_from_file() {
+		$expected = $this->data_example_translations();
+
+		/* @var Translations $actual */
+		$actual = GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/translation-ngx.json' );
+
+		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Returns the expected data for the parsed example-untranslated.json file.
+	 */
+	public function data_example_originals() {
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'This file is too big. Files must be less than %d KB in size.',
+			'context'  => 'ORIGINAL1',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => '%d Theme Update',
+			'context'  => 'ORIGINAL2',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'password strength',
+			'context'  => 'ORIGINAL3',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'taxonomy singular name',
+			'context'  => 'ORIGINAL4',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'post type general name',
+			'context'  => 'ORIGINAL5',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'on',
+			'context'  => 'ORIGINAL6[1]',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'off',
+			'context'  => 'ORIGINAL6[2]',
+		) ) );
+		return $translations;
+	}
+
+	/**
+	 * Returns the expected data for the parsed example-untranslated.json file.
+	 */
+	public function data_example_translations() {
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Ce fichier est trop grang. Les fichiers doivent avoir une taille plus petite que %d KB.',
+			'context'  => 'ORIGINAL1',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => '%d Mise \u00e0 jour de th\u00e8me',
+			'context'  => 'ORIGINAL2',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Force du mot de passe',
+			'context'  => 'ORIGINAL3',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Nom de la taxonomie au singulier',
+			'context'  => 'ORIGINAL4',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'Nom générique pour les posts',
+			'context'  => 'ORIGINAL5',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'actif',
+			'context'  => 'ORIGINAL6[1]',
+		) ) );
+		$translations->add_entry( new Translation_Entry( array(
+			'singular' => 'inactif',
+			'context'  => 'ORIGINAL6[2]',
+		) ) );
+		return $translations;
+	}
+}


### PR DESCRIPTION
Hi, i tried to use the json format to be able to import/export json files for NGX-Translate (used in Ionic and Angular mobile application development).
Unfortunately, the json format produced is not exactly the same for NGX-translate.
I wrote the format class to be able to manage NGX-Translate json files.
It should be useful to include this format for the growing Ionic/Angular developers population

Thanks a lot !