### PR TITLE
Fixed with suggestions

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -90,6 +90,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 				$find_parms = array(
 					'glossary_id' => $glossary->id,
 					'term'        => $new_glossary_entry->term,
+					'translation' => $new_glossary_entry->translation,
 				);
 
 				if ( GP::$glossary_entry->find_one( $find_parms ) ) {


### PR DESCRIPTION
Adds translation to the find_parms but left part_of_speech out so we can't have duplicate translations irrelevant as to what part of speech. If there's a use case where two identical translations can be different parts of speech and that's desired then can add part_of_speech back. Re fixes #946 