### PR TITLE
944: Make sure $wp is an instance of WP before use.

### DIFF
--- a/gp-includes/rewrite.php
+++ b/gp-includes/rewrite.php
@@ -92,7 +92,7 @@ function gp_run_route() {
 function is_glotpress() {
 	global $wp;
 
-	if ( ! is_admin() && GP_ROUTING && null != $wp->query_vars && array_key_exists( 'gp_route', $wp->query_vars ) ) {
+	if ( ! is_admin() && GP_ROUTING && $wp INSTANCEOF WP && null != $wp->query_vars && array_key_exists( 'gp_route', $wp->query_vars ) ) {
 		return true;
 	}
 	return false;

--- a/gp-includes/rewrite.php
+++ b/gp-includes/rewrite.php
@@ -92,7 +92,7 @@ function gp_run_route() {
 function is_glotpress() {
 	global $wp;
 
-	if ( ! is_admin() && GP_ROUTING && $wp INSTANCEOF WP && null != $wp->query_vars && array_key_exists( 'gp_route', $wp->query_vars ) ) {
+	if ( ! is_admin() && GP_ROUTING && $wp instanceof WP && null !== $wp->query_vars && array_key_exists( 'gp_route', $wp->query_vars ) ) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
There's no need to check if $wp is a object before checking if it is an instanceof WP as we've declared it as a global inside the function so PHP doesn't throw an undefined warning.

Resolves #944.