### PR TITLE
Change wording from 'Current' to 'Translated'

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -303,7 +303,7 @@ function textareas( $entry, $permissions, $index = 0 ) {
 
 function display_status( $status ) {
 	$status_labels = array(
-		'current'  => _x( 'current', 'Single Status', 'glotpress' ),
+		'current'  => _x( 'translated', 'Single Status', 'glotpress' ),
 		'waiting'  => _x( 'waiting', 'Single Status', 'glotpress' ),
 		'fuzzy'    => _x( 'fuzzy', 'Single Status', 'glotpress' ),
 		'old'      => _x( 'old', 'Single Status', 'glotpress' ),

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -40,7 +40,7 @@ gp_tmpl_header();
 
 	$status_options = array();
 	if ( isset( $can_import_current ) && $can_import_current ) {
-		$status_options['current'] = __( 'Current', 'glotpress' );
+		$status_options['current'] = __( 'Translated', 'glotpress' );
 	}
 	if ( isset( $can_import_waiting ) && $can_import_waiting ) {
 		$status_options['waiting'] = __( 'Waiting', 'glotpress' );

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -237,12 +237,12 @@ $i = 0;
 					echo gp_radio_buttons(
 						'filters[status]', // TODO: show only these, which user is allowed to see afterwards.
 						array(
-							'current_or_waiting_or_fuzzy_or_untranslated' => __( 'Current/waiting/fuzzy + untranslated (All)', 'glotpress' ),
-							'current'                                     => __( 'Current only', 'glotpress' ),
+							'current_or_waiting_or_fuzzy_or_untranslated' => __( 'Translated/waiting/fuzzy + untranslated (All)', 'glotpress' ),
+							'current'                                     => __( 'Translated only', 'glotpress' ),
 							'old'                                         => __( 'Approved, but obsoleted by another translation', 'glotpress' ),
 							'waiting'                                     => __( 'Waiting approval', 'glotpress' ),
 							'rejected'                                    => __( 'Rejected', 'glotpress' ),
-							'untranslated'                                => __( 'Without current translation', 'glotpress' ),
+							'untranslated'                                => __( 'Without translation', 'glotpress' ),
 							'either'                                      => __( 'Any', 'glotpress' ),
 						),
 						gp_array_get( $filters, 'status', 'current_or_waiting_or_fuzzy_or_untranslated' )
@@ -424,7 +424,7 @@ echo gp_pagination( $page, $per_page, $total_translations_count );
 <?php
 		switch ( $legend_status ) {
 			case 'current':
-				_e( 'Current', 'glotpress' );
+				_e( 'Translated', 'glotpress' );
 				break;
 			case 'waiting':
 				_e( 'Waiting', 'glotpress' );
@@ -462,7 +462,7 @@ echo gp_pagination( $page, $per_page, $total_translations_count );
 		}
 
 		/**
-		 * The 'default' filter is 'Current/waiting/fuzzy + untranslated (All)', however that is not
+		 * The 'default' filter is 'Translated/waiting/fuzzy + untranslated (All)', however that is not
 		 * the default action when exporting so make sure to set it on the export link if no filter
 		 * has been activated by the user.
 		 */
@@ -486,8 +486,8 @@ echo gp_pagination( $page, $per_page, $total_translations_count );
 		$what_dropdown   = gp_select(
 			'what-to-export',
 			array(
-				'all'      => _x( 'all current', 'export choice', 'glotpress' ),
-				'filtered' => _x( 'only matching the filter', 'export choice', 'glotpress' ),
+				'all'      => _x( 'All translated', 'export choice', 'glotpress' ),
+				'filtered' => _x( 'Only matching the filter', 'export choice', 'glotpress' ),
 			),
 			'all'
 		);


### PR DESCRIPTION
Fix #1179

Rename all the 'Current' status to 'Translated'.
This includes the status of the string, the import status select, and some of the advanced filters.

**Advanced filter**
![imagem](https://user-images.githubusercontent.com/7371591/85340249-ad826f00-b4dd-11ea-8238-dd82056ed4e8.png)

**String meta**
![imagem](https://user-images.githubusercontent.com/7371591/85340417-f9cdaf00-b4dd-11ea-94d3-527eb1611f5e.png)

**Table bottom**
![imagem](https://user-images.githubusercontent.com/7371591/85340525-2a154d80-b4de-11ea-891e-d67bf948cc8e.png)

**Import screen**
![imagem](https://user-images.githubusercontent.com/7371591/85340346-d9055980-b4dd-11ea-88df-0b68c5c335a6.png)

