### PR TITLE
Remove unnecessary preview/edit translation-rows from variant translation set

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -416,9 +416,8 @@ $class_rtl = 'rtl' === $locale->text_direction ? ' translation-sets-rtl' : '';
 		ksort( $translations_by_id );
 		$last_translation = end( $translations_by_id );
 		foreach ( $translations_by_id as $translation_by_root_id ) {
-			if ( 'current' === $translation_by_root_id->root_status ) {
+			if ( 'current' === $translation_by_root_id->root_status || 'waiting' === $translation_by_root_id->root_status || 'fuzzy' === $translation_by_root_id->root_status ) {
 				$current_translation = $translation_by_root_id;
-				break;
 			}
 		}
 		$translations[] = $current_translation ? $current_translation : $last_translation;

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -414,8 +414,8 @@ $class_rtl = 'rtl' === $locale->text_direction ? ' translation-sets-rtl' : '';
 	foreach ( $variant_translations as $translations_by_id ) {
 		// Sort translations ascending the by root_id to keep the last in the end.
 		ksort( $translations_by_id );
-		$last_translation = $translations_by_id[ array_key_last( $translations_by_id ) ];
-		foreach( $translations_by_id as $translation_by_root_id ) {
+		$last_translation = end( $translations_by_id );
+		foreach ( $translations_by_id as $translation_by_root_id ) {
 			if ( 'current' === $translation_by_root_id->root_status ) {
 				$current_translation = $translation_by_root_id;
 				break;


### PR DESCRIPTION
Fixes #1301 

I've added this duplicate removal only on the template ending to avoid any conflicts with the expected default behaviour everywhere.

But if there is no need for this duplicates in any other place, it might better to just be fix it above the template, either after it's called on https://github.com/GlotPress/GlotPress-WP/blob/develop/gp-includes/routes/translation.php#L217 or even on the [for_translation()](https://github.com/GlotPress/GlotPress-WP/blob/e5887528a27a7b669c1ccd735c300cd4f3c5f708/gp-includes/things/translation.php#L307) method output itself.