### PR TITLE
Links: Add missing docs and remove use of call_user_func_array()

### DIFF
--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -1,5 +1,22 @@
 <?php
+/**
+ * Link Template Functions
+ *
+ * @package GlotPress
+ * @subpackage Template
+ */
 
+/**
+ * Creates a HTML link.
+ *
+ * @since 1.0.0
+ *
+ * @param string $url   The URL to link to.
+ * @param string $text  The text to use for the link.
+ * @param array  $attrs Optional. Additional attributes to use
+ *                      to determine the classes for the link.
+ * @return string The HTML link.
+ */
 function gp_link_get( $url, $text, $attrs = array() ) {
 	$before = '';
 	$after  = '';
@@ -15,12 +32,35 @@ function gp_link_get( $url, $text, $attrs = array() ) {
 	return sprintf( '%1$s<a href="%2$s"%3$s>%4$s</a>%5$s', $before, esc_url( $url ), $attributes, $text, $after );
 }
 
-function gp_link() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_get', $args );
+/**
+ * Creates a HTML link.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_get()
+ *
+ * @param string $url   The URL to link to.
+ * @param string $text  The text to use for the link.
+ * @param array  $attrs Optional. Additional attributes to use
+ *                      to determine the classes for the link.
+ */
+function gp_link( $url, $text, $attrs = array() ) {
+	echo gp_link_get( $url, $text, $attrs );
 }
 
+/**
+ * Creates a HTML link with a confirmation request.
+ *
+ * Uses the `window.confirm()` method to display a modal dialog for confirmation.
+ *
+ * @since 1.0.0
+ *
+ * @param string $url   The URL to link to.
+ * @param string $text  The text to use for the link.
+ * @param array  $attrs Optional. Additional attributes to use
+ *                      to determine the classes for the link.
+ * @return string The HTML link.
+ */
 function gp_link_with_ays_get( $url, $text, $attrs = array() ) {
 	$ays_text = $attrs['ays-text'];
 	unset( $attrs['ays-text'] );
@@ -28,24 +68,66 @@ function gp_link_with_ays_get( $url, $text, $attrs = array() ) {
 	return gp_link_get( $url, $text, $attrs );
 }
 
-function gp_link_with_ays() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_with_ays_get', $args );
+/**
+ * Creates a HTML link with a confirmation request.
+ *
+ * Uses the `window.confirm()` method to display a modal dialog for confirmation.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_with_ays_get()
+ *
+ * @param string $url   The URL to link to.
+ * @param string $text  The text to use for the link.
+ * @param array  $attrs Optional. Additional attributes to use
+ *                      to determine the classes for the link.
+ */
+function gp_link_with_ays( $url, $text, $attrs = array() ) {
+	echo gp_link_with_ays_get( $url, $text, $attrs );
 }
 
+/**
+ * Creates a HTML link to the page of a project.
+ *
+ * @since 1.0.0
+ *
+ * @param GP_Project|string $project_or_path The project to link to.
+ * @param string            $text            The text to use for the link.
+ * @param array             $attrs           Optional. Additional attributes to use
+ *                                           to determine the classes for the link.
+ * @return string The HTML link.
+ */
 function gp_link_project_get( $project_or_path, $text, $attrs = array() ) {
-	$attrs = array_merge( array( 'title' => 'Project: ' . $text ), $attrs );
 	return gp_link_get( gp_url_project( $project_or_path ), $text, $attrs );
 }
 
-function gp_link_project() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_project_get', $args );
+/**
+ * Outputs a HTML link to the page of a project.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_project_get()
+ *
+ * @param GP_Project|string $project_or_path The project to link to.
+ * @param string            $text            The text to use for the link.
+ * @param array             $attrs           Optional. Additional attributes to use
+ *                                           to determine the classes for the link.
+ */
+function gp_link_project( $project_or_path, $text, $attrs = array() ) {
+	echo gp_link_project_get( $project_or_path, $text, $attrs );
 }
 
-function gp_link_project_edit_get( $project, $text = null, $attrs = array() ) {
+/**
+ * Creates a HTML link to the edit page for projects.
+ *
+ * @since 1.0.0
+ *
+ * @param GP_Project $project The project to link to.
+ * @param string     $text    Optional. The text to use for the link. Default 'Edit'.
+ * @param array      $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
+ */
+function gp_link_project_edit_get( $project, $text = '', $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
 		return '';
 	}
@@ -53,13 +135,32 @@ function gp_link_project_edit_get( $project, $text = null, $attrs = array() ) {
 	return gp_link_get( gp_url_project( $project, '-edit' ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-function gp_link_project_edit() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_project_edit_get', $args );
+/**
+ * Outputs a HTML link to the edit page for projects.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_project_edit_get()
+ *
+ * @param GP_Project $project The project to link to.
+ * @param string     $text    Optional. The text to use for the link. Default 'Edit'.
+ * @param array      $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ */
+function gp_link_project_edit( $project, $text = '', $attrs = array() ) {
+	echo gp_link_project_edit_get( $project, $text, $attrs );
 }
 
-function gp_link_project_delete_get( $project, $text = false, $attrs = array() ) {
+/**
+ * Creates a HTML link to the delete page for projects.
+ *
+ * @since 1.0.0
+ *
+ * @param GP_Project $project The project to link to.
+ * @param string     $text    Optional. The text to use for the link. Default 'Delete'.
+ * @param array      $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
+ */
+function gp_link_project_delete_get( $project, $text = '', $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'delete', 'project', $project->id ) ) {
 		return '';
 	}
@@ -67,92 +168,127 @@ function gp_link_project_delete_get( $project, $text = false, $attrs = array() )
 	return gp_link_get( gp_url_project( $project, '-delete' ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-function gp_link_project_delete() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_project_delete_get', $args );
+/**
+ * Outputs a HTML link to the delete page for projects.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_project_delete_get()
+ *
+ * @param GP_Project $project The project to link to.
+ * @param string     $text    Optional. The text to use for the link.
+ * @param array      $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ */
+function gp_link_project_delete( $project, $text = '', $attrs = array() ) {
+	echo gp_link_project_delete_get( $project, $text, $attrs );
 }
 
+/**
+ * Creates a HTML link to the home page of GlotPress.
+ *
+ * @since 1.0.0
+ *
+ * @return string The HTML link.
+ */
 function gp_link_home_get() {
-	return gp_link_get( gp_url( '/' ), __( 'Home', 'glotpress' ), array( 'title' => __( 'Home Is Where The Heart Is', 'glotpress' ) ) );
+	return gp_link_get( gp_url( '/' ), __( 'Home', 'glotpress' ) );
 }
 
+/**
+ * Outputs a HTML link to the home page of GlotPress.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_home_get()
+ */
 function gp_link_home() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_home_get', $args );
-}
-
-function gp_link_set_edit_get( $set, $project, $text = false, $attrs = array() ) {
-	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
-		return '';
-	}
-	$text = $text ? $text : __( 'Edit', 'glotpress' );
-	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-edit' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
-}
-
-function gp_link_set_edit() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_set_edit_get', $args );
+	echo gp_link_home_get();
 }
 
 /**
  * Creates a HTML link to the delete page for translations sets.
  *
- * Does the heavy lifting for gp_link_set_delete().
+ * @since 1.0.0
+ *
+ * @param GP_Translation_Set $set     The translation set to link to.
+ * @param GP_Project         $project The project the translation set belongs to.
+ * @param string             $text    Optional. The text to use for the link. Default 'Edit'.
+ * @param array              $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
+ */
+function gp_link_set_edit_get( $set, $project, $text = '', $attrs = array() ) {
+	if ( ! GP::$permission->current_user_can( 'write', 'project', $project->id ) ) {
+		return '';
+	}
+
+	$text = $text ? $text : __( 'Edit', 'glotpress' );
+	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-edit' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
+}
+
+/**
+ * Outputs a HTML link to the edit page for translations sets.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_set_edit_get()
+ *
+ * @param GP_Translation_Set $set     The translation set to link to.
+ * @param GP_Project         $project The project the translation set belongs to.
+ * @param string             $text    Optional. The text to use for the link. Default 'Edit'.
+ * @param array              $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ */
+function gp_link_set_edit( $set, $project, $text = '', $attrs = array() ) {
+	echo gp_link_set_edit_get( $set, $project, $text, $attrs );
+}
+
+/**
+ * Creates a HTML link to the delete page for translations sets.
  *
  * @since 2.0.0
  *
  * @param GP_Translation_Set $set     The translation set to link to.
  * @param GP_Project         $project The project the translation set belongs to.
- * @param string             $text    The text to use for the link.
- * @param array              $attrs   Additional attributes to use to determine the classes for the link.
- *
- * @return string $link
+ * @param string             $text    Optional. The text to use for the link. Default 'Delete'.
+ * @param array              $attrs   Optional. Additional attributes to use to determine the classes for the link.
+ * @return string The HTML link.
  */
-function gp_link_set_delete_get( $set, $project, $text = false, $attrs = array() ) {
+function gp_link_set_delete_get( $set, $project, $text = '', $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'delete', 'project', $project->id ) ) {
 		return '';
 	}
 
-	if ( false === $text ) {
-		$text = __( 'Delete', 'glotpress' );
-	}
-
+	$text = $text ? $text : __( 'Delete', 'glotpress' );
 	return gp_link_get( gp_url( gp_url_join( '/sets', $set->id, '-delete' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
 /**
  * Outputs a HTML link to the delete page for translations sets.
  *
- * Does the heavy lifting for gp_link_set_delete().
- *
  * @since 2.0.0
+ *
+ * @see gp_link_set_delete_get()
  *
  * @param GP_Translation_Set $set     The translation set to link to.
  * @param GP_Project         $project The project the translation set belongs to.
- * @param string             $text    The text to use for the link.
- * @param array              $attrs   Additional attributes to use to determine the classes for the link.
+ * @param string             $text    Optional. The text to use for the link. Default 'Delete'.
+ * @param array              $attrs   Optional. Additional attributes to use to determine the classes for the link.
  */
-function gp_link_set_delete( $set, $project, $text = false, $attrs = array() ) {
+function gp_link_set_delete( $set, $project, $text = '', $attrs = array() ) {
 	echo gp_link_set_delete_get( $set, $project, $text, $attrs );
 }
 
 /**
- * Creates a HTML link to the delete page for translations sets.
- *
- * Does the heavy lifting for gp_link_glossary_delete.
+ * Creates a HTML link to the edit page for glossaries.
  *
  * @since 1.0.0
  *
  * @param GP_Glossary        $glossary The glossary to link to.
  * @param GP_Translation_Set $set      The translation set the glossary is for.
- * @param string             $text     The text to use for the link.
- * @param array              $attrs    Additional attributes to use to determine the classes for the link.
+ * @param string             $text     Optional. The text to use for the link. Default 'Edit'.
+ * @param array              $attrs    Optional. Additional attributes to use to determine the classes for the link.
  * @return string The HTML link.
  */
-function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = array() ) {
+function gp_link_glossary_edit_get( $glossary, $set, $text = '', $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'approve', 'translation-set', $set->id ) ) {
 		return '';
 	}
@@ -161,26 +297,34 @@ function gp_link_glossary_edit_get( $glossary, $set, $text = false, $attrs = arr
 	return gp_link_get( gp_url( gp_url_join( '/glossaries', $glossary->id, '-edit' ) ), $text, gp_attrs_add_class( $attrs, 'action edit' ) );
 }
 
-function gp_link_glossary_edit() {
-	$args = func_get_args();
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo call_user_func_array( 'gp_link_glossary_edit_get', $args );
+/**
+ * Outputs a HTML link to the edit page for glossaries.
+ *
+ * @since 1.0.0
+ *
+ * @see gp_link_glossary_edit_get()
+ *
+ * @param GP_Glossary        $glossary The glossary to link to.
+ * @param GP_Translation_Set $set      The translation set the glossary is for.
+ * @param string             $text     Optional. The text to use for the link. Default 'Edit'.
+ * @param array              $attrs    Optional. Additional attributes to use to determine the classes for the link.
+ */
+function gp_link_glossary_edit( $glossary, $set, $text = '', $attrs = array() ) {
+	echo gp_link_glossary_edit_get( $glossary, $set, $text, $attrs );
 }
 
 /**
- * Creates a HTML link to the delete page for translations sets.
- *
- * Does the heavy lifting for gp_link_glossary_delete.
+ * Creates a HTML link to the delete page for glossaries.
  *
  * @since 2.0.0
  *
  * @param GP_Glossary        $glossary The glossary to link to.
  * @param GP_Translation_Set $set      The translation set the glossary is for.
- * @param string             $text     The text to use for the link.
- * @param array              $attrs    Additional attributes to use to determine the classes for the link.
+ * @param string             $text     Optional. The text to use for the link. Default 'Delete'.
+ * @param array              $attrs    Optional. Additional attributes to use to determine the classes for the link.
  * @return string The HTML link.
  */
-function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = array() ) {
+function gp_link_glossary_delete_get( $glossary, $set, $text = '', $attrs = array() ) {
 	if ( ! GP::$permission->current_user_can( 'delete', 'translation-set', $set->id ) ) {
 		return '';
 	}
@@ -194,12 +338,14 @@ function gp_link_glossary_delete_get( $glossary, $set, $text = false, $attrs = a
  *
  * @since 2.0.0
  *
+ * @see gp_link_glossary_delete_get()
+ *
  * @param GP_Glossary        $glossary The glossary to link to.
  * @param GP_Translation_Set $set      The translation set the glossary is for.
- * @param string             $text     The text to use for the link.
- * @param array              $attrs    Additional attributes to use to determine the classes for the link.
+ * @param string             $text     Optional. The text to use for the link. Default 'Delete'.
+ * @param array              $attrs    Optional. Additional attributes to use to determine the classes for the link.
  */
-function gp_link_glossary_delete( $glossary, $set, $text = false, $attrs = array() ) {
+function gp_link_glossary_delete( $glossary, $set, $text = '', $attrs = array() ) {
 	echo gp_link_glossary_delete_get( $glossary, $set, $text, $attrs );
 }
 

--- a/gp-includes/url.php
+++ b/gp-includes/url.php
@@ -135,9 +135,9 @@ function gp_url_current() {
  *
  * A leading double-slash will avoid prepending /projects/ to the path.
  *
- * @param bool|string|object $project_or_path Project path or object
- * @param string|array       $path Addition path to append to the base path
- * @param array              $query associative array of query arguments (optional)
+ * @param GP_Project|string $project_or_path Project path or object.
+ * @param string|array      $path            Addition path to append to the base path.
+ * @param array             $query           Optional. Associative array of query arguments.
  *
  * @return string
  */

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,8 +41,16 @@
 				<element value="gp_locales_by_project_dropdown"/>
 				<element value="gp_link"/>
 				<element value="gp_link_get"/>
+				<element value="gp_link_glossary_edit_get"/>
 				<element value="gp_link_glossary_delete_get"/>
+				<element value="gp_link_set_edit_get"/>
 				<element value="gp_link_set_delete_get"/>
+				<element value="gp_link_project_get"/>
+				<element value="gp_link_project_edit_get"/>
+				<element value="gp_link_project_delete_get"/>
+				<element value="gp_link_home_get"/>
+				<element value="gp_link_with_ays_get"/>
+				<element value="gp_link_user"/>
 				<element value="gp_js_focus_on"/>
 				<element value="gp_translation_row_classes"/>
 				<element value="gp_pagination"/>


### PR DESCRIPTION
Adds missing docs and removes the use of `func_get_args()` with `call_user_func_array()` to ensure required arguments are passed to the output functions.