### PR TITLE
Add support for the placeholders with precision

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -374,7 +374,7 @@ class GP_Builtin_Translation_Warnings {
 		 *
 		 * @param string $placeholders_re Regular expression pattern without leading or trailing slashes.
 		 */
-		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX%l@]' );
+		$placeholders_re = apply_filters( 'gp_warning_placeholders_re', '(?<!%)%(\d+\$(?:\d+)?)?(\.\d+)?[bcdefgosuxEFGX%l@]' );
 
 		$original_counts    = $this->_placeholders_counts( $original, $placeholders_re );
 		$translation_counts = $this->_placeholders_counts( $translation, $placeholders_re );
@@ -617,7 +617,7 @@ class GP_Builtin_Translation_Warnings {
 			preg_match_all( '/(?P<context>[^\s%]*)%((\d+\$(?:\d+)?)?(?P<char>.))/i', $translation, $m );
 			foreach ( $m['char'] as $i => $char ) {
 				// % is included for escaped %%.
-				if ( false === strpos( 'bcdefgosux%l', $char ) ) {
+				if ( false === strpos( 'bcdefgosux%l.', $char ) ) {
 					$unexpected_tokens[] = $m[0][ $i ];
 				}
 			}

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -209,12 +209,12 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'placeholders',
 			'%1$.2f baba',
 			'%1$.f баба',
-		'Missing %1$.2f placeholder in translation.');
+			'Missing %1$.2f placeholder in translation.');
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
 			'%1$.f baba',
 			'%1$.4f баба',
-		'Extra %1$.4f placeholder in translation.');
+			'Extra %1$.4f placeholder in translation.');
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
 			'%s baba',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -205,11 +205,13 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', '%2$.2fMB baba', '%2$.2fMB баба' );
 		$this->assertNoWarnings( 'placeholders', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s' );
 
-		$this->assertHasWarningsAndContainsOutput( 'placeholders',
+		$this->assertHasWarningsAndContainsOutput(
+			'placeholders',
 			'%1$.2f baba',
 			'%1$.f баба',
 		'Missing %1$.2f placeholder in translation.');
-		$this->assertHasWarningsAndContainsOutput( 'placeholders',
+		$this->assertHasWarningsAndContainsOutput(
+			'placeholders',
 			'%1$.f baba',
 			'%1$.4f баба',
 		'Extra %1$.4f placeholder in translation.');

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -209,12 +209,14 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 			'placeholders',
 			'%1$.2f baba',
 			'%1$.f баба',
-			'Missing %1$.2f placeholder in translation.');
+			'Missing %1$.2f placeholder in translation.'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
 			'%1$.f baba',
 			'%1$.4f баба',
-			'Extra %1$.4f placeholder in translation.');
+			'Extra %1$.4f placeholder in translation.'
+		);
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
 			'%s baba',

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -201,7 +201,18 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'placeholders', '%% baba', '%% баба' );
 		$this->assertNoWarnings( 'placeholders', '%s%% baba', '%s%% баба' );
 		$this->assertNoWarnings( 'placeholders', '%1$d baba %2$@', '%2$@ баба %1$d' );
+		$this->assertNoWarnings( 'placeholders', '%1$.4f baba', '%1$.4f баба' );
+		$this->assertNoWarnings( 'placeholders', '%2$.2fMB baba', '%2$.2fMB баба' );
+		$this->assertNoWarnings( 'placeholders', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s' );
 
+		$this->assertHasWarningsAndContainsOutput( 'placeholders',
+			'%1$.2f baba',
+			'%1$.f баба',
+		'Missing %1$.2f placeholder in translation.');
+		$this->assertHasWarningsAndContainsOutput( 'placeholders',
+			'%1$.f baba',
+			'%1$.4f баба',
+		'Extra %1$.4f placeholder in translation.');
 		$this->assertHasWarningsAndContainsOutput(
 			'placeholders',
 			'%s baba',
@@ -540,6 +551,12 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertNoWarnings( 'unexpected_sprintf_token', '<a href="%a">100 percent</a>', '<a href="%a">100%</a>' );
 		$this->assertNoWarnings( 'unexpected_sprintf_token', '<a href="%s">100 percent</a>', '<a href="%s">100%%</a>' );
 		$this->assertNoWarnings( 'unexpected_sprintf_token', '<a href="%1$s">100 percent</a>', '<a href="%1$s">100%%</a>' );
+		$this->assertNoWarnings( 'unexpected_sprintf_token', '%1$.2f baba', '%1$.2f баба' );
+		$this->assertNoWarnings( 'unexpected_sprintf_token', '%1$.2f baba', '%1$.3f баба' );
+		$this->assertNoWarnings( 'unexpected_sprintf_token', '%2$.2fMB baba', '%2$.2fMB баба' );
+		$this->assertNoWarnings( 'unexpected_sprintf_token', '%2$.3fMB baba', '%2$.2fMB баба' );
+		$this->assertNoWarnings( 'unexpected_sprintf_token', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s', 'Data: %1$.2fMB | Index: %2$.2fMB | Free: %3$.2fMB | Engine: %4$s' );
+
 		$this->assertNoWarnings(
 			'unexpected_sprintf_token',
 			'The %s contains %d items',


### PR DESCRIPTION
Add support for the placeholders with a format like %1$.2f

See https://meta.trac.wordpress.org/ticket/5927