### PR TITLE
875: Fix display of long translation strings

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -327,7 +327,7 @@ table.translations.translation-sets-rtl .foreign-text {
 
 table.translations td.original, table.translations td.translation {
 	width: 45%;
-	word-break: break-word;
+	word-break: break-all;
 	word-wrap: break-word;
 }
 
@@ -391,6 +391,8 @@ span.context {
 	color: white;
 	font-size: 100%;
 	padding: 0.3em;
+	word-break: break-all;
+	word-wrap: break-word;
 }
 
 span.morethan90 {
@@ -405,10 +407,12 @@ span.morethan90 {
 	font-weight: bold;
 	white-space: pre-wrap;
 	max-width: 50em;
+	word-break: break-all;
 }
 
 .editor .translation {
 	white-space: pre-wrap;
+	word-break: break-all;
 }
 
 .editor .strings {
@@ -771,7 +775,7 @@ span.removed {
 #legend {
 	float: left;
 	margin-top: .3em;
-	padding-left: 1.5em;	
+	padding-left: 1.5em;
 }
 
 #legend div {


### PR DESCRIPTION
Properly wrap long translation strings and other elements in the tranlsation editor.