### PR TITLE
479: Provide an uninstall routine

### DIFF
--- a/gp-includes/admin.php
+++ b/gp-includes/admin.php
@@ -19,52 +19,37 @@ class GP_Admin {
 	 * @since 3.0.0
 	 */
 	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'gp_admin_menu' ), 10, 1 );
+		add_action( 'admin_menu', array( $this, 'glotpress_settings_menu' ), 10, 1 );
+		add_action( 'admin_init', array( $this, 'glotpress_settings_init' ) );
 	}
 
 	/**
-	 * Callback to add the GlotPress menu and register the settings.
+	 * Adds the GlotPress menu and registers the settings.
 	 *
 	 * @since 3.0.0
 	 */
-	public function gp_admin_menu() {
+	public function glotpress_settings_menu() {
 		add_options_page(
 			__( 'GlotPress', 'glotpress' ),
 			__( 'GlotPress', 'glotpress' ),
 			'manage_options',
-			'gp_admin_menu',
-			array( $this, 'gp_admin_page' )
+			'glotpress',
+			array( $this, 'glotpress_option_page' )
 		);
-		register_setting( 'glotpress', 'gp_delete_on_uninstall' );
 	}
 
 	/**
-	 * Callback to ouput the GlotPress admin page.
+	 * Displays the GlotPress settings page.
 	 *
 	 * @since 3.0.0
 	 */
-	public function gp_admin_page() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
+	public function glotpress_option_page() {
 		?>
 		<div class="wrap">
-			<h1><?php _e( 'GlotPress Settings', 'glotpress' ); ?></h1>
-
-			<form method="post" action="options.php" novalidate="novalidate">
-				<table class="form-table">
-					<tr>
-						<th scope="row"><label for="gp_delete_on_uninstall"><?php _e( 'Delete data during uninstall', 'glotpress' ); ?></label></th>
-						<td>
-							<input name="gp_delete_on_uninstall" type="checkbox" id="gp_delete_on_uninstall" value="1"
-									<?php checked( '1', get_option( 'gp_delete_on_uninstall' ) ); ?> />
-									<?php _e( 'Selecting this option will remove all GlotPress data when you uninstall GlotPress from the plugins page.', 'glotpress' ); ?>
-						</td>
-					</tr>
-				</table>
-
+			<h2><?php _e( 'GlotPress', 'glotpress' ); ?></h2>
+			<form action="options.php" method="post">
 				<?php
-				settings_fields( 'glotpress' );
+				settings_fields( 'gp_options' );
 				do_settings_sections( 'glotpress' );
 				submit_button();
 				?>
@@ -72,6 +57,93 @@ class GP_Admin {
 		</div>
 		<?php
 	}
+
+	/**
+	 * Initializes the GlotPress settings page.
+	 *
+	 * @since 3.0.0
+	 */
+	function glotpress_settings_init() {
+		$args = array(
+			'type'              => 'boolean',
+			'sanitize_callback' => array( $this, 'glotpress_validate_options' ),
+			'default'           => array(
+				'delete_options' => true,
+				'delete_data'    => false,
+			),
+		);
+		register_setting(
+			'gp_options',
+			'gp_options',
+			$args
+		);
+		add_settings_section(
+			'glotpress_delete',
+			__( 'GlotPress uninstall settings' ),
+			array( $this, 'glotpress_delete_section_text' ),
+			'glotpress'
+		);
+		add_settings_field(
+			'delete_options',
+			__( 'Delete options' ),
+			array( $this, 'checkbox' ),
+			'glotpress',
+			'glotpress_delete',
+			$args = array(
+				'id'    => 'delete_options',
+				'type'  => 'checkbox',
+				'label' => __( 'The GlotPress options will be deleted on uninstall.' ),
+			)
+		);
+		add_settings_field(
+			'delete_data',
+			__( 'Delete data' ),
+			array( $this, 'checkbox' ),
+			'glotpress',
+			'glotpress_delete',
+			$args = array(
+				'id'    => 'delete_data',
+				'type'  => 'checkbox',
+				'label' => __( 'The GlotPress data will be deleted on uninstall.' ),
+			)
+		);
+	}
+
+	/**
+	 * Displays the text in the delete section.
+	 *
+	 * @since 3.0.0
+	 */
+	function glotpress_delete_section_text() {
+		_e( 'Select this options to delete the GlotPress options and/or data on uninstall.' );
+	}
+
+	/**
+	 * Displays the HTML code for the checkboxes.
+	 *
+	 * @since 3.0.0
+	 */
+	function checkbox( $args ) {
+		$options = (array) get_option( 'gp_options' );
+		$value   = ( true === isset( $options[ $args['id'] ] ) ) ? $options[ $args['id'] ] : false;
+		$html    = '<input type="checkbox" id="' . $args['id'] . '" ';
+		$html   .= 'name="gp_options[' . $args['id'] . ']" value="1" ' . checked( 1, $value, false ) . ' />';
+		$html   .= '<label for="' . $args['id'] . '">' . $args['label'] . '</label>';
+		echo $html;
+	}
+
+	/**
+	 * Validates the GlotPress options.
+	 *
+	 * @since 3.0.0
+	 */
+	function glotpress_validate_options( $input ) {
+		$valid                   = array();
+		$valid['delete_options'] = isset( $input['delete_options'] ) && true == $input['delete_options'];
+		$valid['delete_data']    = isset( $input['delete_data'] ) && true == $input['delete_data'];
+		return $valid;
+	}
+
 }
 
 if ( is_admin() ) {

--- a/gp-includes/admin.php
+++ b/gp-includes/admin.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * All code related to the GlotPress admin functions in the WordPress backend.
+ *
+ * @package GlotPress
+ * @since 3.0.0
+ */
+
+/**
+ * Class to add a settings page to the WordPress admin settings menu and other admin related functions.
+ *
+ * @since 3.0.0
+ */
+class GP_Admin {
+
+	/**
+	 * GP_Admin constructor.
+	 *
+	 * @since 3.0.0
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'gp_admin_menu' ), 10, 1 );
+	}
+
+	/**
+	 * Callback to add the GlotPress menu and register the settings.
+	 *
+	 * @since 3.0.0
+	 */
+	public function gp_admin_menu() {
+		add_options_page(
+			__( 'GlotPress', 'glotpress' ),
+			__( 'GlotPress', 'glotpress' ),
+			'manage_options',
+			'gp_admin_menu',
+			array( $this, 'gp_admin_page' )
+		);
+		register_setting( 'glotpress', 'gp_delete_on_uninstall' );
+	}
+
+	/**
+	 * Callback to ouput the GlotPress admin page.
+	 *
+	 * @since 3.0.0
+	 */
+	public function gp_admin_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php _e( 'GlotPress Settings', 'glotpress' ); ?></h1>
+
+			<form method="post" action="options.php" novalidate="novalidate">
+				<table class="form-table">
+					<tr>
+						<th scope="row"><label for="gp_delete_on_uninstall"><?php _e( 'Delete data during uninstall', 'glotpress' ); ?></label></th>
+						<td>
+							<input name="gp_delete_on_uninstall" type="checkbox" id="gp_delete_on_uninstall" value="1"
+									<?php checked( '1', get_option( 'gp_delete_on_uninstall' ) ); ?> />
+									<?php _e( 'Selecting this option will remove all GlotPress data when you uninstall GlotPress from the plugins page.', 'glotpress' ); ?>
+						</td>
+					</tr>
+				</table>
+
+				<?php
+				settings_fields( 'glotpress' );
+				do_settings_sections( 'glotpress' );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+}
+
+if ( is_admin() ) {
+	GP::$admin = new GP_Admin();
+}

--- a/gp-includes/admin.php
+++ b/gp-includes/admin.php
@@ -63,7 +63,7 @@ class GP_Admin {
 	 *
 	 * @since 3.0.0
 	 */
-	function glotpress_settings_init() {
+	public function glotpress_settings_init() {
 		$args = array(
 			'type'              => 'boolean',
 			'sanitize_callback' => array( $this, 'glotpress_validate_options' ),
@@ -114,7 +114,7 @@ class GP_Admin {
 	 *
 	 * @since 3.0.0
 	 */
-	function glotpress_delete_section_text() {
+	public function glotpress_delete_section_text() {
 		_e( 'Select this options to delete the GlotPress options and/or data on uninstall.' );
 	}
 
@@ -123,13 +123,13 @@ class GP_Admin {
 	 *
 	 * @since 3.0.0
 	 */
-	function checkbox( $args ) {
+	public function checkbox( $args ) {
 		$options = (array) get_option( 'gp_options' );
 		$value   = ( true === isset( $options[ $args['id'] ] ) ) ? $options[ $args['id'] ] : false;
 		$html    = '<input type="checkbox" id="' . $args['id'] . '" ';
 		$html   .= 'name="gp_options[' . $args['id'] . ']" value="1" ' . checked( 1, $value, false ) . ' />';
 		$html   .= '<label for="' . $args['id'] . '">' . $args['label'] . '</label>';
-		echo $html;
+		echo esc_attr( $html );
 	}
 
 	/**
@@ -137,7 +137,7 @@ class GP_Admin {
 	 *
 	 * @since 3.0.0
 	 */
-	function glotpress_validate_options( $input ) {
+	public function glotpress_validate_options( $input ) {
 		$valid                   = array();
 		$valid['delete_options'] = isset( $input['delete_options'] ) && true == $input['delete_options'];
 		$valid['delete_data']    = isset( $input['delete_data'] ) && true == $input['delete_data'];

--- a/gp-includes/gp.php
+++ b/gp-includes/gp.php
@@ -23,7 +23,7 @@ class GP {
 	public static $project;
 
 	/**
-	 * Model for transalation set.
+	 * Model for translation set.
 	 *
 	 * @since 1.0.0
 	 *
@@ -165,4 +165,13 @@ class GP {
 	 * @var array
 	 */
 	public static $scripts = array();
+
+	/**
+	 * Model for GP_Admin.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var GP_Admin
+	 */
+	public static $admin;
 }

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -119,6 +119,8 @@ require_once GP_PATH . GP_INC . 'formats/format-json.php';
 require_once GP_PATH . GP_INC . 'formats/format-jed1x.php';
 require_once GP_PATH . GP_INC . 'formats/format-ngx.php';
 
+require_once GP_PATH . GP_INC . 'admin.php';
+
 // Let's do it again, there are more variables added since last time we called it.
 gp_set_globals( get_defined_vars() );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Uninstall routine for GlotPress.
+ *
+ * @package GlotPress
+ * @since 3.0.0
+ */
+
+if ( defined( 'ABSPATH' ) && defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	if ( '1' === get_option( 'gp_delete_on_uninstall' ) ) {
+		gp_delete_tables();
+	}
+	gp_delete_options();
+}
+
+/**
+ * Function to remove all GlotPress database tables.
+ *
+ * @since 3.0.0
+ */
+function gp_delete_tables() {
+	global $wpdb, $gp_table_prefix;
+
+	// Since we may have been called after GP has been disabled, make sure we have all the defines we need.
+	if ( ! defined( 'GP_PATH' ) ) {
+		define( 'GP_PATH', __DIR__ . '/' );
+	}
+
+	if ( ! defined( 'GP_INC' ) ) {
+		define( 'GP_INC', 'gp-includes/' );
+	}
+
+	if ( ! isset( $gp_table_prefix ) ) {
+		$gp_table_prefix = $GLOBALS['table_prefix'] . 'gp_';
+	}
+
+	// Include the schema so we can get the list of tables.
+	if ( ! function_exists( 'gp_schema_get' ) ) {
+		include GP_PATH . GP_INC . 'schema.php';
+	}
+
+	// Get the schema and loop through each table so we can delete it.
+	$schema = gp_schema_get();
+
+	foreach ( $schema as $table => $sql ) {
+		$table_name = $gp_table_prefix . $table;
+
+		// We can't use $wpdb->prepare here as the table name is not one of the support data types.
+		$wpdb->query( "DROP TABLE IF EXISTS {$table_name};" ); // WPCS: unprepared SQL ok.
+	}
+}
+
+/**
+ * Function to remove all GlotPress settings in the WordPress options table.
+ *
+ * @since 3.0.0
+ */
+function gp_delete_options() {
+	delete_option( 'gp_db_version' );
+	delete_option( 'gp_rewrite_rule' );
+	delete_option( 'gp_delete_on_uninstall' );
+}
+
+

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,58 +7,56 @@
  */
 
 if ( defined( 'ABSPATH' ) && defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-	if ( '1' === get_option( 'gp_delete_on_uninstall' ) ) {
-		gp_delete_tables();
+	$options = get_option( 'gp_options' );
+	if ( isset( $options['delete_data'] ) && ( true === $options['delete_data'] ) ) {
+		gp_delete_data();
 	}
-	gp_delete_options();
+	// As the new option to delete the GlotPress options has the default value set to true,
+	// if the option doesn't exist in the options table, the GlotPress options will be deleted.
+	if ( ! isset( $options['delete_data'] ) || ( isset( $options['delete_data'] ) && ( true === $options['delete_options'] ) ) ) {
+		gp_delete_options();
+	}
 }
 
 /**
- * Function to remove all GlotPress database tables.
+ * Removes all GlotPress database tables.
  *
  * @since 3.0.0
  */
-function gp_delete_tables() {
+function gp_delete_data() {
 	global $wpdb, $gp_table_prefix;
 
 	// Since we may have been called after GP has been disabled, make sure we have all the defines we need.
 	if ( ! defined( 'GP_PATH' ) ) {
 		define( 'GP_PATH', __DIR__ . '/' );
 	}
-
 	if ( ! defined( 'GP_INC' ) ) {
 		define( 'GP_INC', 'gp-includes/' );
 	}
-
 	if ( ! isset( $gp_table_prefix ) ) {
 		$gp_table_prefix = $GLOBALS['table_prefix'] . 'gp_';
 	}
-
-	// Include the schema so we can get the list of tables.
+	// Include the schema, so we can get the list of tables.
 	if ( ! function_exists( 'gp_schema_get' ) ) {
 		include GP_PATH . GP_INC . 'schema.php';
 	}
-
-	// Get the schema and loop through each table so we can delete it.
+	// Get the schema and loop through each table, so we can delete it.
 	$schema = gp_schema_get();
-
 	foreach ( $schema as $table => $sql ) {
 		$table_name = $gp_table_prefix . $table;
-
-		// We can't use $wpdb->prepare here as the table name is not one of the support data types.
-		$wpdb->query( "DROP TABLE IF EXISTS {$table_name};" ); // WPCS: unprepared SQL ok.
+		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" ); // WPCS: unprepared SQL ok.
 	}
 }
 
 /**
- * Function to remove all GlotPress settings in the WordPress options table.
+ * Removes all GlotPress settings in the WordPress options table.
  *
  * @since 3.0.0
  */
 function gp_delete_options() {
 	delete_option( 'gp_db_version' );
 	delete_option( 'gp_rewrite_rule' );
-	delete_option( 'gp_delete_on_uninstall' );
+	delete_option( 'gp_options' );
 }
 
 


### PR DESCRIPTION
This code is based on PR #513 and issue #479.

- Add a settings page menu for WordPress to confirm the data deletion.
- Delete all GlotPress database tables only if the confirmation check was selected.
- Delete all GlotPress settings in the WordPress options table.