### PR TITLE
Bump required WordPress version to 4.6

### DIFF
--- a/glotpress.php
+++ b/glotpress.php
@@ -33,11 +33,8 @@ define( 'GP_ROUTING', true );
 define( 'GP_PLUGIN_FILE', __FILE__ );
 define( 'GP_PATH', __DIR__ . '/' );
 define( 'GP_INC', 'gp-includes/' );
-define( 'GP_WP_REQUIRED_VERSION', '4.4' );
+define( 'GP_WP_REQUIRED_VERSION', '4.6' );
 define( 'GP_PHP_REQUIRED_VERSION', '5.6' );
-
-// Load the plugin's translated strings.
-load_plugin_textdomain( 'glotpress' );
 
 /**
  * Displays an admin notice on the plugins page that GlotPress has been disabled and why..

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -246,26 +246,9 @@ class GP_Route {
 			return false;
 		}
 
-		$ref = $this->get_raw_referer();
+		$ref = wp_get_raw_referer();
 		if ( $ref ) {
 			return wp_validate_redirect( $ref, false );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Retrieves unvalidated referer from '_wp_http_referer' or HTTP referer.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @return string|false Referer URL on success, false on failure.
-	 */
-	private function get_raw_referer() {
-		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
-			return wp_unslash( gp_array_get( $_REQUEST, '_wp_http_referer' ) );
-		} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
-			return wp_unslash( gp_array_get( $_SERVER, 'HTTP_REFERER' ) );
 		}
 
 		return false;


### PR DESCRIPTION
* Remove now unused load_plugin_textdomain() call.
* Replace GP_Route::get_http_referer() with wp_get_raw_referer().

Fixes #1097.