### PR TITLE
Notes: fix missing urls preventing notes actions from happening

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -8,7 +8,7 @@ gp_enqueue_scripts( array( 'gp-editor', 'gp-translations-page' ) );
 wp_localize_script( 'gp-translations-page', '$gp_translations_options', array( 'sort' => __( 'Sort', 'glotpress' ), 'filter' => __( 'Filter', 'glotpress' ) ) );
 
 // localizer adds var in front of the variable name, so we can't use $gp.editor.options
-$editor_options = compact('can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url');
+$editor_options = compact( 'can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url' , 'new_note_url', 'edit_note_url', 'delete_note_url' );
 
 wp_localize_script( 'gp-editor', '$gp_editor_options', $editor_options );
 

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -8,7 +8,7 @@ gp_enqueue_scripts( array( 'gp-editor', 'gp-translations-page' ) );
 wp_localize_script( 'gp-translations-page', '$gp_translations_options', array( 'sort' => __( 'Sort', 'glotpress' ), 'filter' => __( 'Filter', 'glotpress' ) ) );
 
 // localizer adds var in front of the variable name, so we can't use $gp.editor.options
-$editor_options = compact( 'can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url' , 'new_note_url', 'edit_note_url', 'delete_note_url' );
+$editor_options = compact( 'can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url', 'new_note_url', 'edit_note_url', 'delete_note_url' );
 
 wp_localize_script( 'gp-editor', '$gp_editor_options', $editor_options );
 


### PR DESCRIPTION
This adds the note routes URLs to the editor options. 

Fixes #1008 