### PR TITLE
914: Split up translation-row template for easier modification by plugins

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -317,12 +317,12 @@ class GP_Route_Translation extends GP_Route_Main {
 				$translations = GP::$translation->for_translation( $project, $translation_set, 'no-limit', array('translation_id' => $translation->id), array() );
 
 				if ( ! empty( $translations ) ) {
-					$t = $translations[0];
+					$translation = $translations[0];
 
 					$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 					$can_write = $this->can( 'write', 'project', $project->id );
 					$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
-					$can_approve_translation = $this->can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
+					$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
 
 					$output[ $original_id ] = gp_tmpl_get_output( 'translation-row', get_defined_vars() );
 				} else {
@@ -577,12 +577,12 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$translations = GP::$translation->for_translation( $project, $translation_set, 'no-limit', array('translation_id' => $translation->id, 'status' => 'either'), array() );
 		if ( ! empty( $translations ) ) {
-			$t = $translations[0];
+			$translation = $translations[0];
 
 			$can_edit = $this->can( 'edit', 'translation-set', $translation_set->id );
 			$can_write = $this->can( 'write', 'project', $project->id );
 			$can_approve = $this->can( 'approve', 'translation-set', $translation_set->id );
-			$can_approve_translation = $this->can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
+			$can_approve_translation = $this->can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
 
 			$this->tmpl( 'translation-row', get_defined_vars() );
 		} else {

--- a/gp-templates/translation-row-editor-actions.php
+++ b/gp-templates/translation-row-editor-actions.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template for the action buttons displayed below the editor
+ *
+ * @package    GlotPress
+ * @subpackage Templates
+ */
+
+?>
+<div class="actions">
+	<?php if ( $can_edit ) : ?>
+		<button class="ok" data-nonce="<?php echo esc_attr( wp_create_nonce( 'add-translation_' . $translation->original_id ) ); ?>">
+			<?php echo $can_approve_translation ? __( 'Add translation &rarr;', 'glotpress' ) : __( 'Suggest new translation &rarr;', 'glotpress' ); ?>
+		</button>
+	<?php endif; ?>
+	<?php _e( 'or', 'glotpress' ); ?> <a href="#" class="close"><?php _e( 'Cancel', 'glotpress' ); ?></a>
+</div>

--- a/gp-templates/translation-row-editor-meta-status.php
+++ b/gp-templates/translation-row-editor-meta-status.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Template for the meta section of the editor row in a translation set display
+ *
+ * @package    GlotPress
+ * @subpackage Templates
+ */
+
+?>
+<dl>
+	<dt><?php _e( 'Status:', 'glotpress' ); ?></dt>
+	<dd>
+		<?php echo display_status( $translation->translation_status ); // WPCS: XSS OK. ?>
+		<?php if ( $translation->translation_status ) : ?>
+			<?php if ( $can_approve_translation ) : ?>
+				<?php if ( 'current' !== $translation->translation_status ) : ?>
+					<button class="approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Approve this translation. Any existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>+</strong> <?php _ex( 'Approve', 'Action', 'glotpress' ); ?></button>
+				<?php endif; ?>
+				<?php if ( 'rejected' !== $translation->translation_status ) : ?>
+					<button class="reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
+				<?php endif; ?>
+				<?php if ( 'fuzzy' !== $translation->translation_status ) : ?>
+					<button class="fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>
+				<?php endif; ?>
+			<?php elseif ( $can_reject_self ) : ?>
+				<button class="reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
+				<button class="fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>
+			<?php endif; ?>
+		<?php endif; ?>
+	</dd>
+</dl>

--- a/gp-templates/translation-row-editor-meta.php
+++ b/gp-templates/translation-row-editor-meta.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Template for the meta section of the editor row in a translation set display
+ *
+ * @package    GlotPress
+ * @subpackage Templates
+ */
+
+$more_links = array();
+if ( $translation->translation_status ) {
+	$translation_permalink = gp_url_project_locale(
+		$project,
+		$locale->slug,
+		$translation_set->slug,
+		array(
+			'filters[status]'         => 'either',
+			'filters[original_id]'    => $translation->original_id,
+			'filters[translation_id]' => $translation->id,
+		)
+	);
+
+	$more_links['translation-permalink'] = '<a tabindex="-1" href="' . esc_url( $translation_permalink ) . '">' . __( 'Permalink to this translation', 'glotpress' ) . '</a>';
+} else {
+	$original_permalink = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[original_id]' => $translation->original_id ) );
+
+	$more_links['original-permalink'] = '<a tabindex="-1" href="' . esc_url( $original_permalink ) . '">' . __( 'Permalink to this original', 'glotpress' ) . '</a>';
+}
+
+$original_history = gp_url_project_locale(
+	$project, $locale->slug, $translation_set->slug, array(
+		'filters[status]'      => 'either',
+		'filters[original_id]' => $translation->original_id,
+		'sort[by]'             => 'translation_date_added',
+		'sort[how]'            => 'asc',
+	)
+);
+
+$more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history ) . '">' . __( 'All translations of this original', 'glotpress' ) . '</a>';
+
+/**
+ * Allows to modify the more links in the translation editor.
+ *
+ * @since 2.3.0
+ *
+ * @param array $more_links The links to be output.
+ * @param GP_Project $project Project object.
+ * @param GP_Locale $locale Locale object.
+ * @param GP_Translation_Set $translation_set Translation Set object.
+ * @param GP_Translation $translation Translation object.
+ */
+$more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $translation );
+
+?>
+<div class="meta">
+	<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
+
+	<?php gp_tmpl_load( 'translation-row-editor-meta-status', get_defined_vars() ); ?>
+
+	<?php if ( $translation->context ) : ?>
+		<dl>
+			<dt><?php _e( 'Context:', 'glotpress' ); ?></dt>
+			<dd><span class="context bubble"><?php echo esc_translation( $translation->context ); // WPCS: XSS OK. ?></span></dd>
+		</dl>
+	<?php endif; ?>
+	<?php if ( $translation->extracted_comments ) : ?>
+		<dl>
+			<dt><?php _e( 'Comment:', 'glotpress' ); ?></dt>
+			<dd><?php echo make_clickable( esc_translation( $translation->extracted_comments ) ); // WPCS: XSS OK. ?></dd>
+		</dl>
+	<?php endif; ?>
+	<?php if ( $translation->translation_added && '0000-00-00 00:00:00' !== $translation->translation_added ) : ?>
+		<dl>
+			<dt><?php _e( 'Date added:', 'glotpress' ); ?></dt>
+			<dd><?php echo esc_html( $translation->translation_added ); ?> GMT</dd>
+		</dl>
+	<?php endif; ?>
+	<?php if ( $translation->user ) : ?>
+		<dl>
+			<dt><?php _e( 'Translated by:', 'glotpress' ); ?></dt>
+			<dd><?php gp_link_user( $translation->user ); ?></dd>
+		</dl>
+	<?php endif; ?>
+	<?php if ( $translation->user_last_modified && ( ! $translation->user || $translation->user->ID !== $translation->user_last_modified->ID ) ) : ?>
+		<dl>
+			<dt>
+			<?php
+			if ( 'current' === $translation->translation_status ) {
+				_e( 'Approved by:', 'glotpress' );
+			} elseif ( 'rejected' === $translation->translation_status ) {
+				_e( 'Rejected by:', 'glotpress' );
+			} else {
+				_e( 'Last updated by:', 'glotpress' );
+			}
+			?>
+			</dt>
+			<dd><?php gp_link_user( $translation->user_last_modified ); ?></dd>
+		</dl>
+	<?php endif; ?>
+	<?php references( $project, $translation ); ?>
+
+	<dl>
+		<dt><?php _e( 'Priority:', 'glotpress' ); ?></dt>
+		<?php if ( $can_write ) : ?>
+			<dd>
+				<?php
+				echo gp_select(
+					'priority-' . $translation->original_id,
+					GP::$original->get_static( 'priorities' ),
+					$translation->priority,
+					array(
+						'class'      => 'priority',
+						'tabindex'   => '-1',
+						'data-nonce' => wp_create_nonce( 'set-priority_' . $translation->original_id ),
+					)
+				);
+				?>
+			</dd>
+		<?php else : ?>
+			<dd><?php echo gp_array_get( GP::$original->get_static( 'priorities' ), $translation->priority, 'unknown' ); // WPCS: XSS ok. ?></dd>
+		<?php endif; ?>
+	</dl>
+
+	<dl>
+		<dt><?php _e( 'More links:', 'glotpress' ); ?>
+			<ul>
+				<?php foreach ( $more_links as $link ) : ?>
+					<li><?php echo $link; // WPCS: XSS ok. ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</dt>
+	</dl>
+</div>

--- a/gp-templates/translation-row-editor.php
+++ b/gp-templates/translation-row-editor.php
@@ -16,10 +16,12 @@
  */
 $colspan = apply_filters( 'gp_translation_row_editor_colspan', $can_approve ? 5 : 4 );
 
+$translation_singular = isset( $translation->singular_glossary_markup ) ? $translation->singular_glossary_markup : esc_translation( $translation->singular );
+
 $singular = sprintf(
 	/* translators: %s: Original singular form of the text */
 	__( 'Singular: %s', 'glotpress' ),
-	'<span class="original">' . ( isset( $translation->singular_glossary_markup ) ? $translation->singular_glossary_markup : esc_translation( $translation->singular ) ) . '</span>'
+	'<span class="original">' . $translation_singular . '</span>'
 );
 $plural = sprintf(
 	/* translators: %s: Original plural form of the text */
@@ -32,7 +34,7 @@ $plural = sprintf(
 	<td colspan="<?php echo esc_attr( $colspan ); ?>">
 		<div class="strings">
 			<?php if ( ! $translation->plural ) : ?>
-				<p class="original"><?php echo prepare_original( $singular );  // WPCS: XSS OK. ?></p>
+				<p class="original"><?php echo prepare_original( $translation_singular );  // WPCS: XSS OK. ?></p>
 				<?php textareas( $translation, array( $can_edit, $can_approve_translation ) ); ?>
 			<?php else : ?>
 				<?php if ( absint( $locale->nplurals ) === 2 && 'n != 1' === $locale->plural_expression ) : ?>

--- a/gp-templates/translation-row-editor.php
+++ b/gp-templates/translation-row-editor.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Template for the editor part of a single translation row in a translation set display
+ *
+ * @package    GlotPress
+ * @subpackage Templates
+ */
+
+/**
+ * Filter to update colspan of editor. Decrease to add an extra column
+ * with action 'gp_translation_row_editor_columns'.
+ *
+ * @since 3.0.0
+ *
+ * @param int $colspan The colspan of editor column.
+ */
+$colspan = apply_filters( 'gp_translation_row_editor_colspan', $can_approve ? 5 : 4 );
+
+$singular = sprintf(
+	/* translators: %s: Original singular form of the text */
+	__( 'Singular: %s', 'glotpress' ),
+	'<span class="original">' . ( isset( $translation->singular_glossary_markup ) ? $translation->singular_glossary_markup : esc_translation( $translation->singular ) ) . '</span>'
+);
+$plural = sprintf(
+	/* translators: %s: Original plural form of the text */
+	__( 'Plural: %s', 'glotpress' ),
+	'<span class="original">' . ( isset( $translation->plural_glossary_markup ) ? $translation->plural_glossary_markup : esc_translation( $translation->plural ) ) . '</span>'
+);
+
+?>
+<tr class="editor <?php gp_translation_row_classes( $translation ); ?>" id="editor-<?php echo esc_attr( $translation->row_id ); ?>" row="<?php echo esc_attr( $translation->row_id ); ?>">
+	<td colspan="<?php echo esc_attr( $colspan ); ?>">
+		<div class="strings">
+			<?php if ( ! $translation->plural ) : ?>
+				<p class="original"><?php echo prepare_original( $singular );  // WPCS: XSS OK. ?></p>
+				<?php textareas( $translation, array( $can_edit, $can_approve_translation ) ); ?>
+			<?php else : ?>
+				<?php if ( absint( $locale->nplurals ) === 2 && 'n != 1' === $locale->plural_expression ) : ?>
+					<p>
+						<?php echo $singular;  // WPCS: XSS OK. ?>
+					</p>
+					<?php textareas( $translation, array( $can_edit, $can_approve ), 0 ); ?>
+					<p class="clear">
+						<?php echo $plural;  // WPCS: XSS OK. ?>
+					</p>
+					<?php textareas( $translation, array( $can_edit, $can_approve ), 1 ); ?>
+				<?php else : ?>
+					<!--
+					TODO: labels for each plural textarea and a sample number
+					-->
+					<p>
+						<?php echo $singular;  // WPCS: XSS OK. ?>
+					</p>
+					<p class="clear">
+						<?php echo $plural;  // WPCS: XSS OK. ?>
+					</p>
+					<?php foreach ( range( 0, $locale->nplurals - 1 ) as $plural_index ) : ?>
+						<?php if ( $locale->nplurals > 1 ) : ?>
+							<p class="plural-numbers">
+								<?php
+								printf(
+									/* translators: %s: Numbers */
+									__( 'This plural form is used for numbers like: %s', 'glotpress' ),
+									'<span class="numbers">' . implode( ', ', $locale->numbers_for_index( $plural_index ) ) . '</span>'
+								); // WPCS: XSS OK.
+								?>
+							</p>
+						<?php endif; ?>
+						<?php textareas( $translation, array( $can_edit, $can_approve ), $plural_index ); ?>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			<?php endif; ?>
+			<?php gp_tmpl_load( 'translation-row-editor-actions', get_defined_vars() ); ?>
+		</div>
+		<?php gp_tmpl_load( 'translation-row-editor-meta', get_defined_vars() ); ?>
+	</td>
+	<?php
+	/**
+	 * Fires after editor column.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param GP_Translation     $translation The current translation.
+	 * @param GP_Translation_Set $translation_set The current translation set.
+	 */
+	do_action( 'gp_translation_row_editor_columns', $translation, $translation_set );
+	?>
+</tr>

--- a/gp-templates/translation-row-preview.php
+++ b/gp-templates/translation-row-preview.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Template for the preview part of a single translation row in a translation set display
+ *
+ * @package    GlotPress
+ * @subpackage Templates
+ */
+
+$priority_char = array(
+	'-2' => array( '&times;', 'transparent', '#ccc' ),
+	'-1' => array( '&darr;', 'transparent', 'blue' ),
+	'0'  => array( '', 'transparent', 'white' ),
+	'1'  => array( '&uarr;', 'transparent', 'green' ),
+);
+?>
+
+<tr class="preview <?php gp_translation_row_classes( $translation ); ?>" id="preview-<?php echo esc_attr( $translation->row_id ); ?>" row="<?php echo esc_attr( $translation->row_id ); ?>">
+	<?php if ( $can_approve_translation ) : ?>
+		<th scope="row" class="checkbox"><input type="checkbox" name="selected-row[]"/></th>
+	<?php elseif ( $can_approve ) : ?>
+		<th scope="row"></th>
+	<?php endif; ?>
+	<?php /* translators: %s: Priority of original */ ?>
+	<td class="priority" title="<?php echo esc_attr( sprintf( __( 'Priority: %s', 'glotpress' ), gp_array_get( GP::$original->get_static( 'priorities' ), $translation->priority ) ) ); ?>">
+		<?php echo $priority_char[ $translation->priority ][0]; // WPCS: XSS OK. ?>
+	</td>
+	<td class="original">
+		<?php echo prepare_original( esc_translation( $translation->singular ) ); // WPCS: XSS OK. ?>
+		<?php if ( $translation->context ) : ?>
+			<?php /* translators: %s: Context of original */ ?>
+			<span class="context bubble" title="<?php echo esc_attr( sprintf( __( 'Context: %s', 'glotpress' ), $translation->context ) ); ?>"><?php echo esc_html( $translation->context ); ?></span>
+		<?php endif; ?>
+	</td>
+	<td class="translation foreign-text">
+		<?php
+		if ( $can_edit ) {
+			$edit_text = __( 'Double-click to add', 'glotpress' );
+		} elseif ( is_user_logged_in() ) {
+			$edit_text = __( 'You are not allowed to add a translation.', 'glotpress' );
+		} else {
+			/* translators: %s: url */
+			$edit_text = sprintf( __( 'You <a href="%s">have to log in</a> to add a translation.', 'glotpress' ), esc_url( wp_login_url( gp_url_current() ) ) ); // WPCS: XSS OK.
+		}
+
+		$missing_text = "<span class='missing'>$edit_text</span>"; // WPCS: XSS OK.
+		if ( ! count( array_filter( $translation->translations, 'gp_is_not_null' ) ) ) :
+			echo $missing_text; // WPCS: XSS OK.
+		elseif ( ! $translation->plural ) :
+			echo esc_translation( $translation->translations[0] ); // WPCS: XSS OK.
+		else :
+		?>
+			<ul>
+				<?php foreach ( $translation->translations as $translation ) : ?>
+					<li>
+					<?php echo gp_is_empty_string( $translation ) ? $missing_text : esc_translation( $translation ); // WPCS: XSS OK. ?>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		<?php endif; ?>
+	</td>
+	<td class="actions">
+		<a href="#" row="<?php echo $translation->row_id; // WPCS: XSS OK. ?>" class="action edit"><?php _e( 'Details', 'glotpress' ); ?></a>
+	</td>
+</tr>

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -6,248 +6,36 @@
  * @subpackage Templates
  */
 
-$priority_char = array(
-    '-2' => array('&times;', 'transparent', '#ccc'),
-    '-1' => array('&darr;', 'transparent', 'blue'),
-    '0' => array('', 'transparent', 'white'),
-    '1' => array('&uarr;', 'transparent', 'green'),
-);
-$user = wp_get_current_user();
-$can_reject_self = ( isset( $t->user->user_login ) && $user->user_login === $t->user->user_login && 'waiting' === $t->translation_status );
-
-$more_links = array();
-if ( $t->translation_status ) {
-	$translation_permalink = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[status]' => 'either', 'filters[original_id]' => $t->original_id, 'filters[translation_id]' => $t->id ) );
-	$more_links['translation-permalink'] = '<a tabindex="-1" href="' . esc_url( $translation_permalink ) . '">' . __( 'Permalink to this translation', 'glotpress' ) . '</a>';
-} else {
-	$original_permalink = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[original_id]' => $t->original_id ) );
-	$more_links['original-permalink'] = '<a tabindex="-1" href="' . esc_url( $original_permalink ) . '">' . __( 'Permalink to this original', 'glotpress' ) . '</a>';
-}
-
-$original_history = gp_url_project_locale( $project, $locale->slug, $translation_set->slug, array( 'filters[status]' => 'either', 'filters[original_id]' => $t->original_id, 'sort[by]' => 'translation_date_added', 'sort[how]' => 'asc' ) );
-$more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history ) . '">' . __( 'All translations of this original', 'glotpress' ) . '</a>';
-
-/**
- * Allows to modify the more links in the translation editor.
- *
- * @since 2.3.0
- *
- * @param array              $more_links      The links to be output.
- * @param GP_Project         $project         Project object.
- * @param GP_Locale          $locale          Locale object.
- * @param GP_Translation_Set $translation_set Translation Set object.
- * @param GP_Translation     $t               Translation object.
- */
-$more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $t );
+$user            = wp_get_current_user();
+$can_reject_self = ( isset( $translation->user->user_login ) && $user->user_login === $translation->user->user_login && 'waiting' === $translation->translation_status );
 
 if ( is_object( $glossary ) ) {
 	if ( ! isset( $glossary_entries_terms ) ) {
-		$glossary_entries = $glossary->get_entries();
+		$glossary_entries       = $glossary->get_entries();
 		$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
 	}
 
-	$t = map_glossary_entries_to_translation_originals( $t, $glossary, $glossary_entries_terms );
+	$translation = map_glossary_entries_to_translation_originals( $translation, $glossary, $glossary_entries_terms );
 }
 
-?>
-
-<tr class="preview <?php gp_translation_row_classes( $t ); ?>" id="preview-<?php echo esc_attr( $t->row_id ) ?>" row="<?php echo esc_attr( $t->row_id ); ?>">
-	<?php if ( $can_approve_translation ) : ?>
-		<th scope="row" class="checkbox"><input type="checkbox" name="selected-row[]" /></th>
-	<?php elseif ( $can_approve ) : ?>
-		<th scope="row"></th>
-	<?php endif; ?>
-	<td class="priority" title="<?php echo esc_attr( sprintf( __( 'Priority: %s', 'glotpress' ), gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority ) ) ); ?>">
-	   <?php echo $priority_char[$t->priority][0] ?>
-	</td>
-	<td class="original">
-		<?php echo prepare_original( esc_translation( $t->singular ) ); ?>
-		<?php if ( $t->context ): ?>
-		<span class="context bubble" title="<?php printf( __( 'Context: %s', 'glotpress' ), esc_html($t->context) ); ?>"><?php echo esc_html($t->context); ?></span>
-		<?php endif; ?>
-
-	</td>
-	<td class="translation foreign-text">
-	<?php
-		if ( $can_edit ) {
-			$edit_text = __( 'Double-click to add', 'glotpress' );
-		}
-		elseif ( is_user_logged_in() ) {
-			$edit_text = __( 'You are not allowed to add a translation.', 'glotpress' );
-		}
-		else {
-			$edit_text = sprintf( __( 'You <a href="%s">have to log in</a> to add a translation.', 'glotpress' ), esc_url( wp_login_url( gp_url_current() ) ) );
-		}
-
-		$missing_text = "<span class='missing'>$edit_text</span>";
-		if ( ! count( array_filter( $t->translations, 'gp_is_not_null' ) ) ) :
-			echo $missing_text;
-		elseif ( ! $t->plural ) :
-			echo esc_translation( $t->translations[0] );
-		else: ?>
-		<ul>
-			<?php
-				foreach( $t->translations as $translation ):
-			?>
-				<li><?php echo gp_is_empty_string( $translation ) ? $missing_text : esc_translation( $translation ); ?></li>
-			<?php
-				endforeach;
-			?>
-		</ul>
-	<?php
-		endif;
-	?>
-	</td>
-	<td class="actions">
-		<a href="#" row="<?php echo $t->row_id; ?>" class="action edit"><?php _e( 'Details', 'glotpress' ); ?></a>
-	</td>
-</tr>
-<tr class="editor <?php echo gp_translation_row_classes( $t ); ?>" id="editor-<?php echo esc_attr( $t->row_id ); ?>" row="<?php echo esc_attr( $t->row_id ); ?>">
-	<td colspan="<?php echo $can_approve ? 5 : 4 ?>">
-		<div class="strings">
-		<?php
-			$singular = isset( $t->singular_glossary_markup ) ? $t->singular_glossary_markup : esc_translation( $t->singular );
-			$plural   = isset( $t->plural_glossary_markup ) ? $t->plural_glossary_markup : esc_translation( $t->plural );
-		?>
-
-		<?php if ( ! $t->plural ): ?>
-		<p class="original"><?php echo prepare_original( $singular ); ?></p>
-		<?php textareas( $t, array( $can_edit, $can_approve_translation ) ); ?>
-		<?php else: ?>
-			<?php if ( $locale->nplurals == 2 && $locale->plural_expression == 'n != 1'): ?>
-				<p><?php printf(__( 'Singular: %s', 'glotpress' ), '<span class="original">'. $singular .'</span>'); ?></p>
-				<?php textareas( $t, array( $can_edit, $can_approve ), 0 ); ?>
-				<p class="clear">
-					<?php printf(__( 'Plural: %s', 'glotpress' ), '<span class="original">'. $plural .'</span>'); ?>
-				</p>
-				<?php textareas( $t, array( $can_edit, $can_approve ), 1 ); ?>
-			<?php else: ?>
-				<!--
-				TODO: labels for each plural textarea and a sample number
-				-->
-				<p><?php printf(__( 'Singular: %s', 'glotpress' ), '<span class="original">'. $singular .'</span>'); ?></p>
-				<p class="clear">
-					<?php printf(__( 'Plural: %s', 'glotpress' ), '<span class="original">'. $plural .'</span>'); ?>
-				</p>
-				<?php foreach( range( 0, $locale->nplurals - 1 ) as $plural_index ): ?>
-					<?php if ( $locale->nplurals > 1 ): ?>
-					<p class="plural-numbers"><?php printf(__( 'This plural form is used for numbers like: %s', 'glotpress' ),
-							'<span class="numbers">'.implode(', ', $locale->numbers_for_index( $plural_index ) ).'</span>' ); ?></p>
-					<?php endif; ?>
-					<?php textareas( $t, array( $can_edit, $can_approve ), $plural_index ); ?>
-				<?php endforeach; ?>
-			<?php endif; ?>
-		<?php endif; ?>
-			<div class="actions">
-				<?php if ( $can_edit ) : ?>
-					<button class="ok" data-nonce="<?php echo esc_attr( wp_create_nonce( 'add-translation_' . $t->original_id ) ); ?>">
-						<?php echo $can_approve_translation ? __( 'Add translation &rarr;', 'glotpress' ) : __( 'Suggest new translation &rarr;', 'glotpress' ); ?>
-					</button>
-				<?php endif; ?>
-				<?php _e( 'or', 'glotpress' ); ?> <a href="#" class="close"><?php _e( 'Cancel', 'glotpress' ); ?></a>
-			</div>
-		</div>
-		<div class="meta">
-			<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
-			<dl>
-				<dt><?php _e( 'Status:', 'glotpress' ); ?></dt>
-				<dd>
-					<?php echo display_status( $t->translation_status ); ?>
-					<?php if ( $t->translation_status ): ?>
-						<?php if ( $can_approve_translation ) : ?>
-							<?php if ( 'current' !== $t->translation_status ) : ?>
-							<button class="approve" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-current_' . $t->id ) ); ?>" title="<?php echo esc_attr_e( 'Approve this translation. Any existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>+</strong> <?php _ex( 'Approve', 'Action', 'glotpress' ); ?></button>
-							<?php endif; ?>
-							<?php if ( 'rejected' !== $t->translation_status ) : ?>
-							<button class="reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $t->id ) ); ?>" title="<?php echo esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
-							<?php endif; ?>
-							<?php if ( 'fuzzy' !== $t->translation_status ) : ?>
-							<button class="fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $t->id ) ); ?>" title="<?php echo esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>
-							<?php endif; ?>
-						<?php elseif ( $can_reject_self ): ?>
-							<button class="reject" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $t->id ) ); ?>" title="<?php echo esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
-							<button class="fuzzy" tabindex="-1" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $t->id ) ); ?>" title="<?php echo esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>
-						<?php endif; ?>
-					<?php endif; ?>
-				</dd>
-			</dl>
-			<!--
-			<dl>
-				<dt><?php _e( 'Priority:', 'glotpress' ); ?></dt>
-				<dd><?php echo esc_html($t->priority); ?></dd>
-			</dl>
-			-->
-
-			<?php if ( $t->context ): ?>
-			<dl>
-				<dt><?php _e( 'Context:', 'glotpress' ); ?></dt>
-				<dd><span class="context bubble"><?php echo esc_translation($t->context); ?></span></dd>
-			</dl>
-			<?php endif; ?>
-			<?php if ( $t->extracted_comments ): ?>
-			<dl>
-				<dt><?php _e( 'Comment:', 'glotpress' ); ?></dt>
-				<dd><?php echo make_clickable( esc_translation($t->extracted_comments) ); ?></dd>
-			</dl>
-			<?php endif; ?>
-			<?php if ( $t->translation_added && $t->translation_added != '0000-00-00 00:00:00' ): ?>
-			<dl>
-				<dt><?php _e( 'Date added:', 'glotpress' ); ?></dt>
-				<dd><?php echo $t->translation_added; ?> GMT</dd>
-			</dl>
-			<?php endif; ?>
-			<?php if ( $t->user ) : ?>
-			<dl>
-				<dt><?php _e( 'Translated by:', 'glotpress' ); ?></dt>
-				<dd><?php gp_link_user( $t->user ); ?></dd>
-			</dl>
-			<?php endif; ?>
-			<?php if ( $t->user_last_modified && ( ! $t->user || $t->user->ID !== $t->user_last_modified->ID ) ) : ?>
-				<dl>
-					<dt><?php
-						if ( 'current' === $t->translation_status ) {
-							_e( 'Approved by:', 'glotpress' );
-						} elseif ( 'rejected' === $t->translation_status ) {
-							_e( 'Rejected by:', 'glotpress' );
-						} else {
-							_e( 'Last updated by:', 'glotpress' );
-						}
-						?>
-					</dt>
-					<dd><?php gp_link_user( $t->user_last_modified ); ?></dd>
-				</dl>
-			<?php endif; ?>
-			<?php references( $project, $t ); ?>
-
-			<dl>
-			    <dt><?php _e( 'Priority:', 'glotpress' ); ?></dt>
-			<?php if ( $can_write ): ?>
-				<dd><?php
-					echo gp_select(
-						'priority-' . $t->original_id,
-						GP::$original->get_static( 'priorities' ),
-						$t->priority,
-						array(
-							'class'      => 'priority',
-							'tabindex'   => '-1',
-							'data-nonce' => wp_create_nonce( 'set-priority_' . $t->original_id ),
-						)
-					);
-					?></dd>
-			<?php else : ?>
-				<dd><?php echo gp_array_get( GP::$original->get_static( 'priorities' ), $t->priority, 'unknown' ); // WPCS: XSS ok. ?></dd>
-			<?php endif; ?>
-			</dl>
-
-			<dl>
-			    <dt><?php _e( 'More links:', 'glotpress' ); ?>
-				<ul>
-					<?php foreach ( $more_links as $link ) : ?>
-						<li><?php echo $link; // WPCS: XSS ok. ?></li>
-					<?php endforeach; ?>
-				</ul>
-				</dt>
-			</dl>
-		</div>
-	</td>
-</tr>
+gp_tmpl_load(
+	'translation-row-preview', array(
+		'translation'             => $translation,
+		'can_edit'                => $can_edit,
+		'can_approve'             => $can_approve,
+		'can_approve_translation' => $can_approve_translation,
+	)
+);
+gp_tmpl_load(
+	'translation-row-editor', array(
+		'translation'             => $translation,
+		'can_write'               => $can_write,
+		'can_edit'                => $can_edit,
+		'can_approve'             => $can_approve,
+		'can_approve_translation' => $can_approve_translation,
+		'can_edit'                => $can_edit,
+		'locale'                  => $locale,
+		'project'                 => $project,
+		'translation_set'         => $translation_set,
+	)
+);

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -18,24 +18,5 @@ if ( is_object( $glossary ) ) {
 	$translation = map_glossary_entries_to_translation_originals( $translation, $glossary, $glossary_entries_terms );
 }
 
-gp_tmpl_load(
-	'translation-row-preview', array(
-		'translation'             => $translation,
-		'can_edit'                => $can_edit,
-		'can_approve'             => $can_approve,
-		'can_approve_translation' => $can_approve_translation,
-	)
-);
-gp_tmpl_load(
-	'translation-row-editor', array(
-		'translation'             => $translation,
-		'can_write'               => $can_write,
-		'can_edit'                => $can_edit,
-		'can_approve'             => $can_approve,
-		'can_approve_translation' => $can_approve_translation,
-		'can_edit'                => $can_edit,
-		'locale'                  => $locale,
-		'project'                 => $project,
-		'translation_set'         => $translation_set,
-	)
-);
+gp_tmpl_load('translation-row-preview', get_defined_vars());
+gp_tmpl_load('translation-row-editor', get_defined_vars());

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -236,24 +236,21 @@ echo gp_pagination( $page, $per_page, $total_translations_count );
 	</tr>
 	</thead>
 <?php
-	if ( $glossary ) {
-		$glossary_entries = $glossary->get_entries();
-		$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
-	}
+if ( $glossary ) {
+	$glossary_entries       = $glossary->get_entries();
+	$glossary_entries_terms = gp_sort_glossary_entries_terms( $glossary_entries );
+}
+
+foreach ( $translations as $translation ) {
+	$translation->translation_set_id = $translation_set->id;
+
+	$can_approve_translation = GP::$permission->current_user_can( 'approve', 'translation', $translation->id, array( 'translation' => $translation ) );
+	gp_tmpl_load( 'translation-row', get_defined_vars() );
+}
 ?>
-<?php foreach( $translations as $t ):
-		$t->translation_set_id = $translation_set->id;
-		$can_approve_translation = GP::$permission->current_user_can( 'approve', 'translation', $t->id, array( 'translation' => $t ) );
-		gp_tmpl_load( 'translation-row', get_defined_vars() );
-?>
-<?php endforeach; ?>
-<?php
-	if ( !$translations ):
-?>
+<?php if ( ! $translations ) : ?>
 	<tr><td colspan="<?php echo $can_approve ? 5 : 4; ?>"><?php _e( 'No translations were found!', 'glotpress' ); ?></td></tr>
-<?php
-	endif;
-?>
+<?php endif; ?>
 </table>
 <?php
 if ( $can_approve ) {


### PR DESCRIPTION
This will make maintenance easier for some plugins which need to override the entire translation-row template. Now the can just override the smaller templates or take advantage of the new filters and actions. 
For #914 