### PR TITLE
Fix GP_Validation_Rules::__call() error message

### DIFF
--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -108,8 +108,8 @@ class GP_Validation_Rules {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error(
 			sprintf(
-				/* translators: 1: Class name, 2: method name.  */
 				'Call to undefined method: %1$s::%2$s().',
+				/* translators: 1: Class name, 2: Method name. */
 				esc_html( get_class( $this ) ),
 				esc_html( $name )
 			),

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -108,7 +108,7 @@ class GP_Validation_Rules {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error(
 			sprintf(
-				/* translators: 1: Method name. */
+				/* translators: %s: Method name. */
 				esc_html__( 'Call to undefined method: %s.', 'glotpress' ),
 				sprintf(
 					'%1$s::%2$s()',

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -109,7 +109,7 @@ class GP_Validation_Rules {
 		trigger_error(
 			sprintf(
 				/* translators: 1: Class name, 2: method name.  */
-				'Call to undefined method: %1$::%2$().',
+				'Call to undefined method: %1$s::%2$s().',
 				esc_html( get_class( $this ) ),
 				esc_html( $name )
 			),

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -108,10 +108,13 @@ class GP_Validation_Rules {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error(
 			sprintf(
-				/* translators: 1: Class name, 2: Method name. */
-				esc_html__( 'Call to undefined method: %1$s::%2$s().', 'glotpress' ),
-				esc_html( get_class( $this ) ),
-				esc_html( $name )
+				/* translators: 1: Method name. */
+				esc_html__( 'Call to undefined method: %s.', 'glotpress' ),
+				sprintf(
+					'%1$s::%2$s()',
+					esc_html( get_class( $this ) ),
+					esc_html( $name )
+				)
 			),
 			E_USER_ERROR
 		);

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -108,8 +108,8 @@ class GP_Validation_Rules {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error(
 			sprintf(
-				'Call to undefined method: %1$s::%2$s().',
 				/* translators: 1: Class name, 2: Method name. */
+				esc_html__( 'Call to undefined method: %1$s::%2$s().', 'glotpress' ),
 				esc_html( get_class( $this ) ),
 				esc_html( $name )
 			),


### PR DESCRIPTION
The string [`Call to undefined method: %1$::%2$().`](https://github.com/GlotPress/GlotPress-WP/blob/develop/gp-includes/validation.php#L112) has wrong numbered variables and no gettext.
- [x] Fix variables: ~%1$~, ~%2$~ -> %1$s, %2$s
- [x] Add missing gettext, with escaping and textdomain
- [x] Single variable for `class::method()`, concatenated outside of the translation string