### PR TITLE
Add `Action` context to bulk actions

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -262,9 +262,9 @@ function gp_translations_bulk_actions_toolbar( $bulk_action, $can_write, $locati
 	<div>
 	<select name="bulk[action]" id="bulk-action-<?php echo esc_attr( $location ); ?>" class="bulk-action">
 		<option value="" selected="selected"><?php _e( 'Bulk Actions', 'glotpress' ); ?></option>
-		<option value="approve"><?php _e( 'Approve', 'glotpress' ); ?></option>
-		<option value="reject"><?php _e( 'Reject', 'glotpress' ); ?></option>
-		<option value="fuzzy"><?php _e( 'Fuzzy', 'glotpress' ); ?></option>
+		<option value="approve"><?php _ex( 'Approve', 'Action', 'glotpress' ); ?></option>
+		<option value="reject"><?php _ex( 'Reject', 'Action', 'glotpress' ); ?></option>
+		<option value="fuzzy"><?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></option>
 	<?php if ( $can_write ) : ?>
 		<option value="set-priority" class="hide-if-no-js"><?php _e( 'Set Priority', 'glotpress' ); ?></option>
 	<?php endif; ?>


### PR DESCRIPTION
This makes the strings the same as the proposed changes in https://github.com/GlotPress/GlotPress-WP/pull/813