### PR TITLE
648: Fix newline and tab character filters

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -403,11 +403,16 @@ span.morethan90 {
 /*
  * Translation Row Editor
  */
-.editor .original {
+.editor .original, .editor .original_raw {
 	font-weight: bold;
 	white-space: pre-wrap;
 	max-width: 50em;
 	word-break: break-all;
+}
+
+.editor .original_raw {
+	visibility: hidden;
+	height: 0px;
 }
 
 .editor .translation {
@@ -433,6 +438,10 @@ span.morethan90 {
 
 .editor .strings p.plural-numbers span.numbers {
 	font-weight: bold;
+}
+
+.editor .actions {
+	padding-top: 15px;
 }
 
 .editor .textareas, .editor .actions {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -94,8 +94,10 @@ $gp.editor = (
 					.on( 'dblclick', 'tr.preview td', $gp.editor.hooks.show )
 					.on( 'change', 'select.priority', $gp.editor.hooks.set_priority )
 					.on( 'click', 'a.close', $gp.editor.hooks.cancel )
-					.on( 'click', 'a.copy', $gp.editor.hooks.copy )
 					.on( 'click', 'a.discard-warning', $gp.editor.hooks.discard_warning )
+					.on( 'click', 'button.copy', $gp.editor.hooks.copy )
+					.on( 'click', 'button.inserttab', $gp.editor.hooks.tab )
+					.on( 'click', 'button.insertnl', $gp.editor.hooks.newline )
 					.on( 'click', 'button.approve', $gp.editor.hooks.set_status_current )
 					.on( 'click', 'button.reject', $gp.editor.hooks.set_status_rejected )
 					.on( 'click', 'button.fuzzy', $gp.editor.hooks.set_status_fuzzy )
@@ -362,15 +364,32 @@ $gp.editor = (
 			copy: function( link ) {
 				var chunks = link.parents( '.textareas' ).find( 'textarea' ).attr( 'id' ).split( '_' );
 				var original_index = parseInt( chunks[ chunks.length - 1 ], 10 );
-				var original_text = link.parents( '.textareas' ).prev().find( '.original' ).eq( original_index );
+				var original_text = link.parents( '.textareas' ).prev().find( '.original_raw' ).eq( original_index );
 
-				if ( ! original_text.hasClass( 'original' ) ) {
-					original_text = link.parents( '.strings' ).find( '.original' ).eq( original_index );
+				if ( ! original_text.hasClass( 'original_raw' ) ) {
+					original_text = link.parents( '.strings' ).find( '.original_raw' ).eq( original_index );
 				}
 
 				original_text = original_text.text();
-				original_text = original_text.replace( /<span class=.invisibles.*?<\/span>/g, '' );
 				link.parents( '.textareas' ).find( 'textarea' ).val( original_text ).focus();
+			},
+			tab: function( link ) {
+				var text_area = link.parents( '.textareas' ).find( 'textarea' );
+				var cursorPos = text_area.prop( 'selectionStart' );
+			    var v = text_area.val();
+			    var textBefore = v.substring( 0,  cursorPos );
+			    var textAfter  = v.substring( cursorPos, v.length );
+
+			    text_area.val( textBefore + '\t' + textAfter );
+			},
+			newline: function( link ) {
+				var text_area = link.parents( '.textareas' ).find( 'textarea' );
+				var cursorPos = text_area.prop( 'selectionStart' );
+			    var v = text_area.val();
+			    var textBefore = v.substring( 0,  cursorPos );
+			    var textAfter  = v.substring( cursorPos, v.length );
+
+			    text_area.val( textBefore + '\n' + textAfter );
 			},
 			hooks: {
 				show: function() {
@@ -401,6 +420,14 @@ $gp.editor = (
 				},
 				copy: function() {
 					$gp.editor.copy( $( this ) );
+					return false;
+				},
+				tab: function() {
+					$gp.editor.tab( $( this ) );
+					return false;
+				},
+				newline: function() {
+					$gp.editor.newline( $( this ) );
 					return false;
 				},
 				discard_warning: function() {

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -575,7 +575,9 @@ function gp_project_options_form( $project ) {
 
 function gp_entry_actions( $seperator = ' &bull; ' ) {
 	$actions = array(
-		'<a href="#" class="copy" tabindex="-1">' . __( 'Copy from original', 'glotpress' ) . '</a>'
+		'<button class="copy" tabindex="-1" title="' . __( 'Copy the original string to the translation area (overwrites existing text).', 'glotpress' ) . '">' . __( 'Copy from original', 'glotpress' ) . '</button> ' .
+		'<button class="inserttab" tabindex="-1" title="' . __( 'Insert tab (\t) at the current cursor position.', 'glotpress' ) . '">' . __( 'Insert tab', 'glotpress' ) . '</button> ' .
+		'<button class="insertnl" tabindex="-1" title="' . __( 'Insert newline (\n) at the current cursor position.', 'glotpress' ) . '">' . __( 'Insert newline', 'glotpress' ) . '</button>',
 	);
 
 	/**

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -236,7 +236,7 @@ class GP_Translation extends GP_Thing {
 		// Reduce range by one since we're starting at 0, see GH#516.
 		foreach ( range( 0, $this->get_static( 'number_of_plural_translations' ) - 1 ) as $i ) {
 			if ( isset( $args[ "translation_$i" ] ) ) {
-				$args[ "translation_$i" ] = $this->fix_translation( $args[ "translation_$i" ] );
+				$args[ "translation_$i" ] = $args[ "translation_$i" ];
 			}
 		}
 
@@ -265,20 +265,6 @@ class GP_Translation extends GP_Thing {
 		}
 
 		return $args;
-	}
-
-	public function fix_translation( $translation ) {
-		// When selecting some browsers take the newlines and some don't
-		// that's why we don't want to insert too many newlines for each ↵.
-		$translation = str_replace( "↵\n", '↵', $translation );
-		$translation = str_replace( '↵', "\n", $translation );
-
-		// When selecting some browsers take the tab and some don't
-		// that's why we don't want to insert too many tabs for each ↵.
-		$translation = str_replace( "→\t", '→', $translation );
-		$translation = str_replace( '→', "\t", $translation );
-
-		return $translation;
 	}
 
 	/**

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -112,6 +112,7 @@ if ( is_object( $glossary ) ) {
 
 		<?php if ( ! $t->plural ): ?>
 		<p class="original"><?php echo prepare_original( $singular ); ?></p>
+		<p class="original_raw"><?php echo $singular; // WPCS: XSS ok. ?></p>
 		<?php textareas( $t, array( $can_edit, $can_approve_translation ) ); ?>
 		<?php else: ?>
 			<?php if ( $locale->nplurals == 2 && $locale->plural_expression == 'n != 1'): ?>


### PR DESCRIPTION
Add raw original data to the translations row and use it for the "copy from original" code, then remove the filtering of the invisibles tab/nl so that translations can contain these UTF characters.  

Also convert "copy from original" to a button and added two new buttons to make it easier to add tab and newline characters to the translation.

Resolves #648 and #681.