### PR TITLE
Remove `GP_Thing::set_memory_limit()` and use `wp_raise_memory_limit()` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+**Breaking Changes**
+* Developers: Removed `GP_Thing::set_memory_limit()` in favor of `wp_raise_memory_limit()`. ([#1246](https://github.com/GlotPress/GlotPress-WP/pull/1246))
+
 ## [3.0.0-alpha.3 (April 29, 2021)
 
 **Bugfixes**

--- a/gp-includes/default-filters.php
+++ b/gp-includes/default-filters.php
@@ -62,3 +62,6 @@ add_filter( 'gp_glossary_description', 'wp_kses_post' );
 add_filter( 'gp_title', 'wptexturize' );
 add_filter( 'gp_title', 'convert_chars' );
 add_filter( 'gp_title', 'esc_html' );
+
+// Memory limit
+add_filter( 'gp_translations_import_memory_limit', 'gp_set_translations_import_max_memory_limit' );

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -652,3 +652,14 @@ function gp_get_sort_by_fields() {
 	 */
 	return apply_filters( 'gp_sort_by_fields', $sort_fields );
 }
+
+/**
+ * Sets the maximum memory limit available for translations imports.
+ *
+ * @since 3.0.0
+ *
+ * @return string The maximum memory limit.
+ */
+function gp_set_translations_import_max_memory_limit() {
+	return '256M';
+}

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -766,32 +766,4 @@ class GP_Thing {
 		}
 		return implode( ' AND ', $conditions );
 	}
-
-
-	// set memory limits.
-	public function set_memory_limit( $new_limit ) {
-		$current_limit = ini_get( 'memory_limit' );
-
-		if ( '-1' == $current_limit ) {
-			return false;
-		}
-
-		$current_limit_int = intval( $current_limit );
-		if ( false !== strpos( $current_limit, 'G' ) ) {
-			$current_limit_int *= 1024;
-		}
-
-		$new_limit_int = intval( $new_limit );
-		if ( false !== strpos( $new_limit, 'G' ) ) {
-			$new_limit_int *= 1024;
-		}
-
-		if ( -1 != $current_limit && ( -1 == $new_limit || $current_limit_int < $new_limit_int ) ) {
-			ini_set( 'memory_limit', $new_limit );
-			return true;
-		}
-
-		return false;
-	}
-
 }

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -231,7 +231,7 @@ class GP_Translation_Set extends GP_Thing {
 	 * @return boolean or void
 	 */
 	public function import( $translations, $desired_status = 'current' ) {
-		$this->set_memory_limit( '256M' );
+		wp_raise_memory_limit( 'gp_translations_import' );
 
 		if ( ! isset( $this->project ) || ! $this->project ) {
 			$this->project = GP::$project->get( $this->project_id );


### PR DESCRIPTION
`wp_raise_memory_limit()` was introduced in WP 4.6 which is the current minimum required version.