### PR TITLE
Use strict type check for in_array() and array_search().

### DIFF
--- a/gp-includes/cli/translation-set.php
+++ b/gp-includes/cli/translation-set.php
@@ -81,7 +81,7 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 			$valid_priorities = GP::$original->get_static( 'priorities' );
 
 			foreach ( $priorities as $priority ) {
-				$key = array_search( $priority, $valid_priorities );
+				$key = array_search( $priority, $valid_priorities, true );
 				if ( false === $key ) {
 					WP_CLI::warning( sprintf( 'Invalid priority %s', $priority ) );
 				} else {

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -284,7 +284,7 @@ function gp_error_log_dump( $value ) {
 }
 
 function gp_object_has_var( $object, $var_name ) {
-	return in_array( $var_name, array_keys( get_object_vars( $object ) ) );
+	return in_array( $var_name, array_keys( get_object_vars( $object ) ), true );
 }
 
 /**

--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -75,7 +75,7 @@ class GP_Route_Locale extends GP_Route_Main {
 			// Store parent id for
 			$parents[ $set_project->id ] = $parent_id;
 
-			if ( ! in_array( $set_project->parent_project_id, $locale_projects ) ) {
+			if ( ! in_array( $set_project->parent_project_id, $locale_projects, true ) ) {
 				$projects_data[ $parent_id ][ $set_project->id ]['project'] = $set_project;
 				$projects_data[ $parent_id ][ $set_project->id ]['sets'][ $set->id ] = $this->set_data( $set, $set_project );
 				$projects_data[ $parent_id ][ $set_project->id ]['totals'] = $this->set_data( $set, $set_project );
@@ -84,7 +84,7 @@ class GP_Route_Locale extends GP_Route_Main {
 					$projects_data[ $parent_id ][ $set_project->id ]['project'] = $set_project;
 				}
 			} else {
-				while ( ! in_array( $parent_id, array_keys( $projects_data ) ) && isset( $parents[ $parent_id ] ) ) {
+				while ( ! in_array( $parent_id, array_keys( $projects_data ), true ) && isset( $parents[ $parent_id ] ) ) {
 					$previous_parent = $parent_id;
 					$parent_id = $parents[ $parent_id ];
 				}

--- a/gp-includes/routes/profile.php
+++ b/gp-includes/routes/profile.php
@@ -79,7 +79,7 @@ class GP_Route_Profile extends GP_Route_Main {
 
 		$i = 0;
 		foreach ( $translations as $translation ) {
-			if ( in_array( $translation->translation_set_id, $set_ids ) ) {
+			if ( in_array( $translation->translation_set_id, $set_ids, true ) ) {
 				continue;
 			}
 

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -410,8 +410,8 @@ function gp_locales_dropdown( $name_and_id, $selected_slug = null, $attrs = arra
  * @param string $name_and_id         Name and ID of the select element.
  * @param string $selected_project_id The project id to mark as the currently selected.
  * @param array  $attrs               Extra attributes.
- * @param array  $exclude             An array of locales to exclude from the list.
- * @param array  $exclude_no_parent   Exclude the "No Parent" option from the list of locales.
+ * @param array  $exclude             An array of project IDs to exclude from the list.
+ * @param array  $exclude_no_parent   Exclude the "No Parent" option from the list of projects.
  *
  * @return string HTML markup for a select element.
  */
@@ -445,7 +445,7 @@ function gp_projects_dropdown( $name_and_id, $selected_project_id = null, $attrs
 		while ( ! empty( $stack ) ) {
 			$id = array_pop( $stack );
 
-			if ( in_array( $id, $exclude ) ) {
+			if ( in_array( $id, $exclude, true ) ) {
 				continue;
 			}
 

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -466,12 +466,12 @@ class GP_Thing {
 			unset( $args[ $attribute ] );
 		}
 		foreach ( $args as $key => $value ) {
-			if ( ! in_array( $key, $this->field_names ) ) {
+			if ( ! in_array( $key, $this->field_names, true ) ) {
 				unset( $args[ $key ] );
 			}
 		}
 
-		if ( in_array( 'date_modified', $this->field_names ) ) {
+		if ( in_array( 'date_modified', $this->field_names, true ) ) {
 			$args['date_modified'] = $this->now_in_mysql_format();
 		}
 
@@ -484,7 +484,7 @@ class GP_Thing {
 	}
 
 	public function prepare_fields_for_create( $args ) {
-		if ( in_array( 'date_added', $this->field_names ) ) {
+		if ( in_array( 'date_added', $this->field_names, true ) ) {
 			$args['date_added'] = $this->now_in_mysql_format();
 		}
 		return $args;

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -433,7 +433,7 @@ class GP_Translation extends GP_Thing {
 		$join_on = array();
 		$status = gp_array_get( $filters, 'status', 'current_or_waiting_or_fuzzy_or_untranslated' );
 		$statuses = explode( '_or_', $status );
-		if ( in_array( 'untranslated', $statuses ) ) {
+		if ( in_array( 'untranslated', $statuses, true ) ) {
 			if ( array( 'untranslated' ) == $statuses ) {
 				$where[] = 't.translation_0 IS NULL';
 			}
@@ -447,7 +447,7 @@ class GP_Translation extends GP_Thing {
 
 		$all_statuses = $this->get_static( 'statuses' );
 		$statuses = array_filter( $statuses, function( $s ) use ( $all_statuses ) {
-			return in_array( $s, $all_statuses );
+			return in_array( $s, $all_statuses, true );
 		} );
 
 		if ( ! empty( $statuses ) ) {


### PR DESCRIPTION
See #585.

Fixes `WordPress.PHP.StrictInArray.MissingTrueStrict` issues.