### PR TITLE
Introduce the spread operator in `GP_Thing()` methods.

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -86,10 +86,16 @@ class GP_Glossary_Entry extends GP_Thing {
 		return $this->many( "SELECT * FROM $this->table WHERE glossary_id= %d ORDER by term ASC", $glossary_id );
 	}
 
+	/**
+	 * Retrieves the last modified date of a entry in a glossary.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GP_Glossary $glossary The glossary to retrieve the last modified date.
+	 * @return string The last modified date on success, empty string on failure.
+	 */
 	public function last_modified( $glossary ) {
-		global $wpdb;
-
-		return $wpdb->get_var( $wpdb->prepare( "SELECT date_modified FROM {$this->table} WHERE glossary_id = %d ORDER BY date_modified DESC LIMIT 1", $glossary->id, 'current' ) );
+		return (string) $this->value( "SELECT date_modified FROM {$this->table} WHERE glossary_id = %d ORDER BY date_modified DESC LIMIT 1", $glossary->id, 'current' );
 	}
 }
 

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -651,6 +651,13 @@ class GP_Translation_Set extends GP_Thing {
 		return $original_count ? floor( $this->current_count() / $original_count * 100 ) : 0;
 	}
 
+	/**
+	 * Retrieves the last modified date of a translation in this translation set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|false The last modified date on success, false on failure.
+	 */
 	public function last_modified() {
 		return GP::$translation->last_modified( $this );
 	}

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -785,9 +785,15 @@ class GP_Translation extends GP_Thing {
 		return $translations;
 	}
 
+	/**
+	 * Retrieves the last modified date of a translation in a translation set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GP_Translation_Set $translation_set The translation set to retrieve the last modified date.
+	 * @return string|false The last modified date on success, false on failure.
+	 */
 	public function last_modified( $translation_set ) {
-		global $wpdb;
-
 		$last_modified = wp_cache_get( $translation_set->id, 'translation_set_last_modified' );
 		// Cached as "" if no translations.
 		if ( '' === $last_modified ) {
@@ -796,7 +802,7 @@ class GP_Translation extends GP_Thing {
 			return $last_modified;
 		}
 
-		$last_modified = $wpdb->get_var( $wpdb->prepare( "SELECT date_modified FROM {$this->table} WHERE translation_set_id = %d AND status = %s ORDER BY date_modified DESC LIMIT 1", $translation_set->id, 'current' ) );
+		$last_modified = $this->value( "SELECT date_modified FROM {$this->table} WHERE translation_set_id = %d AND status = %s ORDER BY date_modified DESC LIMIT 1", $translation_set->id, 'current' );
 		wp_cache_set( $translation_set->id, (string) $last_modified, 'translation_set_last_modified' );
 		return $last_modified;
 	}


### PR DESCRIPTION
Rather than relying `func_get_args()` to retrieve arbitrary function arguments, we can now use the spread operator to assign them directly to a variable.