### PR TITLE
743: Fix incorrect variable name for `German (Switzerland)' google code.

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -513,7 +513,7 @@ class GP_Locales {
 		$de_ch->country_code = 'ch';
 		$de_ch->wp_locale = 'de_CH';
 		$de_ch->slug = 'de-ch';
-		$de->google_code = 'de';
+		$de_ch->google_code = 'de';
 
 		$dv = new GP_Locale();
 		$dv->english_name = 'Dhivehi';


### PR DESCRIPTION
Resolves #743.