### PR TITLE
Add new Pirate English locale

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -638,6 +638,18 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
+		$en_pi = new GP_Locale();
+		$en_pi->english_name = 'English (Pirate)';
+		$en_pi->native_name = 'English (Pirate)';
+		$en_pi->lang_code_iso_639_1 = 'en';
+		$en_pi->lang_code_iso_639_2 = 'eng';
+		$en_pi->lang_code_iso_639_3 = 'eng';
+		$en_pi->country_code = 'pi';
+		$en_pi->wp_locale = 'en_PI';
+		$en_pi->slug = 'en-pi';
+		$en_pi->google_code = 'xx-pirate';
+		$en_pi->facebook_locale = 'en_PI';
+
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -638,17 +638,14 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
-		$en_pi = new GP_Locale();
-		$en_pi->english_name = 'English (Pirate)';
-		$en_pi->native_name = 'English (Pirate)';
-		$en_pi->lang_code_iso_639_1 = 'en';
-		$en_pi->lang_code_iso_639_2 = 'eng';
-		$en_pi->lang_code_iso_639_3 = 'eng';
-		$en_pi->country_code = 'pi';
-		$en_pi->wp_locale = 'en_PI';
-		$en_pi->slug = 'en-pi';
-		$en_pi->google_code = 'xx-pirate';
-		$en_pi->facebook_locale = 'en_PI';
+		$pirate = new GP_Locale();
+		$pirate->english_name = 'English (Pirate)';
+		$pirate->native_name = 'English (Pirate)';
+		$pirate->lang_code_iso_639_2 = 'art';
+		$pirate->wp_locale = 'art_xpirate';
+		$pirate->slug = 'en-pi';
+		$pirate->google_code = 'xx-pirate';
+		$pirate->facebook_locale = 'en_PI';
 
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -638,15 +638,6 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
-		$pirate = new GP_Locale();
-		$pirate->english_name = 'English (Pirate)';
-		$pirate->native_name = 'English (Pirate)';
-		$pirate->lang_code_iso_639_2 = 'art';
-		$pirate->wp_locale = 'art_xpirate';
-		$pirate->slug = 'en-pi';
-		$pirate->google_code = 'xx-pirate';
-		$pirate->facebook_locale = 'en_PI';
-
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';
@@ -1634,6 +1625,15 @@ class GP_Locales {
 		$pa->slug = 'pa';
 		$pa->google_code = 'pa';
 		$pa->facebook_locale = 'pa_IN';
+
+		$pirate = new GP_Locale();
+		$pirate->english_name = 'English (Pirate)';
+		$pirate->native_name = 'English (Pirate)';
+		$pirate->lang_code_iso_639_2 = 'art';
+		$pirate->wp_locale = 'art_xpirate';
+		$pirate->slug = 'art-xpirate';
+		$pirate->google_code = 'xx-pirate';
+		$pirate->facebook_locale = 'en_PI';
 
 		$pl = new GP_Locale();
 		$pl->english_name = 'Polish';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -638,18 +638,6 @@ class GP_Locales {
 		$en_za->slug = 'en-za';
 		$en_za->google_code = 'en';
 
-		$en_pi = new GP_Locale();
-		$en_pi->english_name = 'English (Pirate)';
-		$en_pi->native_name = 'English (Pirate)';
-		$en_pi->lang_code_iso_639_1 = 'en';
-		$en_pi->lang_code_iso_639_2 = 'eng';
-		$en_pi->lang_code_iso_639_3 = 'eng';
-		$en_pi->country_code = 'pi';
-		$en_pi->wp_locale = 'en_PI';
-		$en_pi->slug = 'en-pi';
-		$en_pi->google_code = 'xx-pirate';
-		$en_pi->facebook_locale = 'en_PI';
-
 		$eo = new GP_Locale();
 		$eo->english_name = 'Esperanto';
 		$eo->native_name = 'Esperanto';


### PR DESCRIPTION
Please add a new locale for English (Pirate).

This is based off of the original request in PR #832.

I've also altered the locale code to match up with existing locales of the same name. Facebook refers to it as `en_PI` so I suggest keeping the locale code the same for compatibility.

See #828.