### PR TITLE
Fix syntax error by removing a stray M character

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -658,7 +658,7 @@ class GP_Translation extends GP_Thing {
 		array(
 			'original_id'        => $this->original_id,
 			'translation_set_id' => $this->translation_set_id,
-			'status'             => 'fuzzy'M,
+			'status'             => 'fuzzy',
 		) )
 		&& $this->save( array(
 			'status'                => 'current',


### PR DESCRIPTION
Introduced in https://github.com/GlotPress/GlotPress-WP/commit/8decc5d624f48db427b41fc640828df13c829434 via #1066.