### PR TITLE
Fix long strings for Apple strings file export

### DIFF
--- a/gp-includes/formats/format-strings.php
+++ b/gp-includes/formats/format-strings.php
@@ -64,12 +64,11 @@ class GP_Format_Strings extends GP_Format {
 		usort( $sorted_entries, array( 'GP_Format_Strings', 'sort_entries' ) );
 
 		foreach ( $sorted_entries as $entry ) {
-			$entry->context = $this->escape( $entry->context );
-			$translation = empty( $entry->translations ) ? $entry->context : $this->escape( $entry->translations[0] );
+			$translation = $this->escape( empty( $entry->translations ) ? $entry->singular : $entry->translations[0] );
 
-			$original = str_replace( "\n", "\\n", $entry->context );
+			$original    = str_replace( "\n", "\\n", $this->escape( $entry->singular ) );
 			$translation = str_replace( "\n", "\\n", $translation );
-			$comment = preg_replace( "/(^\s+)|(\s+$)/us", "", $entry->extracted_comments );
+			$comment     = preg_replace( '/(^\s+)|(\s+$)/us', '', $entry->extracted_comments );
 
 			if ( $comment == "" ) {
 				$comment = "No comment provided by engineer.";


### PR DESCRIPTION
Use the original singular for the string identifier instead of the context as context is limited to 255 characters.

Fixes #921.