### PR TITLE
Translations: Remove default sorting for untranslated view

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -108,8 +108,6 @@ $i = 0;
 
 		$untranslated_filters = array(
 			'filters[status]' => 'untranslated',
-			'sort[by]'        => 'priority',
-			'sort[how]'       => 'desc',
 		);
 
 		$is_current_filter = array() === array_diff( $untranslated_filters, $filters_and_sort ) && false === $additional_filters && ! $warnings_filter;


### PR DESCRIPTION
The untranslated filter was added in https://github.com/GlotPress/GlotPress-WP/commit/0eb77ef759726c2f05376fa3b3804e81415be482 together with a link to get random untranslated strings. But the random link was removed https://github.com/GlotPress/GlotPress-WP/commit/77d3ccbcdcdabc441f5d7296549c9d2f54c8d595.

This removes the hardcoded sorting to ensure the one of the profile setting is used. It also prevents having a "Current Filter" link when clicking on the Untranslated column in the translations table. Instead the default "Untranslated" link should be highlighted.

<img width="971" alt="filter-view" src="https://user-images.githubusercontent.com/617637/80806480-170b8e80-8bbb-11ea-865e-7926236ef964.png">
