### PR TITLE
841: Fix skipped tests.

### DIFF
--- a/tests/phpunit/testcases/tests_formats/test_format_pomo.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_pomo.php
@@ -85,10 +85,6 @@ class GP_Test_Format_PO extends GP_UnitTestCase {
 	 * @ticket GH-450
 	 */
 	public function test_po_export_includes_project_id_version_header() {
-		if ( 'GP_Format_PO' !== get_class( $this->format ) ) {
-			$this->markTestSkipped();
-		}
-
 		$parent_project_one = $this->factory->project->create();
 		$parent_project_two = $this->factory->project->create( array( 'parent_project_id' => $parent_project_one->id ) );
 		$set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'parent_project_id' => $parent_project_two->id ) );
@@ -186,7 +182,7 @@ class GP_Test_Format_MO extends GP_Test_Format_PO {
 	 */
 	protected $format;
 
-   public function setUp() {
+   	public function setUp() {
 		parent::setUp();
 
 		$this->translation_file = GP_DIR_TESTDATA . '/translation.mo';
@@ -194,6 +190,10 @@ class GP_Test_Format_MO extends GP_Test_Format_PO {
 		$this->has_comments = false;
 
 		$this->format = new Testable_GP_Format_MO;
+	}
+
+	public function test_po_export_includes_project_id_version_header() {
+		$this->assertEquals( 'Testable_GP_Format_MO', get_class( $this->format ) );
 	}
 }
 

--- a/tests/phpunit/testcases/tests_formats/test_format_pomo.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_pomo.php
@@ -84,7 +84,7 @@ class GP_Test_Format_PO extends GP_UnitTestCase {
 	/**
 	 * @ticket GH-450
 	 */
-	public function test_po_export_includes_project_id_version_header() {
+	public function test_export_includes_project_id_version_header() {
 		$parent_project_one = $this->factory->project->create();
 		$parent_project_two = $this->factory->project->create( array( 'parent_project_id' => $parent_project_one->id ) );
 		$set = $this->factory->translation_set->create_with_project_and_locale( array(), array( 'parent_project_id' => $parent_project_two->id ) );
@@ -192,7 +192,8 @@ class GP_Test_Format_MO extends GP_Test_Format_PO {
 		$this->format = new Testable_GP_Format_MO;
 	}
 
-	public function test_po_export_includes_project_id_version_header() {
+	public function test_export_includes_project_id_version_header() {
+		// MO files do no have header info, so "skip" this test without reporting that it has been skipped by phpunit.
 		$this->assertEquals( 'Testable_GP_Format_MO', get_class( $this->format ) );
 	}
 }


### PR DESCRIPTION
When the PO/MO tests were updated with the "Testable" class, the logic for detecting the class name in the  `test_po_export_includes_project_id_version_header` test was not similarly updated.

This PR changes the class test to occur only in the MO file test class and produce a clean phpunit report (aka no "Skipped" tests).

Resolves #841.