### PR TITLE
Route: Don't escape exit output as it may contain HTML

### DIFF
--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -337,7 +337,8 @@ class GP_Route {
 			$this->exit_message = $message;
 			return;
 		}
-		exit( esc_html( $message ) );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- May contain HTML.
+		exit( $message );
 	}
 
 	public function header( $string ) {


### PR DESCRIPTION
Introduced in #1098.