### PR TITLE
Add missing return to match bool typehint

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -59,6 +59,7 @@ class GP_Locale {
 		if ( 'rtl' == $name ) {
 			return isset( $this->text_direction );
 		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
The return type for `GP_Locale` method `__isset()` is `bool`.

This PR adds the missing `return false;`