### PR TITLE
Glossary: Set up part of speech values earlier

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -32,8 +32,9 @@ class GP_Glossary_Entry extends GP_Thing {
 
 
 	public function __construct( $fields = array() ) {
-		parent::__construct( $fields );
 		$this->setup_pos();
+
+		parent::__construct( $fields );
 	}
 
 	/**

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -23,6 +23,13 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 		$this->assertFalse( $verdict );
 	}
 
+	function test_invalid_part_of_speech() {
+		$glossary_entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'term', 'part_of_speech' => 'invalid', 'last_edited_by' =>'1' ) );
+		$verdict = $glossary_entry->validate();
+
+		$this->assertFalse( $verdict );
+	}
+
 	function test_negative_last_edited_by() {
 		$glossary_entry = GP::$glossary_entry->create( array( 'glossary_id' => '1', 'term' => 'tern', 'part_of_speech' => 'verb', 'last_edited_by' =>'-1' ) );
 		$verdict = $glossary_entry->validate();


### PR DESCRIPTION
The `parts_of_speech` property is now also used for validation purposes. Since validation rules are set by the `GP_Thing` constructor we have to set the property before calling the parent method.

Related: https://github.com/WordPress/meta-environment/issues/165, https://github.com/WordPress/meta-environment/issues/166, https://github.com/GlotPress/GlotPress-WP/pull/1277