### PR TITLE
Fix 'original_id is invalid' error when submitting a translation

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -587,7 +587,7 @@ class GP_Translation extends GP_Thing {
 		$translations     = array();
 
 		foreach ( (array) $rows as $row ) {
-			if ( null === $row->id && $has_root ) {
+			if ( $has_root && null === $row->id && null !== $row->root_id ) {
 				$row->id                    = $row->root_id;
 				$row->original_id           = $row->root_original_id;
 				$row->translation_set_id    = $row->root_translation_set_id;


### PR DESCRIPTION
Currently no original ID is available when you want to submit a translation to a locale which has a root locale but no translation.

![image](https://user-images.githubusercontent.com/617637/116533611-dfc0e200-a8e1-11eb-9fc4-bbce80c388e7.png)