### PR TITLE
Travis: Remove node_js from language section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ cache:
     - $HOME/phpunit-bin
     - $HOME/.composer/cache
 
-language:
-  - php
-  - node_js
+language: php
 
 matrix:
   allow_failures:


### PR DESCRIPTION
```
$ travis lint .travis.yml
Warnings for .travis.yml:
[x] in language section: does not support multiple values, dropping node_js
```