### PR TITLE
Improve printf placeholder warnings

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -265,7 +265,7 @@ class GP_Builtin_Translation_Warnings {
 		 *
 		 * @param string $placeholders_re Regular expression pattern without leading or trailing slashes.
 		 */
-		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX]' );
+		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX]' );
 
 		$original_counts    = $this->_placeholders_counts( $original, $placeholders_re );
 		$translation_counts = $this->_placeholders_counts( $translation, $placeholders_re );

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -265,7 +265,7 @@ class GP_Builtin_Translation_Warnings {
 		 *
 		 * @param string $placeholders_re Regular expression pattern without leading or trailing slashes.
 		 */
-		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX]' );
+		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX%]' );
 
 		$original_counts    = $this->_placeholders_counts( $original, $placeholders_re );
 		$translation_counts = $this->_placeholders_counts( $translation, $placeholders_re );

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -72,6 +72,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', '%sHome%s', '%sНачало%s' );
 		$this->assertNoWarnings( 'placeholders', 'This string has %stwo variables%s.', 'Deze string heeft %stwee variabelen%s.' );
 		$this->assertNoWarnings( 'placeholders', '%% baba', '%% баба' );
+		$this->assertHasWarnings( 'placeholders', '%% baba', '% баба' );
 		$this->assertNoWarnings( 'placeholders', '%s%% baba', '%s%% баба' );
 		$this->assertHasWarnings( 'placeholders', '%s baba', '%%s баба' );
 		$this->assertHasWarnings( 'placeholders', '%1$s baba', '%%1$s баба' );

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -76,7 +76,6 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', '%s%% baba', '%s%% баба' );
 		$this->assertHasWarnings( 'placeholders', '%s baba', '%%s баба' );
 		$this->assertHasWarnings( 'placeholders', '%1$s baba', '%%1$s баба' );
-		$this->assertHasWarnings( 'placeholders', '%s 100 percent', '%s 100% баба' );
 	}
 
 	function test_should_begin_end_on_newline() {

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -71,6 +71,11 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', '%1$s baba', '%1$s баба' );
 		$this->assertNoWarnings( 'placeholders', '%sHome%s', '%sНачало%s' );
 		$this->assertNoWarnings( 'placeholders', 'This string has %stwo variables%s.', 'Deze string heeft %stwee variabelen%s.' );
+		$this->assertNoWarnings( 'placeholders', '%% baba', '%% баба' );
+		$this->assertNoWarnings( 'placeholders', '%s%% baba', '%s%% баба' );
+		$this->assertHasWarnings( 'placeholders', '%s baba', '%%s баба' );
+		$this->assertHasWarnings( 'placeholders', '%1$s baba', '%%1$s баба' );
+		$this->assertHasWarnings( 'placeholders', '%s 100 percent', '%s 100% баба' );
 	}
 
 	function test_should_begin_end_on_newline() {


### PR DESCRIPTION
The printf placeholder warnings can miss some cases currently, such as:
 - `%s` will pass if the translation contains `%%s`
 - `%%` in the original isn't checked that it's in the translation, ie. `40%%` would pass if `40%` is in the translation.
 
This PR fixes those cases.

Note: This would also cause it to treat `%1$%` as a placeholder, but that doesn't appear to be an issue, as if it exists in the translation it's a problem, but if it's in the original and not in the translation it's probably also a problem.