### PR TITLE
415: Avoid URLENCODE on the double slash paths

### DIFF
--- a/gp-includes/url.php
+++ b/gp-includes/url.php
@@ -146,14 +146,14 @@ function gp_url_current() {
  * @return string
  */
 function gp_url_project( $project_or_path = '', $path = '', $query = null ) {
-	$project_path = urlencode( is_object( $project_or_path ) ? $project_or_path->path : $project_or_path );
+	$project_path = is_object( $project_or_path ) ? $project_or_path->path : $project_or_path;
 
 	// A leading double-slash will avoid prepending /projects/ to the path.
 	// This was introduced to enable linking to the locale glossary.
 	if ( '//' === substr( $project_path, 0, 2 ) ) {
-		$project_path = ltrim( $project_path, '/' );
+		$project_path = urlencode( ltrim( $project_path, '/' ) );
 	} else {
-		$project_path = array( 'projects', $project_path );
+		$project_path = array( 'projects', urlencode( $project_path ) );
 	}
 
 	return gp_url( array( $project_path, $path ), $query );


### PR DESCRIPTION
This updates the gp_url_project urlencode implementation to avoid encoding the glossary locale URLs that contain the preceeding double slash '//'. This fixes #415 again without compromising Glossaries

I made sure to retest the original issue raised by @ocean90 in #451 so this implementation still addresses that properly.
![screen shot 2018-10-30 at 3 25 03 pm](https://user-images.githubusercontent.com/8726005/47754874-7fda1980-dc59-11e8-8aa5-b76b5ae0f500.png)
