### PR TITLE
Android Strings: Convert escaped unicode before stripping the slashes

### DIFF
--- a/gp-includes/formats/format-android.php
+++ b/gp-includes/formats/format-android.php
@@ -406,6 +406,21 @@ class GP_Format_Android extends GP_Format {
 	}
 
 	/**
+	 * Convert a string potentially containing escaped Unicode into UTF-8.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $string The string to unescape UTF-8.
+	 *
+	 * @return string Returns the unescaped string.
+	 */
+	private function unescape_unicode( $string ) {
+		return preg_replace_callback( '#\\\\u([0-9a-fA-F]{4})#', function ( $match ) {
+		    return mb_convert_encoding( pack( 'H*', $match[1] ), 'UTF-8', 'UTF-16BE' );
+		}, $string );
+	}
+
+	/**
 	 * Unescapes a string with c style slashes.
 	 *
 	 * @since 1.0.0
@@ -415,6 +430,7 @@ class GP_Format_Android extends GP_Format {
 	 * @return string Returns the unescaped string.
 	 */
 	private function unescape( $string ) {
+		$string = $this->unescape_unicode( $string );
 		return stripcslashes( $string );
 	}
 

--- a/gp-includes/formats/format-android.php
+++ b/gp-includes/formats/format-android.php
@@ -414,10 +414,8 @@ class GP_Format_Android extends GP_Format {
 	 *
 	 * @return string Returns the unescaped string.
 	 */
-	private function unescape_unicode( $string ) {
-		return preg_replace_callback( '#\\\\u([0-9a-fA-F]{4})#', function ( $match ) {
-		    return mb_convert_encoding( pack( 'H*', $match[1] ), 'UTF-8', 'UTF-16BE' );
-		}, $string );
+	private function preserve_escaped_unicode( $string ) {
+		return preg_replace( '#\\\\u([0-9a-fA-F]{4})#', '\\\\$0', $string );
 	}
 
 	/**
@@ -430,7 +428,7 @@ class GP_Format_Android extends GP_Format {
 	 * @return string Returns the unescaped string.
 	 */
 	private function unescape( $string ) {
-		$string = $this->unescape_unicode( $string );
+		$string = $this->preserve_escaped_unicode( $string );
 		return stripcslashes( $string );
 	}
 

--- a/gp-includes/formats/format-android.php
+++ b/gp-includes/formats/format-android.php
@@ -406,13 +406,13 @@ class GP_Format_Android extends GP_Format {
 	}
 
 	/**
-	 * Convert a string potentially containing escaped Unicode into UTF-8.
+	 * Preserve a Unicode sequence (like \u1234) by adding another backslash.
 	 *
 	 * @since 3.0
 	 *
-	 * @param string $string The string to unescape UTF-8.
+	 * @param string $string The string to process.
 	 *
-	 * @return string Returns the unescaped string.
+	 * @return string Returns the string with double-escaped Unicode sequences.
 	 */
 	private function preserve_escaped_unicode( $string ) {
 		return preg_replace( '#\\\\u([0-9a-fA-F]{4})#', '\\\\$0', $string );

--- a/tests/phpunit/data/originals.android.xml
+++ b/tests/phpunit/data/originals.android.xml
@@ -9,4 +9,5 @@
 	<string name="with_gt">me > you</string>
 	<string name="with_amps">me &amp; you are not &amp;amp;</string>
 	<string name="with_comment" comment="Me, myself &amp; Irene">baba</string>
+	<string name="with_escaped_unicode">No posts saved \u2014 yet!</string>
 </resources>

--- a/tests/phpunit/data/translation.android.xml
+++ b/tests/phpunit/data/translation.android.xml
@@ -15,4 +15,5 @@ Language: en_US
 	<string name="with_gt">аз > ти</string>
 	<string name="with_amps">аз &amp; ти не сме &amp;amp;</string>
 	<string name="with_comment">баба</string>
+	<string name="with_escaped_unicode">Keine Beiträge gespeichert — noch!</string>
 </resources>

--- a/tests/phpunit/data/translation.android.xml
+++ b/tests/phpunit/data/translation.android.xml
@@ -15,5 +15,5 @@ Language: en_US
 	<string name="with_gt">аз > ти</string>
 	<string name="with_amps">аз &amp; ти не сме &amp;amp;</string>
 	<string name="with_comment">баба</string>
-	<string name="with_escaped_unicode">Keine Beiträge gespeichert — noch!</string>
+	<string name="with_escaped_unicode">Keine Beiträge gespeichert \u2014 noch!</string>
 </resources>

--- a/tests/phpunit/testcases/tests_formats/test_format_android.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_android.php
@@ -14,7 +14,7 @@ class GP_Test_Format_Android extends GP_UnitTestCase {
 			array( 'with_gt', 'me > you', "аз > ти", '' ),
 			array( 'with_amps', 'me & you are not &amp;', 'аз & ти не сме &amp;', '' ),
 			array( 'with_comment', 'baba', 'баба', 'Me, myself & Irene' ),
-			array( 'with_escaped_unicode', 'No posts saved — yet!', 'Keine Beiträge gespeichert — noch!', '' ),
+			array( 'with_escaped_unicode', 'No posts saved \u2014 yet!', 'Keine Beiträge gespeichert \u2014 noch!', '' ),
 		);
 	}
 

--- a/tests/phpunit/testcases/tests_formats/test_format_android.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_android.php
@@ -14,6 +14,7 @@ class GP_Test_Format_Android extends GP_UnitTestCase {
 			array( 'with_gt', 'me > you', "аз > ти", '' ),
 			array( 'with_amps', 'me & you are not &amp;', 'аз & ти не сме &amp;', '' ),
 			array( 'with_comment', 'baba', 'баба', 'Me, myself & Irene' ),
+			array( 'with_escaped_unicode', 'No posts saved — yet!', 'Keine Beiträge gespeichert — noch!', '' ),
 		);
 	}
 


### PR DESCRIPTION
Fixes #910.

The reason for the current behavior is that `stripcslashes()` is unaware of the `\u` syntax and interprets it as a superflous backslash which it then removes.

The fix converts the escaped unicode to the actual Unicode byte sequence, therefore `stripcslashes()` leaves it alone.