### PR TITLE
Adding Catalan Valencian variant,

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -467,7 +467,7 @@ class GP_Locales {
 		$ca_valencia->native_name = 'Català (Valencià)';
 		$ca_valencia->lang_code_iso_639_1 = 'ca';
 		$ca_valencia->lang_code_iso_639_2 = 'cat';
-		$ca_valencia->wp_locale = 'ca-valencia';
+		$ca_valencia->wp_locale = 'ca_valencia';
 		$ca_valencia->slug = 'ca-valencia';
 		$ca_valencia->google_code = 'ca';
 		$ca_valencia->variant_root = $ca->slug;

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -462,6 +462,18 @@ class GP_Locales {
 		$ca->google_code = 'ca';
 		$ca->facebook_locale = 'ca_ES';
 
+		$ca_valencia = new GP_Locale();
+		$ca_valencia->english_name = 'Catalan (Valencian)';
+		$ca_valencia->native_name = 'Català (Valencià)';
+		$ca_valencia->lang_code_iso_639_1 = 'ca';
+		$ca_valencia->lang_code_iso_639_2 = 'cat';
+		$ca_valencia->wp_locale = 'ca-valencia';
+		$ca_valencia->slug = 'ca-valencia';
+		$ca_valencia->google_code = 'ca';
+		$ca_valencia->variant_root = $ca->slug;
+		$ca_valencia->facebook_locale = 'ca_ES';
+		$ca->variants[ $ca_valencia->slug ] = $ca_valencia->english_name;
+
 		$ce = new GP_Locale();
 		$ce->english_name = 'Chechen';
 		$ce->native_name = 'Нохчийн мотт';


### PR DESCRIPTION
This variant was already added on translations.wp.org (see https://make.wordpress.org/polyglots/2018/02/27/locale-cat-country-code-es/#comment-278706) 

It also exists on many other open-source projects:

- Gnome https://l10n.gnome.org/teams/ca/
- Moodle https://download.moodle.org/langpack/3.4/
- Ubuntu https://translations.launchpad.net/ubuntu/focal/+lang/ca@valencia