### PR TITLE
919: Fix warnings count.

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -493,6 +493,7 @@ class GP_Translation_Set extends GP_Thing {
 					o.status = '+active' AND
 					( t.status = 'current' OR t.status = 'waiting' )
 					AND warnings IS NOT NULL
+					AND warnings != ''
 			", $this->id ) );
 
 			if ( $warnings_counts ) {


### PR DESCRIPTION
Fix the SQL query to be consistent with the one in the GP_Translation class.

Resolves #919.