### PR TITLE
Locales: Add definitions for Lower Sorbian, Ch’ti (France), Wolof

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -569,6 +569,17 @@ class GP_Locales {
 		$de_ch->variant_root = $de->slug;
 		$de->variants[ $de_ch->slug ] = $de_ch->english_name;
 
+		$dsb = new GP_Locale();
+		$dsb->english_name = 'Lower Sorbian';
+		$dsb->native_name = 'Dolnoserbšćina';
+		$dsb->lang_code_iso_639_2 = 'dsb';
+		$dsb->lang_code_iso_639_3 = 'dsb';
+		$dsb->country_code = 'de';
+		$dsb->wp_locale = 'dsb';
+		$dsb->slug = 'dsb';
+		$dsb->nplurals = 4;
+		$dsb->plural_expression = '(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3)';
+
 		$dv = new GP_Locale();
 		$dv->english_name = 'Dhivehi';
 		$dv->native_name = 'ދިވެހި';
@@ -1843,6 +1854,16 @@ class GP_Locales {
 		$pap_aw->wp_locale = 'pap_AW';
 		$pap_aw->slug = 'pap-aw';
 
+		$pcd = new GP_Locale();
+		$pcd->english_name = 'Picard';
+		$pcd->native_name = 'Ch’ti';
+		$pcd->lang_code_iso_639_3 = 'pcd';
+		$pcd->country_code = 'fr';
+		$pcd->wp_locale = 'pcd';
+		$pcd->slug = 'pcd';
+		$pcd->nplurals = 2;
+		$pcd->plural_expression = '(n > 1)';
+
 		$pirate = new GP_Locale();
 		$pirate->english_name = 'English (Pirate)';
 		$pirate->native_name = 'English (Pirate)';
@@ -2419,6 +2440,19 @@ class GP_Locales {
 		$wa->country_code = 'be';
 		$wa->wp_locale = 'wa';
 		$wa->slug = 'wa';
+
+		$wol = new GP_Locale();
+		$wol->english_name = 'Wolof';
+		$wol->native_name = 'Wolof';
+		$wol->lang_code_iso_639_1 = 'wo';
+		$wol->lang_code_iso_639_2 = 'wol';
+		$wol->lang_code_iso_639_3 = 'wol';
+		$wol->country_code = 'sn';
+		$wol->wp_locale = 'wol';
+		$wol->slug = 'wol';
+		$wol->nplurals = 1;
+		$wol->plural_expression = '0';
+		$wol->google_code = 'wo';
 
 		$xho = new GP_Locale();
 		$xho->english_name = 'Xhosa';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1862,7 +1862,7 @@ class GP_Locales {
 		$pcd->wp_locale = 'pcd';
 		$pcd->slug = 'pcd';
 		$pcd->nplurals = 2;
-		$pcd->plural_expression = '(n > 1)';
+		$pcd->plural_expression = 'n > 1';
 
 		$pirate = new GP_Locale();
 		$pirate->english_name = 'English (Pirate)';
@@ -2452,7 +2452,6 @@ class GP_Locales {
 		$wol->slug = 'wol';
 		$wol->nplurals = 1;
 		$wol->plural_expression = '0';
-		$wol->google_code = 'wo';
 
 		$xho = new GP_Locale();
 		$xho->english_name = 'Xhosa';

--- a/locales/no-variants/locales.php
+++ b/locales/no-variants/locales.php
@@ -559,6 +559,17 @@ class GP_Locales {
 		$de_ch->slug = 'de-ch';
 		$de_ch->google_code = 'de';
 
+		$dsb = new GP_Locale();
+		$dsb->english_name = 'Lower Sorbian';
+		$dsb->native_name = 'Dolnoserbšćina';
+		$dsb->lang_code_iso_639_2 = 'dsb';
+		$dsb->lang_code_iso_639_3 = 'dsb';
+		$dsb->country_code = 'de';
+		$dsb->wp_locale = 'dsb';
+		$dsb->slug = 'dsb';
+		$dsb->nplurals = 4;
+		$dsb->plural_expression = '(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3)';
+
 		$dv = new GP_Locale();
 		$dv->english_name = 'Dhivehi';
 		$dv->native_name = 'ދިވެހި';
@@ -1791,6 +1802,16 @@ class GP_Locales {
 		$pap_aw->wp_locale = 'pap_AW';
 		$pap_aw->slug = 'pap-aw';
 
+		$pcd = new GP_Locale();
+		$pcd->english_name = 'Picard';
+		$pcd->native_name = 'Ch’ti';
+		$pcd->lang_code_iso_639_3 = 'pcd';
+		$pcd->country_code = 'fr';
+		$pcd->wp_locale = 'pcd';
+		$pcd->slug = 'pcd';
+		$pcd->nplurals = 2;
+		$pcd->plural_expression = 'n > 1';
+
 		$pirate = new GP_Locale();
 		$pirate->english_name = 'English (Pirate)';
 		$pirate->native_name = 'English (Pirate)';
@@ -2365,6 +2386,18 @@ class GP_Locales {
 		$wa->country_code = 'be';
 		$wa->wp_locale = 'wa';
 		$wa->slug = 'wa';
+
+		$wol = new GP_Locale();
+		$wol->english_name = 'Wolof';
+		$wol->native_name = 'Wolof';
+		$wol->lang_code_iso_639_1 = 'wo';
+		$wol->lang_code_iso_639_2 = 'wol';
+		$wol->lang_code_iso_639_3 = 'wol';
+		$wol->country_code = 'sn';
+		$wol->wp_locale = 'wol';
+		$wol->slug = 'wol';
+		$wol->nplurals = 1;
+		$wol->plural_expression = '0';
 
 		$xho = new GP_Locale();
 		$xho->english_name = 'Xhosa';


### PR DESCRIPTION
This adds:

* Lower Sorbian: https://make.wordpress.org/polyglots/2019/12/17/hi-please-enable-lower-sorbian/
* Ch’ti (France): https://make.wordpress.org/polyglots/2018/08/02/new-locale-for-chti/
* Wolof: https://make.wordpress.org/polyglots/2020/01/03/hello-we-are-an-organisation/