### PR TITLE
Added Singaporean English locale

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -644,7 +644,7 @@ class GP_Locales {
 		$en_sg->country_code = 'pi';
 		$en_sg->wp_locale = 'en_PI';
 		$en_sg->slug = 'en-pi';
-		$en_sg->google_code = 'en';
+		$en_sg->google_code = 'xx-pirate';
 		$en_gb->facebook_locale = 'en_PI';
 
 		$eo = new GP_Locale();

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -635,6 +635,18 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
+		$en_sg = new GP_Locale();
+		$en_sg->english_name = 'English (Pirate)';
+		$en_sg->native_name = 'English (Pirate)';
+		$en_sg->lang_code_iso_639_1 = 'en';
+		$en_sg->lang_code_iso_639_2 = 'eng';
+		$en_sg->lang_code_iso_639_3 = 'eng';
+		$en_sg->country_code = 'pi';
+		$en_sg->wp_locale = 'en_PI';
+		$en_sg->slug = 'en-pi';
+		$en_sg->google_code = 'en';
+		$en_gb->facebook_locale = 'en_PI';
+
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -635,17 +635,6 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
-		$en_sg = new GP_Locale();
-		$en_sg->english_name = 'English (Singapore)';
-		$en_sg->native_name = 'English (Singapore)';
-		$en_sg->lang_code_iso_639_1 = 'en';
-		$en_sg->lang_code_iso_639_2 = 'eng';
-		$en_sg->lang_code_iso_639_3 = 'eng';
-		$en_sg->country_code = 'sg';
-		$en_sg->wp_locale = 'en_SG';
-		$en_sg->slug = 'en-sg';
-		$en_sg->google_code = 'en';
-
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -635,6 +635,17 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
+		$en_sg = new GP_Locale();
+		$en_sg->english_name = 'English (Singapore)';
+		$en_sg->native_name = 'English (Singapore)';
+		$en_sg->lang_code_iso_639_1 = 'en';
+		$en_sg->lang_code_iso_639_2 = 'eng';
+		$en_sg->lang_code_iso_639_3 = 'eng';
+		$en_sg->country_code = 'sg';
+		$en_sg->wp_locale = 'en_SG';
+		$en_sg->slug = 'en-sg';
+		$en_sg->google_code = 'en';
+
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';


### PR DESCRIPTION
Adds the Singaporean English (SG) locale to the list of English variants.

Make.Polyglots request here: https://make.wordpress.org/polyglots/2018/01/30/new-locale-for-english-sg/