### PR TITLE
259: Link to /glotpress/ on Admin

### DIFF
--- a/gp-includes/default-filters.php
+++ b/gp-includes/default-filters.php
@@ -36,3 +36,5 @@ add_action( 'show_user_profile', 'gp_wp_profile_options' );
 add_action( 'edit_user_profile', 'gp_wp_profile_options' );
 add_action( 'personal_options_update', 'gp_wp_profile_options_update' );
 add_action( 'edit_user_profile_update', 'gp_wp_profile_options_update' );
+// Add the admin page to the WordPress settings menu
+add_action( 'admin_menu', 'gp_wp_dashboard_menu_link', 10, 1 );

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -574,3 +574,21 @@ function gp_get_sort_by_fields() {
 	 */
 	return apply_filters( 'gp_sort_by_fields', $sort_fields );
 }
+
+function gp_wp_dashboard_menu_link() {
+	global $menu;
+
+	// Add the menu to the admin menu.
+	add_menu_page(__('GlotPress'), __('GlotPress'), 'read', __FILE__, 'gp_placeholder_redirect_to_glotpress', 'dashicons-translation', 1 );
+
+	// We're going to hack the menu info to use a link to the front end instead of calling the 'redirect_to_glotpress' function so we save a page load.
+	foreach( $menu as $tag => $mi ) {
+		if( $mi[0] == __( 'GlotPress' ) ) {
+			$menu[$tag][2] = gp_url_public_root();
+		}
+	}
+}
+
+function gp_placeholder_redirect_to_glotpress() {
+	// Just a placeholder, we're going to replace the function call with a real link in the menu_order hook.
+}

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -109,6 +109,7 @@ function gp_nav_menu_items( $location = 'main' ) {
 			$items[ gp_url_profile( $user->user_nicename ) ] = __( 'Profile', 'glotpress' );
 			$items[ gp_url( '/settings' ) ] = __( 'Settings', 'glotpress' );
 			$items[ esc_url( wp_logout_url( gp_url_current() ) ) ]  = __( 'Log out', 'glotpress' );
+			$items[ admin_url() ] = __( 'Dashboard' );
 		}
 		else {
 			$items[ esc_url( wp_login_url( gp_url_current() ) ) ] = __( 'Log in', 'glotpress' );


### PR DESCRIPTION
![screenshot_20170825_230014](https://user-images.githubusercontent.com/403283/29732562-61c341f6-89e9-11e7-8a71-850c4e6c6e4d.png)

This pr include code from https://wordpress.org/plugins/gp-additional-links/.
The main difference that is not using a png logo (not available actually) and use the dashicon of translate.

Ref: https://github.com/GlotPress/GlotPress-WP/issues/259