### PR TITLE
Fix typo in Validation array key

### DIFF
--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -166,7 +166,7 @@ class GP_Validation_Rules {
 						$this->errors[] = $this->construct_error_message( $rule );
 						$verdict        = false;
 					}
-				} elseif ( ! $callback['negativ']( ...$args ) ) {
+				} elseif ( ! $callback['negative']( ...$args ) ) {
 					$this->errors[] = $this->construct_error_message( $rule );
 					$verdict        = false;
 				}


### PR DESCRIPTION
Validation typo introduced in https://github.com/GlotPress/GlotPress-WP/commit/e5c63e69dcfa3d499eced0b36f40a8565abf37e0