### PR TITLE
924: Glossary view: Fix closing dt element

### DIFF
--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -68,7 +68,7 @@ if ( $glossary->description ) {
 
 				<form action="<?php echo esc_url( gp_url_join( $url, '-new' ) ); ?>" method="post">
 					<dl>
-						<dt><label for="new_glossary_entry_term"><?php esc_html( 'Original term:', 'glossary entry', 'glotpress' ); ?></label></dt>
+						<dt><label for="new_glossary_entry_term"><?php echo esc_html( _ex( 'Original term:', 'glossary entry', 'glotpress' ) ); ?></label></dt>
 						<dd><input type="text" name="new_glossary_entry[term]" id="new_glossary_entry_term" value=""></dd>
 						<dt><label for="new_glossary_entry_post"><?php _ex( 'Part of speech', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd>

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -68,7 +68,7 @@ if ( $glossary->description ) {
 
 				<form action="<?php echo esc_url( gp_url_join( $url, '-new' ) ); ?>" method="post">
 					<dl>
-						<dt><label for="new_glossary_entry_term"><?php _ex( 'Original term:', 'glossary entry', 'glotpress' ); ?></label><dt>
+						<dt><label for="new_glossary_entry_term"><?php _ex( 'Original term:', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd><input type="text" name="new_glossary_entry[term]" id="new_glossary_entry_term" value=""></dd>
 						<dt><label for="new_glossary_entry_post"><?php _ex( 'Part of speech', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd>

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -68,7 +68,7 @@ if ( $glossary->description ) {
 
 				<form action="<?php echo esc_url( gp_url_join( $url, '-new' ) ); ?>" method="post">
 					<dl>
-						<dt><label for="new_glossary_entry_term"><?php _ex( 'Original term:', 'glossary entry', 'glotpress' ); ?></label></dt>
+						<dt><label for="new_glossary_entry_term"><?php esc_html( 'Original term:', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd><input type="text" name="new_glossary_entry[term]" id="new_glossary_entry_term" value=""></dd>
 						<dt><label for="new_glossary_entry_post"><?php _ex( 'Part of speech', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd>

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -68,7 +68,7 @@ if ( $glossary->description ) {
 
 				<form action="<?php echo esc_url( gp_url_join( $url, '-new' ) ); ?>" method="post">
 					<dl>
-						<dt><label for="new_glossary_entry_term"><?php echo esc_html( _ex( 'Original term:', 'glossary entry', 'glotpress' ) ); ?></label></dt>
+						<dt><label for="new_glossary_entry_term"><?php echo esc_html( _x( 'Original term:', 'glossary entry', 'glotpress' ) ); ?></label></dt>
 						<dd><input type="text" name="new_glossary_entry[term]" id="new_glossary_entry_term" value=""></dd>
 						<dt><label for="new_glossary_entry_post"><?php _ex( 'Part of speech', 'glossary entry', 'glotpress' ); ?></label></dt>
 						<dd>


### PR DESCRIPTION
This PR resolves #924 by correcting an unclosed `<dt>` tag in the glossary view.

<img width="719" alt="screen shot 2018-09-12 at 4 14 04 pm" src="https://user-images.githubusercontent.com/6458278/45405606-ea81c680-b6a6-11e8-85d5-a17d1b5a6537.png">
