### PR TITLE
Enable caching and parallel file processing for PHPCS

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Coding Standards for GlotPress">
 
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20"/>
+
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache"/>
+
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents" />
@@ -31,13 +46,6 @@
 			<property name="text_domain" value="glotpress" />
 		</properties>
 	</rule>
-
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
-
-	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
-	<arg name="extensions" value="php"/>
-	<file>.</file>
 
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/dev-lib/*</exclude-pattern>


### PR DESCRIPTION
This speeds up running PHPCS on GlotPress files.