### PR TITLE
Don't block multiple Glossary entries with same part_of_speech.

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -90,7 +90,6 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 				$find_parms = array(
 					'glossary_id'    => $glossary->id,
 					'term'           => $new_glossary_entry->term,
-					'part_of_speech' => $new_glossary_entry->part_of_speech,
 				);
 
 				if ( GP::$glossary_entry->find_one( $find_parms ) ) {

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -88,8 +88,8 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 				$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 			} else {
 				$find_parms = array(
-					'glossary_id'    => $glossary->id,
-					'term'           => $new_glossary_entry->term,
+					'glossary_id' => $glossary->id,
+					'term'        => $new_glossary_entry->term,
 				);
 
 				if ( GP::$glossary_entry->find_one( $find_parms ) ) {


### PR DESCRIPTION
Removed part_of_speech from the so as to avoid blocking multiple noun translations. Fixes #946 and Reverts some of the unintentional code merged to resolve #745

I didn't touch the warning text which contains part_of_speech as it is potentially still useful, referring to;
https://github.com/GlotPress/GlotPress-WP/blob/develop/gp-includes/routes/glossary-entry.php#L98