### PR TITLE
688: Update Ewe locale with relevant information

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -541,9 +541,10 @@ class GP_Locales {
 		$ewe->native_name = 'Eʋegbe';
 		$ewe->lang_code_iso_639_1 = 'ee';
 		$ewe->lang_code_iso_639_2 = 'ewe';
+		$ewe->lang_code_iso_639_3 = 'ewe';
 		$ewe->country_code = 'gh';
-		$ewe->wp_locale = 'ee';
-		$ewe->slug = 'ewe';
+		$ewe->wp_locale = 'ewe';
+		$ewe->slug = 'ee';
 
 		$el_po = new GP_Locale();
 		$el_po->english_name = 'Greek (Polytonic)';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -536,12 +536,14 @@ class GP_Locales {
 		$dzo->nplurals = 1;
 		$dzo->plural_expression = '0';
 
-		$ee = new GP_Locale();
-		$ee->english_name = 'Ewe';
-		$ee->native_name = 'Eʋegbe';
-		$ee->lang_code_iso_639_1 = 'ee';
-		$ee->lang_code_iso_639_2 = 'ewe';
-		$ee->slug = 'ee';
+		$ewe = new GP_Locale();
+		$ewe->english_name = 'Ewe';
+		$ewe->native_name = 'Eʋegbe';
+		$ewe->lang_code_iso_639_1 = 'ee';
+		$ewe->lang_code_iso_639_2 = 'ewe';
+		$ewe->country_code = 'gh';
+		$ewe->wp_locale = 'ee';
+		$ewe->slug = 'ewe';
 
 		$el_po = new GP_Locale();
 		$el_po->english_name = 'Greek (Polytonic)';


### PR DESCRIPTION
Updating information about Ewe (Eʋegbe) with the relevant WP information, country code and slug

Relarted request: https://make.wordpress.org/polyglots/2017/05/28/contribution-request-for-e%ca%8begbe/
Related Ethnologue information: https://www.ethnologue.com/language/ewe