### PR TITLE
841: Remove PHP 7.2 deprecated functions.

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -159,39 +159,85 @@ function gp_populate_notices() {
  * each of the argument arrays. The returned array is truncated in length to the length
  * of the shortest argument array.
  *
- * The function works only with numerical arrays.
+ * Previously this function was documented as:
+ *
+ * 		The function works only with numerical arrays.
+ *
+ * However this was incorrect, this function would only return an array of arrays with
+ * numeric basic indexes, but would process any array whether it was numeric or reference
+ * based, using the order in which the array was created as the index value to return.
+ *
+ * For example:
+ *
+ *		$first_array[] = "First"
+ *		$first_array[] = "Second"
+ *		$first_array[] = "Third"
+ *
+ *		$second_array[0]    = "Fourth"
+ *		$second_array[test] = "Fifth"
+ *		$second_array[1]    = "Sixth"
+ *
+ *		$result = gp_array_zip( $first_array, $second_array );
+ *
+ * Would produce:
+ *
+ *		$result[0][0] = "First"
+ *		$result[0][1] = "Fourth"
+ *		$result[1][0] = "Second"
+ *		$result[1][1] = "Fifth"
+ *		$result[2][0] = "Third"
+ *		$result[2][1] = "Sixth"
+ *
+ * Instead of either failing (which is probably what should have happened) or something like:
+ *
+ *		$result[0][0] = "First"
+ *		$result[0][1] = "Fourth"
+ *		$result[1][0] = "Second"
+ *		$result[1][1] = "Sixth"
+ *
+ * Or some other random result.
+ *
  */
 function gp_array_zip() {
 	$args = func_get_args();
+
 	if ( !is_array( $args ) ) {
 		return false;
 	}
+
 	if ( empty( $args ) ) {
 		return array();
 	}
-	$res = array();
+
+	$depth = 0;
+
 	foreach ( $args as &$array ) {
 		if ( !is_array( $array) ) {
 			return false;
 		}
+
+		$array_size = sizeof( $array );
 		reset( $array );
-	}
-	$all_have_more = true;
-	while (true) {
-		$this_round = array();
-		foreach ( $args as &$array ) {
-			$all_have_more = ( list( , $value ) = each( $array ) );
-			if ( !$all_have_more ) {
-				break;
-			}
-			$this_round[] = $value;
-		}
-		if ( $all_have_more ) {
-			$res[] = $this_round;
-		} else {
-			break;
+
+		if ( 0 === $depth || $depth > $array_size ) {
+			$depth = $array_size;
 		}
 	}
+
+	$res = array();
+
+	$array_count = 0;
+
+	foreach ( $args as &$array ) {
+		for ( $i = 0; $i < $depth; $i++) {
+			$res[ $i ][ $array_count ] = current( $array );
+
+			next( $array );
+		}
+
+		$array_count++;
+	}
+
 	return $res;
 }
 

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -161,7 +161,7 @@ function gp_populate_notices() {
  *
  * Previously this function was documented as:
  *
- * 		The function works only with numerical arrays.
+ *      The function works only with numerical arrays.
  *
  * However this was incorrect, this function would only return an array of arrays with
  * numeric basic indexes, but would process any array whether it was numeric or reference
@@ -169,31 +169,31 @@ function gp_populate_notices() {
  *
  * For example:
  *
- *		$first_array[] = "First"
- *		$first_array[] = "Second"
- *		$first_array[] = "Third"
+ *      $first_array[] = "First"
+ *      $first_array[] = "Second"
+ *      $first_array[] = "Third"
  *
- *		$second_array[0]    = "Fourth"
- *		$second_array[test] = "Fifth"
- *		$second_array[1]    = "Sixth"
+ *      $second_array[0]    = "Fourth"
+ *      $second_array[test] = "Fifth"
+ *      $second_array[1]    = "Sixth"
  *
- *		$result = gp_array_zip( $first_array, $second_array );
+ *      $result = gp_array_zip( $first_array, $second_array );
  *
  * Would produce:
  *
- *		$result[0][0] = "First"
- *		$result[0][1] = "Fourth"
- *		$result[1][0] = "Second"
- *		$result[1][1] = "Fifth"
- *		$result[2][0] = "Third"
- *		$result[2][1] = "Sixth"
+ *      $result[0][0] = "First"
+ *      $result[0][1] = "Fourth"
+ *      $result[1][0] = "Second"
+ *      $result[1][1] = "Fifth"
+ *      $result[2][0] = "Third"
+ *      $result[2][1] = "Sixth"
  *
  * Instead of either failing (which is probably what should have happened) or something like:
  *
- *		$result[0][0] = "First"
- *		$result[0][1] = "Fourth"
- *		$result[1][0] = "Second"
- *		$result[1][1] = "Sixth"
+ *      $result[0][0] = "First"
+ *      $result[0][1] = "Fourth"
+ *      $result[1][0] = "Second"
+ *      $result[1][1] = "Sixth"
  *
  * Or some other random result.
  *
@@ -216,7 +216,7 @@ function gp_array_zip() {
 			return false;
 		}
 
-		$array_size = sizeof( $array );
+		$array_size = count( $array );
 		reset( $array );
 
 		if ( 0 === $depth || $depth > $array_size ) {
@@ -229,7 +229,7 @@ function gp_array_zip() {
 	$array_count = 0;
 
 	foreach ( $args as &$array ) {
-		for ( $i = 0; $i < $depth; $i++) {
+		for ( $i = 0; $i < $depth; $i++ ) {
 			$res[ $i ][ $array_count ] = current( $array );
 
 			next( $array );

--- a/tests/phpunit/lib/testcase-request.php
+++ b/tests/phpunit/lib/testcase-request.php
@@ -22,7 +22,11 @@ class GP_UnitTestCase_Request extends GP_UnitTestCase {
             'uri' => $uri,
             'gp_config_path' => dirname( __FILE__ ) . '/../unittests-config.php',
         );
-        extract( array_map( create_function( '$value', 'return var_export( $value, true );' ), $config_vars ) );
+        extract( array_map( function( $value ) {
+            return var_export( $value, true );
+            },
+            $config_vars )
+        );
         $config_php_code = <<<CONFIG
 <?php
 \$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';

--- a/tests/phpunit/testcases/test_warnings.php
+++ b/tests/phpunit/testcases/test_warnings.php
@@ -3,8 +3,12 @@
 class GP_Test_Translation_Warnings extends GP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
-		$this->is_baba = create_function('$o, $t, $l', 'return $t == "баба"? true : "error";');
-		$this->is_equal = create_function('$o, $t, $l', 'return $t == $o? true : "error";');
+		$this->is_baba = function( $o, $t, $l ) {
+			return $t == "баба"? true : "error";
+			};
+		$this->is_equal = function( $o, $t, $l ) {
+			return $t == $o? true : "error";
+			};
 		$this->w = new GP_Translation_Warnings;
 		$this->with_equal = new GP_Translation_Warnings;
 		$this->with_equal->add( 'is_equal', $this->is_equal );

--- a/tests/phpunit/testcases/tests_testlib/test_factory.php
+++ b/tests/phpunit/testcases/tests_testlib/test_factory.php
@@ -118,7 +118,9 @@ class GP_Test_Unittest_Factory extends GP_UnitTestCase {
 
 	function test_factory_for_thing_create_should_use_function_generator() {
 		$generation_defintions = array(
-			'full_name' => GP_UnitTest_Factory_For_Thing::callback( create_function( '$o', 'return $o->name . " baba";' ) ),
+			'full_name' => GP_UnitTest_Factory_For_Thing::callback( function( $o ) {
+				return $o->name . " baba";
+			} ),
 		);
 		$factory = $this->create_factory( null, $generation_defintions );
 		$create_args = array('name' => 'my name is');


### PR DESCRIPTION
`each()` and `create_function()` throw warnings in PHP 7.2 which cause errors during the PHPUnit.

`each()` has been replace with a `current()/next()` call.

`create_function()` has been replaced with anonymous functions.

Resolves #941.