### PR TITLE
992: Fix missing 'By:' author in Glossary entry

### DIFF
--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -48,7 +48,7 @@
 			</dl>
 			<?php if ( $entry->user_login ): ?>
 			<dl>
-				<dt><?php _x( 'By:','by author', 'glotpress' ); ?></dt>
+				<dt><?php _ex( 'By:', 'by author', 'glotpress' ); ?></dt>
 				<dd><?php
 				if ( $entry->user_display_name && $entry->user_display_name != $entry->user_login ) {
 					printf( '%s (%s)', $entry->user_display_name, $entry->user_login );


### PR DESCRIPTION
Fixes #992.

This PR doesn't propose any specific copy as in the issue #992.
It just fix the gettext function `_x()` -> `_ex()` to show the already existing string 'By:' {author}.