### PR TITLE
use single quotes around string literals as this is ALWAYS considered…

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -445,8 +445,8 @@ class GP_Translation extends GP_Thing {
 				$where[] = 't.translation_0 IS NULL';
 			}
 			$join_type = 'LEFT';
-			$join_on[] = 'status != "rejected"';
-			$join_on[] = 'status != "old"';
+			$join_on[] = "status != 'rejected'";
+			$join_on[] = "status != 'old'";
 			$statuses  = array_filter(
 				$statuses,
 				function( $x ) {
@@ -487,7 +487,7 @@ class GP_Translation extends GP_Thing {
 			$where = 'AND ' . $where;
 		}
 
-		$where = 'o.project_id = ' . (int) $project->id . ' AND o.status = "+active" ' . $where;
+		$where = 'o.project_id = ' . (int) $project->id . " AND o.status = '+active' " . $where;
 
 		$join_on = implode( ' AND ', $join_on );
 		if ( $join_on ) {


### PR DESCRIPTION
Single quotes are ALWAYS interpreted as string quote characters, regardless of configuration.

MySQL 8 has a mode `ANSI_QUOTES` which changes how double-quotes are interpreted such that they're treated more like the identifier quote character (`).

This pull-request fixes the following errors that will occur when loading a page of translations without these fixes

`WordPress database error: [Unknown column '+active' in 'where clause']
SELECT SQL_CALC_FOUND_ROWS t.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added FROM wp_cdbd087bfb_gp_originals as o LEFT JOIN wp_cdbd087bfb_gp_translations AS t ON o.id = t.original_id AND t.translation_set_id = 39 AND t.status != "rejected" AND t.status != "old" AND (t.status = 'current' OR t.status = 'waiting' OR t.status = 'fuzzy') WHERE o.project_id = 1 AND o.status = "+active" AND o.priority > -2 ORDER BY o.priority DESC, o.date_added DESC LIMIT 15 OFFSET 0`

`WordPress database error: [Unknown column 'rejected' in 'on clause']
SELECT SQL_CALC_FOUND_ROWS t.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added FROM wp_cdbd087bfb_gp_originals as o LEFT JOIN wp_cdbd087bfb_gp_translations AS t ON o.id = t.original_id AND t.translation_set_id = 39 AND t.status != "rejected" AND t.status != "old" AND (t.status = 'current' OR t.status = 'waiting' OR t.status = 'fuzzy') WHERE o.project_id = 1 AND o.status = '+active' AND o.priority > -2 ORDER BY o.priority DESC, o.date_added DESC LIMIT 15 OFFSET 0`

`WordPress database error: [Unknown column 'old' in 'on clause']
SELECT SQL_CALC_FOUND_ROWS t.*, o.*, t.id as id, o.id as original_id, t.status as translation_status, o.status as original_status, t.date_added as translation_added, o.date_added as original_added FROM wp_cdbd087bfb_gp_originals as o LEFT JOIN wp_cdbd087bfb_gp_translations AS t ON o.id = t.original_id AND t.translation_set_id = 39 AND t.status != "rejected" AND t.status != "old" AND (t.status = 'current' OR t.status = 'waiting' OR t.status = 'fuzzy') WHERE o.project_id = 1 AND o.status = '+active' AND o.priority > -2 ORDER BY o.priority DESC, o.date_added DESC LIMIT 15 OFFSET 0`
