### PR TITLE
Remove unused 'row' attribute for translation edit link

### DIFF
--- a/gp-templates/translation-row-preview.php
+++ b/gp-templates/translation-row-preview.php
@@ -51,15 +51,18 @@ $priority_char = array(
 		else :
 		?>
 			<ul>
-				<?php foreach ( $translation->translations as $translation ) : ?>
+				<?php foreach ( $translation->translations as $current_translation ) : ?>
 					<li>
-					<?php echo gp_is_empty_string( $translation ) ? $missing_text : esc_translation( $translation ); // WPCS: XSS OK. ?>
+					<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo gp_is_empty_string( $current_translation ) ? $missing_text : esc_translation( $current_translation );
+					?>
 					</li>
 				<?php endforeach; ?>
 			</ul>
 		<?php endif; ?>
 	</td>
 	<td class="actions">
-		<a href="#" row="<?php echo $translation->row_id; // WPCS: XSS OK. ?>" class="action edit"><?php _e( 'Details', 'glotpress' ); ?></a>
+		<a href="#" class="action edit"><?php _e( 'Details', 'glotpress' ); ?></a>
 	</td>
 </tr>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,7 +32,7 @@
 
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
-			<property name="customAutoEscapedFunctions" value="gp_radio_buttons=>gp_radio_buttons,gp_select=>gp_select,gp_projects_dropdown=>gp_projects_dropdown,gp_link_glossary_delete_get=>gp_link_glossary_delete_get,gp_link_set_delete_get=>gp_link_set_delete_get,gp_link_get=>gp_link_get,gp_link=>gp_link,__=>__,gp_js_focus_on=>gp_js_focus_on,gp_translation_row_classes=>gp_translation_row_classes,gp_pagination=>gp_pagination" type="array" />
+			<property name="customAutoEscapedFunctions" value="gp_radio_buttons=>gp_radio_buttons,gp_select=>gp_select,gp_projects_dropdown=>gp_projects_dropdown,gp_link_glossary_delete_get=>gp_link_glossary_delete_get,gp_link_set_delete_get=>gp_link_set_delete_get,gp_link_get=>gp_link_get,gp_link=>gp_link,__=>__,gp_js_focus_on=>gp_js_focus_on,gp_translation_row_classes=>gp_translation_row_classes,gp_pagination=>gp_pagination,esc_translation=>esc_translation" type="array" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
`$translation->row_id;` wasn't defined due to a variable override in the loop before. Since the attribute isn't used at all it's save to remove it.