### PR TITLE
Glossary: Use the human-readable name of speech part in tables

### DIFF
--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -1,7 +1,7 @@
 
 <tr class='view' data-id="<?php echo esc_attr( $entry->id ); ?>">
 	<td><?php echo esc_html( $entry->term ); ?></td>
-	<td><?php echo esc_html( $entry->part_of_speech ); ?></td>
+	<td><?php echo esc_html( GP::$glossary_entry->parts_of_speech[ $entry->part_of_speech ] ); ?></td>
 	<td><?php echo esc_html( $entry->translation ); ?></td>
 	<td><?php echo make_clickable( nl2br( esc_html( $entry->comment ) ) ); ?></td>
 


### PR DESCRIPTION
Before with German translation:
<img width="891" alt="before-glossary" src="https://user-images.githubusercontent.com/617637/80280483-8ccbb200-8704-11ea-951d-fe3258e13f8f.png">

After with German translation:
<img width="895" alt="after-glossary" src="https://user-images.githubusercontent.com/617637/80280481-8c331b80-8704-11ea-9f33-20692151e0aa.png">