### PR TITLE
Add "Portuguese (Portugal, AO90)" variant

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1866,6 +1866,17 @@ class GP_Locales {
 		$pt->google_code = 'pt-PT';
 		$pt->facebook_locale = 'pt_PT';
 
+		$pt_ao90 = new GP_Locale();
+		$pt_ao90->english_name = 'Portuguese (Portugal, AO90)';
+		$pt_ao90->native_name = 'Português (AO90)';
+		$pt_ao90->lang_code_iso_639_1 = 'pt';
+		$pt_ao90->country_code = 'pt';
+		$pt_ao90->wp_locale = 'pt_PT_ao90';
+		$pt_ao90->slug = 'pt_ao90';
+		$pt_ao90->google_code = 'pt-PT';
+		$pt_ao90->variant_root = $pt->slug;
+		$pt->variants[ $pt_ao90->slug ] = $pt_ao90->english_name;
+
 		$pt_ao = new GP_Locale();
 		$pt_ao->english_name = 'Portuguese (Angola)';
 		$pt_ao->native_name = 'Português de Angola';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1872,7 +1872,7 @@ class GP_Locales {
 		$pt_ao90->lang_code_iso_639_1 = 'pt';
 		$pt_ao90->country_code = 'pt';
 		$pt_ao90->wp_locale = 'pt_PT_ao90';
-		$pt_ao90->slug = 'pt_ao90';
+		$pt_ao90->slug = 'pt-ao90';
 		$pt_ao90->google_code = 'pt-PT';
 		$pt_ao90->variant_root = $pt->slug;
 		$pt->variants[ $pt_ao90->slug ] = $pt_ao90->english_name;


### PR DESCRIPTION
Add support for the "Portuguese (Portugal, AO90)" variant.

The variant already exists as a pseudo-variant in translate.wordpress.org:
https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php#L1883