### PR TITLE
Glossary: Include part_of_speech in check for duplicate entries

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -87,9 +87,10 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 				$this->redirect( gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) ) );
 			} else {
 				$find_parms = array(
-					'glossary_id' => $glossary->id,
-					'term'        => $new_glossary_entry->term,
-					'translation' => $new_glossary_entry->translation,
+					'glossary_id'    => $glossary->id,
+					'term'           => $new_glossary_entry->term,
+					'translation'    => $new_glossary_entry->translation,
+					'part_of_speech' => $new_glossary_entry->part_of_speech,
 				);
 
 				if ( GP::$glossary_entry->find_one( $find_parms ) ) {


### PR DESCRIPTION
This is a follow-up to:
* https://github.com/GlotPress/GlotPress-WP/pull/746
* https://github.com/GlotPress/GlotPress-WP/pull/947
* https://github.com/GlotPress/GlotPress-WP/pull/948
* https://github.com/GlotPress/GlotPress-WP/pull/949

Related report for translate.w.org: https://meta.trac.wordpress.org/ticket/5508

This PR restores being able to use the same term and translation for a different part of speech.