### PR TITLE
[i18n] Correct uppercase string to merge with existent similar

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -332,7 +332,7 @@ echo gp_pagination( $page, $per_page, $total_translations_count );
 ?>
 	</div><?php endforeach; ?>
 	<div class="box has-warnings"></div>
-	<div><?php _e( 'With Warnings', 'glotpress' ); ?></div>
+	<div><?php _e( 'With warnings', 'glotpress' ); ?></div>
 
 </div>
 <p class="clear actionlist secondary">


### PR DESCRIPTION
The commit https://github.com/GlotPress/GlotPress-WP/commit/78200361c5e3564505048523c11f55c2ad815704  added `With warnings` string as filter option.
There already exists an old `With Warnings` from the footer labels.

This PR merges both in one with the new case choice: `With warnings`.