### PR TITLE
Thing: Fix types of integer fields by normalizing them to integers.

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -58,20 +58,20 @@ class GP_Original extends GP_Thing {
 	 * @return array Normalized arguments for a GP_Original object.
 	 */
 	public function normalize_fields( $args ) {
-		$args = (array) $args;
-
 		foreach ( array( 'plural', 'context', 'references', 'comment' ) as $field ) {
 			if ( isset( $args['parent_project_id'] ) ) {
 				$args[ $field ] = $this->force_false_to_null( $args[ $field ] );
 			}
 		}
 
-		if ( isset( $args['priority'] ) && !is_numeric( $args['priority'] ) ) {
+		if ( isset( $args['priority'] ) && ! is_numeric( $args['priority'] ) ) {
 			$args['priority'] = $this->priority_by_name( $args['priority'] );
 			if ( is_null( $args['priority'] ) ) {
 				unset( $args['priority'] );
 			}
 		}
+
+		$args = parent::normalize_fields( $args );
 
 		return $args;
 	}

--- a/gp-includes/things/permission.php
+++ b/gp-includes/things/permission.php
@@ -35,7 +35,7 @@ class GP_Permission extends GP_Thing {
 	 * @return array Normalized arguments for a GP_Permission object.
 	 */
 	public function normalize_fields( $args ) {
-		$args = (array) $args;
+		$args = parent::normalize_fields( $args );
 
 		foreach ( $this->field_names as $field_name ) {
 			if ( isset( $args[ $field_name ] ) ) {

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -188,8 +188,6 @@ class GP_Project extends GP_Thing {
 	 * @return array Normalized arguments for a GP_Project object.
 	 */
 	public function normalize_fields( $args ) {
-		$args = (array) $args;
-
 		if ( isset( $args['parent_project_id'] ) ) {
 			$args['parent_project_id'] = $this->force_false_to_null( $args['parent_project_id'] );
 		}
@@ -215,6 +213,8 @@ class GP_Project extends GP_Thing {
 				$args['active'] = 0;
 			}
 		}
+
+		$args = parent::normalize_fields( $args );
 
 		return $args;
 	}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -128,7 +128,7 @@ class GP_Translation_Set extends GP_Thing {
 	 * @return array Normalized arguments for a GP_Translation_Set object.
 	 */
 	public function normalize_fields( $args ) {
-		$args = (array) $args;
+		$args = parent::normalize_fields( $args );
 
 		if ( isset( $args['name'] ) && empty( $args['name'] ) ) {
 			if ( isset( $args['locale'] ) && ! empty( $args['locale'] ) ) {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -221,7 +221,7 @@ class GP_Translation extends GP_Thing {
 	 * @return array Normalized arguments for a GP_Translation object.
 	 */
 	public function normalize_fields( $args ) {
-		$args = (array) $args;
+		$args = parent::normalize_fields( $args );
 
 		if ( isset( $args['translations'] ) && is_array( $args['translations'] ) ) {
 			// Reduce range by one since we're starting at 0, see GH#516.
@@ -288,9 +288,13 @@ class GP_Translation extends GP_Thing {
 		$rules->user_id_last_modified_should_not_be( 'empty_string' );
 	}
 
-
-	public function set_fields( $db_object ) {
-		parent::set_fields( $db_object );
+	/**
+	 * Sets fields of the current GP_Thing object.
+	 *
+	 * @param array $fields Fields for a GP_Thing object.
+	 */
+	public function set_fields( $fields ) {
+		parent::set_fields( $fields );
 		if ( $this->warnings ) {
 			$this->warnings = maybe_unserialize( $this->warnings );
 		}

--- a/gp-includes/things/validator-permission.php
+++ b/gp-includes/things/validator-permission.php
@@ -39,8 +39,13 @@ class GP_Validator_Permission extends GP_Permission {
 		$rules->set_slug_should_not_be( 'empty' );
 	}
 
-	public function set_fields( $db_object ) {
-		parent::set_fields( $db_object );
+	/**
+	 * Sets fields of the current GP_Thing object.
+	 *
+	 * @param array $fields Fields for a GP_Thing object.
+	 */
+	public function set_fields( $fields ) {
+		parent::set_fields( $fields );
 		if ( $this->object_id ) {
 			list( $this->project_id, $this->locale_slug, $this->set_slug ) = $this->project_id_locale_slug_set_slug( $this->object_id );
 		}

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary.php
@@ -10,9 +10,9 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 	}
 
 	function test_by_set_id() {
-		$glossary_1 = GP::$glossary->create_and_select( array( 'translation_set_id' => '1' ) );
-		$glossary_2 = GP::$glossary->create_and_select( array( 'translation_set_id' => '2' ) );
-		$new = GP::$glossary->by_set_id( '1' );
+		$glossary_1 = GP::$glossary->create_and_select( array( 'translation_set_id' => 1 ) );
+		$glossary_2 = GP::$glossary->create_and_select( array( 'translation_set_id' => 2 ) );
+		$new = GP::$glossary->by_set_id( 1 );
 		$this->assertEquals( $glossary_1, $new );
 		$this->assertNotEquals( $glossary_2, $new );
 	}
@@ -41,9 +41,9 @@ class GP_Test_Glossary extends GP_UnitTestCase {
 	}
 
 	function test_delete() {
-		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => '1' ) );
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => 1 ) );
 		$glossary->delete();
-		$new = GP::$glossary->by_set_id( '1' );
+		$new = GP::$glossary->by_set_id( 1 );
 		$this->assertNotEquals( $glossary, $new );
 
 	}


### PR DESCRIPTION
Also fix `GP_Thing::reload()` by not passing the full GP_Thing to `GP_Thing::set_fields()`.

Fixes #1050.