### PR TITLE
999: Fix wrong permissions error messages.

### DIFF
--- a/gp-includes/routes/note.php
+++ b/gp-includes/routes/note.php
@@ -28,7 +28,7 @@ class GP_Route_Note extends GP_Route_Main {
 		$admin          = GP::$permission->current_user_can( 'approve', 'translation', $translation_id, array( 'translation' => $translation ) );
 
 		if ( get_current_user_id() !== (int) $translation->user_id && ! $admin ) {
-			return $this->die_with_error( __( 'You don\'t have permissions. Please try again.', 'glotpress' ), 403 );
+			return $this->die_with_error( __( 'Sorry, you are not allowed to create this note.', 'glotpress' ), 403 );
 		}
 
 		if ( ! $this->verify_nonce( 'new-note-' . $translation_id ) ) {
@@ -59,7 +59,7 @@ class GP_Route_Note extends GP_Route_Main {
 		$admin          = GP::$permission->current_user_can( 'approve', 'translation', $translation_id, array( 'translation' => $translation ) );
 
 		if ( get_current_user_id() !== (int) $note_object->user_id && ! $admin ) {
-			return $this->die_with_error( __( 'You don\'t have permissions. Please try again.', 'glotpress' ), 403 );
+			return $this->die_with_error( __( 'Sorry, you are not allowed to edit this note.', 'glotpress' ), 403 );
 		}
 
 		if ( ! $this->verify_nonce( 'edit-note-' . $note_id ) ) {
@@ -88,7 +88,7 @@ class GP_Route_Note extends GP_Route_Main {
 		$admin          = GP::$permission->current_user_can( 'approve', 'translation', $translation_id, array( 'translation' => $translation ) );
 
 		if ( get_current_user_id() !== (int) $note_object->user_id && ! $admin ) {
-			return $this->die_with_error( __( 'You don\'t have permissions. Please try again.', 'glotpress' ), 403 );
+			return $this->die_with_error( __( 'Sorry, you are not allowed to delete this note.', 'glotpress' ), 403 );
 		}
 
 		if ( ! $this->verify_nonce( 'delete-note-' . $note_id ) ) {


### PR DESCRIPTION
Fixes #999.

Corrections made according `Sorry, you are not allowed to create/edit/delete this note.` pattern mentioned in #999.