### PR TITLE
1001: Delete notes in `GP_Original::delete()` when deleting an original

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -516,14 +516,14 @@ class GP_Original extends GP_Thing {
 		 */
 		do_action( 'gp_original_deleted', $this );
 
-		$note_id = GP::$notes->get_by_translation_id( $this->id );
+		$note_ids = GP::$notes->get_by_translation_id( $this->id );
 
 		// Make sure we have some note id's to delete before trying to delete them.
-		if ( ! is_array( $note_id ) ) {
-			GP::$notes->delete_all( array( 'id' => $note_id ) );
+		if ( ! is_array( $note_ids ) ) {
+			return GP::$notes->delete_all( array( 'id' => $note_ids ) );
 		}
 
-		return true;
+		return false;
 	}
 }
 GP::$original = new GP_Original();


### PR DESCRIPTION
As suggested the various fixes for #1001 