### PR TITLE
846: Add DEFAULT_BASE_BRANCH to the TravisCI enviroment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,15 @@ matrix:
     - php: nightly
   include:
   - php: 5.6
-    env: WP_VERSION=trunk WP_MULTISITE=1
+    env: WP_VERSION=trunk WP_MULTISITE=1 DEFAULT_BASE_BRANCH=develop
   - php: 5.6
-    env: WP_VERSION=trunk WP_MULTISITE=0 WP_TRAVISCI=codecoverage
+    env: WP_VERSION=trunk WP_MULTISITE=0 WP_TRAVISCI=codecoverage DEFAULT_BASE_BRANCH=develop
   - php: 7.0
-    env: WP_VERSION=trunk WP_MULTISITE=0
+    env: WP_VERSION=trunk WP_MULTISITE=0 DEFAULT_BASE_BRANCH=develop
   - php: 7.1
-    env: WP_VERSION=trunk WP_MULTISITE=0
+    env: WP_VERSION=trunk WP_MULTISITE=0 DEFAULT_BASE_BRANCH=develop
   - php: nightly
-    env: WP_VERSION=trunk WP_MULTISITE=0
+    env: WP_VERSION=trunk WP_MULTISITE=0 DEFAULT_BASE_BRANCH=develop
 
 install:
   - nvm install 6 && nvm use 6


### PR DESCRIPTION
To make sure the patch comparison works correctly.

Resolves #846.
See #833.