### PR TITLE
732: Fix incorrect default in for_export() function for filters.

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -299,7 +299,7 @@ class GP_Translation extends GP_Thing {
 	}
 
 	public function for_export( $project, $translation_set, $filters =  null ) {
-		return GP::$translation->for_translation( $project, $translation_set, 'no-limit', $filters? $filters : array( 'status' => 'current_or_untranslated' ) );
+		return GP::$translation->for_translation( $project, $translation_set, 'no-limit', $filters );
 	}
 
 	public function for_translation( $project, $translation_set, $page, $filters = array(), $sort = array() ) {


### PR DESCRIPTION
for_translation() already handles the default so passing in a null is fine so don't bother setting the default in for_export().

Resolves #732.