### PR TITLE
PHPCS: Ignore InvalidClassFileName and AlternativeFunctions for `file_get_contents()` rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 notifications:
   email:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards for GlotPress">
 
-	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Core">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents" />
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents" />
+	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra">
 		<exclude name="WordPress.XSS.EscapeOutput.UnsafePrintingFunction" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,7 +31,6 @@
 		</properties>
 	</rule>
 
-
 	<!-- Show sniff codes in all reports -->
 	<arg value="s"/>
 


### PR DESCRIPTION
See #833.