### PR TITLE
Locales: Fix plural expression for Persian locales

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -923,8 +923,8 @@ class GP_Locales {
 		$fa->lang_code_iso_639_2 = 'fas';
 		$fa->wp_locale = 'fa_IR';
 		$fa->slug = 'fa';
-		$fa->nplurals = 1;
-		$fa->plural_expression = '0';
+		$fa->nplurals = 2;
+		$fa->plural_expression = 'n > 1';
 		$fa->text_direction = 'rtl';
 		$fa->google_code = 'fa';
 		$fa->facebook_locale = 'fa_IR';
@@ -936,8 +936,8 @@ class GP_Locales {
 		$fa_af->lang_code_iso_639_2 = 'fas';
 		$fa_af->wp_locale = 'fa_AF';
 		$fa_af->slug = 'fa-af';
-		$fa_af->nplurals = 1;
-		$fa_af->plural_expression = '0';
+		$fa_af->nplurals = 2;
+		$fa_af->plural_expression = 'n > 1';
 		$fa_af->text_direction = 'rtl';
 		$fa_af->google_code = 'fa';
 		$fa_af->variant_root = $fa->slug;

--- a/locales/no-variants/locales.php
+++ b/locales/no-variants/locales.php
@@ -881,8 +881,8 @@ class GP_Locales {
 		$fa->lang_code_iso_639_2 = 'fas';
 		$fa->wp_locale = 'fa_IR';
 		$fa->slug = 'fa';
-		$fa->nplurals = 1;
-		$fa->plural_expression = '0';
+		$fa->nplurals = 2;
+		$fa->plural_expression = 'n > 1';
 		$fa->text_direction = 'rtl';
 		$fa->google_code = 'fa';
 		$fa->facebook_locale = 'fa_IR';
@@ -894,8 +894,8 @@ class GP_Locales {
 		$fa_af->lang_code_iso_639_2 = 'fas';
 		$fa_af->wp_locale = 'fa_AF';
 		$fa_af->slug = 'fa-af';
-		$fa_af->nplurals = 1;
-		$fa_af->plural_expression = '0';
+		$fa_af->nplurals = 2;
+		$fa_af->plural_expression = 'n > 1';
 		$fa_af->text_direction = 'rtl';
 		$fa_af->google_code = 'fa';
 


### PR DESCRIPTION
Hi,
This is a correction for plural form for Translate system for Persian language and Persian Afghanistan
Here is a sample:
Singular: %s post not updated, somebody is editing it.
Plural: %s posts not updated, somebody is editing them.
Singular translation: %s نوشته بروزرسانی نشد، فردی در حال ویرایش آن است.
Plural translation: %s نوشته بروزرسانی نشد، فردی در حال ویرایش آنها می‌باشد.
in first part of the sentence it is same, but in second part it is different
this is a very good sample to clear this issue
I added a patch for this problem