### PR TITLE
Fix import of translations in JSON format

### DIFF
--- a/gp-includes/formats/format-jed1x.php
+++ b/gp-includes/formats/format-jed1x.php
@@ -127,13 +127,7 @@ class GP_Format_Jed1x extends GP_Format_JSON {
 
 			$value = (array) $value;
 
-			if ( isset( $value[0] ) ) {
-				$args['translations'] = $value[0];
-			}
-
-			if ( isset( $value[1] ) ) {
-				$args['plural'] = $value[1];
-			}
+			$args['translations'] = (array) $value;
 
 			$entries->add_entry( new Translation_Entry( $args ) );
 		}

--- a/gp-includes/formats/format-json.php
+++ b/gp-includes/formats/format-json.php
@@ -102,15 +102,7 @@ class GP_Format_JSON extends GP_Format {
 				$args['singular'] = $key[1];
 			}
 
-			$value = (array) $value;
-
-			if ( isset( $value[0] ) ) {
-				$args['translations'] = $value[0];
-			}
-
-			if ( isset( $value[1] ) ) {
-				$args['plural'] = $value[1];
-			}
+			$args['translations'] = (array) $value;
 
 			$entries->add_entry( new Translation_Entry( $args ) );
 		}

--- a/tests/phpunit/testcases/tests_formats/test_format_jed1x.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_jed1x.php
@@ -116,7 +116,7 @@ class GP_Test_Format_Jed1x extends GP_UnitTestCase {
 		/* @var Translations $actual */
 		$actual = GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/translation-jed1x.json' );
 
-		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertCount( 5, $actual->entries );
 		$this->assertEquals( $expected, $actual );
 	}
 
@@ -154,27 +154,37 @@ class GP_Test_Format_Jed1x extends GP_UnitTestCase {
 		$translations = new Translations();
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'This file is too big. Files must be less than %d KB in size.',
-			'translations' => 'Diese Datei ist zu gross. Dateien müssen kleiner als %d KB sein.',
+			'translations' => array(
+				'Diese Datei ist zu gross. Dateien müssen kleiner als %d KB sein.',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => '%d Theme Update',
-			'translations' => '%d Theme-Aktualisierung',
-			'plural'       => '%d Theme-Aktualisierungen',
+			'translations' => array(
+				'%d Theme-Aktualisierung',
+				'%d Theme-Aktualisierungen',
+			),
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Medium',
 			'context'      => 'password strength',
-			'translations' => 'Medium',
+			'translations' => array(
+				'Medium',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Category',
 			'context'      => 'taxonomy singular name',
-			'translations' => 'Kategorie',
+			'translations' => array(
+				'Kategorie',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Pages',
 			'context'      => 'post type general name',
-			'translations' => 'Seiten',
+			'translations' => array(
+				'Seiten',
+			)
 		) ) );
 
 		return $translations;

--- a/tests/phpunit/testcases/tests_formats/test_format_json.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_json.php
@@ -87,13 +87,18 @@ class GP_Test_Format_JSON extends GP_UnitTestCase {
 		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
 	}
 
+	/**
+	 * @group test
+	 *
+	 * @return void
+	 */
 	public function test_read_translations_from_file() {
 		$expected = $this->data_example_translations();
 
 		/* @var Translations $actual */
 		$actual = GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/translation.json' );
 
-		$this->assertSame( 5, count( $actual->entries ) );
+		$this->assertCount( 5, $actual->entries );
 		$this->assertEquals( $expected, $actual );
 	}
 
@@ -131,27 +136,37 @@ class GP_Test_Format_JSON extends GP_UnitTestCase {
 		$translations = new Translations();
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'This file is too big. Files must be less than %d KB in size.',
-			'translations' => 'Diese Datei ist zu gross. Dateien müssen kleiner als %d KB sein.',
+			'translations' => array(
+				'Diese Datei ist zu gross. Dateien müssen kleiner als %d KB sein.',
+			),
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => '%d Theme Update',
-			'translations' => '%d Theme-Aktualisierung',
-			'plural'       => '%d Theme-Aktualisierungen',
+			'translations' => array(
+				'%d Theme-Aktualisierung',
+				'%d Theme-Aktualisierungen',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Medium',
 			'context'      => 'password strength',
-			'translations' => 'Medium',
+			'translations' => array(
+				'Medium',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Category',
 			'context'      => 'taxonomy singular name',
-			'translations' => 'Kategorie',
+			'translations' => array(
+				'Kategorie',
+			)
 		) ) );
 		$translations->add_entry( new Translation_Entry( array(
 			'singular'     => 'Pages',
 			'context'      => 'post type general name',
-			'translations' => 'Seiten',
+			'translations' => array(
+				'Seiten',
+			)
 		) ) );
 
 		return $translations;

--- a/tests/phpunit/testcases/tests_formats/test_format_json.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_json.php
@@ -87,11 +87,6 @@ class GP_Test_Format_JSON extends GP_UnitTestCase {
 		$this->assertFalse( GP::$formats[ $this->format ]->read_translations_from_file( GP_DIR_TESTDATA . '/invalid.json' ) );
 	}
 
-	/**
-	 * @group test
-	 *
-	 * @return void
-	 */
 	public function test_read_translations_from_file() {
 		$expected = $this->data_example_translations();
 


### PR DESCRIPTION
Fixes #1003.

* The `translations` argument needs to be an array otherwise it gets [set to an empty array](https://github.com/WordPress/wordpress-develop/blob/5.4.0/src/wp-includes/pomo/entry.php#L55-L57).
* The `plural` argument should actually be the plural version of the original but this doesn't seem to be supported in JSON as the key is only the singular (with an optional context). That limitation is preventing importing of translations with plural forms. @swissspidy Can you confirm this?