### PR TITLE
Allow plugins to control the number of translations entered

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -157,6 +157,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		$filename = apply_filters( 'gp_export_translations_filename', $filename, $format, $locale, $project, $translation_set );
 
 		$entries = GP::$translation->for_export( $project, $translation_set, gp_get( 'filters' ) );
+		$entries = apply_filters( 'gp_export_translations_entries', $entries );
 
 		if ( gp_has_translation_been_updated( $translation_set ) ) {
 			$last_modified = gmdate( 'D, d M Y H:i:s', gp_gmt_strtotime( GP::$translation->last_modified( $translation_set ) ) ) . ' GMT';

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -506,8 +506,12 @@ class GP_Translation extends GP_Thing {
 
 		$this->found_rows = $this->found_rows();
 		$translations = array();
+
 		foreach( (array)$rows as $row ) {
 			$row->user = $row->user_last_modified = null;
+
+			// Enable plugins to make use of the additional translation fields, regardless of a locale plural numbers.
+			$number_of_translations = apply_filters( 'gp_number_of_translations', $locale->nplurals, $row );
 
 			if ( $row->user_id && 'no-limit' !== $this->per_page ) {
 				$user = get_userdata( $row->user_id );
@@ -534,7 +538,7 @@ class GP_Translation extends GP_Thing {
 			}
 
 			$row->translations = array();
-			for( $i = 0; $i < $locale->nplurals; $i++ ) {
+			for ( $i = 0; $i < $number_of_translations; $i++ ) {
 				$row->translations[] = $row->{"translation_".$i};
 			}
 			$row->references = preg_split('/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY);

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -61,7 +61,7 @@ if ( is_object( $glossary ) ) {
 	   <?php echo $priority_char[$t->priority][0] ?>
 	</td>
 	<td class="original">
-		<?php echo prepare_original( esc_translation( $t->singular ) ); ?>
+		<?php echo prepare_original( esc_translation( $t->singular ) ); // WPCS: XSS ok. ?>
 		<?php if ( $t->context ): ?>
 		<span class="context bubble" title="<?php printf( __( 'Context: %s', 'glotpress' ), esc_html($t->context) ); ?>"><?php echo esc_html($t->context); ?></span>
 		<?php endif; ?>
@@ -110,8 +110,10 @@ if ( is_object( $glossary ) ) {
 			$plural   = isset( $t->plural_glossary_markup ) ? $t->plural_glossary_markup : esc_translation( $t->plural );
 		?>
 
-		<?php if ( ! $t->plural ): ?>
-		<p class="original"><?php echo prepare_original( $singular ); ?></p>
+		<?php if ( apply_filters( 'gp_translation_row_override_textareas', false, $t ) ) : ?>
+			<?php do_action( 'gp_translation_row_textareas', $t, $singular, $plural, $can_edit, $can_approve_translation, $can_approve ); ?>
+		<?php elseif ( ! $t->plural ) : ?>
+			<p class="original"><?php echo prepare_original( $singular ); // WPCS: XSS ok. ?></p>
 		<?php textareas( $t, array( $can_edit, $can_approve_translation ) ); ?>
 		<?php else: ?>
 			<?php if ( $locale->nplurals == 2 && $locale->plural_expression == 'n != 1'): ?>


### PR DESCRIPTION
**Summary**
This PR contains 3 filter hooks (and one related action hook) with the purpose of allowing plugins to control the numbers of translations saved per original, regardless of plural rules.

- The `gp_number_of_translations` filter hook affects the number of translations loaded per original when displaying/exporting the translation (In `GP_Translation::for_translation()`)
- The `gp_translation_row_override_textareas` filter hook allows plugins to completely override the display of the textareas in the `/translation-row.php` template.
- The `gp_translation_row_textareas`  action hook allows the plugin to actually output the textareas where it wishes.
- The `gp_export_translations_entries` filter allow plugins to modify translations when exporting (in `GP_Route_Translation:: export_translations_get()`).

**How they will be used**
A plugin might want to store variations for translation of an original based on a variable other than number (the current use case for multiple translations).
- By hooking on to `gp_number_of_translations`, the plugin could set the number of variations based on any of the relevant data pieces. For example, context. 
- By using `gp_translation_row_override_textareas` and `gp_translation_row_textareas` if will actually create the necessary textareas
- By using `gp_export_translations_entries` it can make sure the output format suits its nneds.

**Example implementation**
[GP Gender](https://github.com/yoavf/gp-gender) relies on all of the above hooks to add Gender support to GlotPress based on a context prefix.

This PR, GP Gender, and additional core WP modifications are all part of my [WC US 2017 talk](https://2017.us.wordcamp.org/sessions/#wcorg-session-4139). Recap and additional links coming soon.
