### PR TITLE
Support %@ placeholder in the warnings and expand the ###...### placeholder format

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -657,7 +657,7 @@ class GP_Builtin_Translation_Warnings {
 	/**
 	 * Adds a warning for changing placeholders.
 	 *
-	 * This only supports placeholders in the format of '###[A-Z_]+###'.
+	 * This only supports placeholders in the format of '###[A-Za-z_-]+###'.
 	 *
 	 * @todo Check that the number of each type of placeholders are the same in the original and in the translation
 	 *
@@ -669,7 +669,7 @@ class GP_Builtin_Translation_Warnings {
 	 * @return string|true
 	 */
 	public function warning_named_placeholders( string $original, string $translation ) {
-		$placeholder_regex = '@(###[A-Z_]+###)@';
+		$placeholder_regex = '@(###[A-Za-z_-]+###)@';
 
 		preg_match_all( $placeholder_regex, $original, $original_placeholders );
 		$original_placeholders = array_unique( $original_placeholders[0] );

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -352,6 +352,12 @@ class GP_Builtin_Translation_Warnings {
 	/**
 	 * Checks whether PHP placeholders are missing or have been added.
 	 *
+	 * The default regular expression:
+	 * bcdefgosuxEFGX are standard printf placeholders.
+	 * % is included to allow/expect %%.
+	 * l is included for wp_sprintf_l()'s custom %l format.
+	 * @ is included for Swift (as used for iOS mobile app) %@ string format.
+	 *
 	 * @since 1.0.0
 	 * @access public
 	 *
@@ -368,7 +374,7 @@ class GP_Builtin_Translation_Warnings {
 		 *
 		 * @param string $placeholders_re Regular expression pattern without leading or trailing slashes.
 		 */
-		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX%l]' );
+		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX%l@]' );
 
 		$original_counts    = $this->_placeholders_counts( $original, $placeholders_re );
 		$translation_counts = $this->_placeholders_counts( $translation, $placeholders_re );

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -200,6 +200,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', 'This string has %stwo variables%s.', 'Deze string heeft %stwee variabelen%s.' );
 		$this->assertNoWarnings( 'placeholders', '%% baba', '%% баба' );
 		$this->assertNoWarnings( 'placeholders', '%s%% baba', '%s%% баба' );
+		$this->assertNoWarnings( 'placeholders', '%1$d baba %2$@', '%2$@ баба %1$d' );
 
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
@@ -242,6 +243,18 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'баба',
 			'%s baba',
 			'Extra %s placeholder in translation.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'placeholders',
+			'%1$d baba %2$@',
+			'%1$d baba',
+			'Missing %2$@ placeholder in translation.'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'placeholders',
+			'%1$d baba',
+			'%1$d baba %2$@',
+			'Extra %2$@ placeholder in translation.'
 		);
 	}
 

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -584,6 +584,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 
 	function test_named_placeholders() {
 		$this->assertNoWarnings( 'named_placeholders', '###NEW_EMAIL###', '###NEW_EMAIL###' );
+		$this->assertNoWarnings( 'named_placeholders', '###new-email###', '###new-email###' );
 		$this->assertNoWarnings(
 			'named_placeholders',
 			'Hi ###USERNAME###, we sent to ###EMAIL### your new password from "###SITENAME###" (###SITEURL###)',
@@ -625,6 +626,18 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'Hi ###USERNAME###, we sent to ###EMAIL### your new password from "###SITENAME###" (###SITEURL###)',
 			'Hola ###USERNAME###, te enviamos desde «###SITENAME###» (###SITEURL###) tu nueva contraseña a EMAIL#',
 			'The translation appears to be missing the following placeholders: ###EMAIL###'
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'named_placeholders',
+			'###NEW_EMAIL###',
+			'###new_email###',
+			"The translation appears to be missing the following placeholders: ###NEW_EMAIL###\nThe translation contains the following unexpected placeholders: ###new_email###"
+		);
+		$this->assertHasWarningsAndContainsOutput(
+			'named_placeholders',
+			'###new_email###',
+			'###NEW_EMAIL###',
+			"The translation appears to be missing the following placeholders: ###new_email###\nThe translation contains the following unexpected placeholders: ###NEW_EMAIL###"
 		);
 	}
 


### PR DESCRIPTION
Support %@ placeholder format for better translations/warnings for Swift code, as used by the WordPress iOS app.

See:
- https://wordpress.slack.com/archives/C02RP50LK/p1629720600345400
- WordPress/wordpress.org@3aad97d#diff-bc4084ccb9bae64ba16d64b413a90681a639844c7350ed992902f0820d1ef745
- https://meta.trac.wordpress.org/changeset/11194

Expand the ###...### placeholder format to accept lowercase characters and dashes.

See:
- https://meta.trac.wordpress.org/changeset/11198
- WordPress/wordpress.org@b4f435b#diff-bc4084ccb9bae64ba16d64b413a90681a639844c7350ed992902f0820d1ef745
