### PR TITLE
Warnings: Adding Korean lang slug to length exclusions

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -148,7 +148,7 @@ class GP_Builtin_Translation_Warnings {
 	 *
 	 * @var array
 	 */
-	public $length_exclude_languages = array( 'art-xemoji', 'ja', 'zh', 'zh-hk', 'zh-cn', 'zh-sg', 'zh-tw' );
+	public $length_exclude_languages = array( 'art-xemoji', 'ja', 'ko', 'zh', 'zh-hk', 'zh-cn', 'zh-sg', 'zh-tw' );
 
 	/**
 	 * Checks whether lengths of source and translation differ too much.


### PR DESCRIPTION
### Summary

This PR addsthe Korean slug – `ko` –  to `$length_exclude_languages`.

Korean generates frequent length warnings when translating from English:

<img width="515" alt="screen shot 2018-01-25 at 3 24 21 pm" src="https://user-images.githubusercontent.com/6458278/35370737-e01a82a4-01e3-11e8-97e6-798f59f6903d.png">

Here are some more examples from translate.wordpress.com:

**Uncategorized** 미분류

**Learn more about Jetpack** 젯팩에 대해 더 알아보기

The difference varies between -10 and -40% of the original string.

Thanks!




