### PR TITLE
Allow specifying the priority for PO import/exports in the `flags`.

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -680,28 +680,3 @@ function gp_get_sort_by_fields() {
 function gp_set_translations_import_max_memory_limit() {
 	return '256M';
 }
-
-/**
- * Parse an array of flags looking for a flag/value.
- *
- * If the field is in the format of 'field=value', only the value will be returned.
- * If the field is in the format of 'field', only the field will be returned.
- *
- * @param Translation_Entry $entry The translation entry.
- * @return string|false The field value, or false on failure.
- */
-function parse_fields_flags_for_field( $flags, $field ) {
-	foreach ( array_reverse( $flags ) as $flag ) {
-		parse_str( $flag, $fields );
-
-		if ( isset( $fields[ $field ] ) ) {
-			if ( '' === $fields[ $field ] ) {
-				return $field;
-			}
-
-			return $fields[ $field ];
-		}
-	}
-
-	return false;
-}

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -680,3 +680,28 @@ function gp_get_sort_by_fields() {
 function gp_set_translations_import_max_memory_limit() {
 	return '256M';
 }
+
+/**
+ * Parse an array of flags looking for a flag/value.
+ *
+ * If the field is in the format of 'field=value', only the value will be returned.
+ * If the field is in the format of 'field', only the field will be returned.
+ *
+ * @param Translation_Entry $entry The translation entry.
+ * @return string|false The field value, or false on failure.
+ */
+function parse_fields_flags_for_field( $flags, $field ) {
+	foreach ( array_reverse( $flags ) as $flag ) {
+		parse_str( $flag, $fields );
+
+		if ( isset( $fields[ $field ] ) ) {
+			if ( '' === $fields[ $field ] ) {
+				return $field;
+			}
+
+			return $fields[ $field ];
+		}
+	}
+
+	return false;
+}

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -228,9 +228,13 @@ class GP_Original extends GP_Thing {
 			);
 
 			// Set the Priority if specified as a flag.
-			$priority = parse_fields_flags_for_field( $entry->flags, 'priority' );
-			if ( false !== $priority && in_array( $priority, self::$priorities ) ) {
-				$data['priority'] = $priority;
+			if ( $entry->flags ) {
+				foreach ( self::$priorities as $priority => $text ) {
+					if ( in_array( "priority={$text}", $entry->flags ) ) {
+						$data['priority'] = $priority;
+						break;
+					}
+				}
 			}
 
 			/**
@@ -295,9 +299,13 @@ class GP_Original extends GP_Thing {
 			);
 
 			// Set the Priority if specified as a flag.
-			$priority = parse_fields_flags_for_field( $entry->flags, 'priority' );
-			if ( false !== $priority && in_array( $priority, self::$priorities ) ) {
-				$data['priority'] = $priority;
+			if ( $entry->flags ) {
+				foreach ( self::$priorities as $priority => $text ) {
+					if ( in_array( "priority={$text}", $entry->flags ) ) {
+						$data['priority'] = $priority;
+						break;
+					}
+				}
 			}
 
 			/** This filter is documented in gp-includes/things/original.php */

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -230,7 +230,7 @@ class GP_Original extends GP_Thing {
 			// Set the Priority if specified as a flag.
 			if ( $entry->flags ) {
 				foreach ( self::$priorities as $priority => $text ) {
-					if ( in_array( "priority={$text}", $entry->flags ) ) {
+					if ( in_array( "{$text}-priority", $entry->flags ) ) {
 						$data['priority'] = $priority;
 						break;
 					}
@@ -301,7 +301,7 @@ class GP_Original extends GP_Thing {
 			// Set the Priority if specified as a flag.
 			if ( $entry->flags ) {
 				foreach ( self::$priorities as $priority => $text ) {
-					if ( in_array( "priority={$text}", $entry->flags ) ) {
+					if ( in_array( "{$text}-priority", $entry->flags ) ) {
 						$data['priority'] = $priority;
 						break;
 					}

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -158,7 +158,6 @@ class GP_Original extends GP_Thing {
 		return 0;
 	}
 
-
 	public function by_project_id_and_entry( $project_id, $entry, $status = null ) {
 		global $wpdb;
 
@@ -194,9 +193,6 @@ class GP_Original extends GP_Thing {
 					'singular' => $original->singular,
 					'plural'   => $original->plural,
 					'context'  => $original->context,
-					'flags'    => array(
-						'priority=' . self::$priorities[ $original->priority ],
-					)
 				)
 			);
 
@@ -232,8 +228,8 @@ class GP_Original extends GP_Thing {
 			);
 
 			// Set the Priority if specified as a flag.
-			$priority = parse_fields_flags_for_field( $entry->flag, 'priority' );
-			if ( $priority ) {
+			$priority = parse_fields_flags_for_field( $entry->flags, 'priority' );
+			if ( false !== $priority && in_array( $priority, self::$priorities ) ) {
 				$data['priority'] = $priority;
 			}
 
@@ -299,8 +295,8 @@ class GP_Original extends GP_Thing {
 			);
 
 			// Set the Priority if specified as a flag.
-			$priority = parse_fields_flags_for_field( $entry->flag, 'priority' );
-			if ( $priority ) {
+			$priority = parse_fields_flags_for_field( $entry->flags, 'priority' );
+			if ( false !== $priority && in_array( $priority, self::$priorities ) ) {
 				$data['priority'] = $priority;
 			}
 

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -230,7 +230,7 @@ class GP_Original extends GP_Thing {
 			// Set the Priority if specified as a flag.
 			if ( $entry->flags ) {
 				foreach ( self::$priorities as $priority => $text ) {
-					if ( in_array( "{$text}-priority", $entry->flags ) ) {
+					if ( in_array( "gp-priority: {$text}", $entry->flags ) ) {
 						$data['priority'] = $priority;
 						break;
 					}
@@ -301,7 +301,7 @@ class GP_Original extends GP_Thing {
 			// Set the Priority if specified as a flag.
 			if ( $entry->flags ) {
 				foreach ( self::$priorities as $priority => $text ) {
-					if ( in_array( "{$text}-priority", $entry->flags ) ) {
+					if ( in_array( "gp-priority: {$text}", $entry->flags ) ) {
 						$data['priority'] = $priority;
 						break;
 					}

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -194,6 +194,9 @@ class GP_Original extends GP_Thing {
 					'singular' => $original->singular,
 					'plural'   => $original->plural,
 					'context'  => $original->context,
+					'flags'    => array(
+						'priority=' . self::$priorities[ $original->priority ],
+					)
 				)
 			);
 
@@ -227,6 +230,12 @@ class GP_Original extends GP_Thing {
 				'references' => implode( ' ', $entry->references ),
 				'status'     => '+active',
 			);
+
+			// Set the Priority if specified as a flag.
+			$priority = parse_fields_flags_for_field( $entry->flag, 'priority' );
+			if ( $priority ) {
+				$data['priority'] = $priority;
+			}
 
 			/**
 			 * Filter the data of an original being imported or updated.
@@ -288,6 +297,12 @@ class GP_Original extends GP_Thing {
 				'references' => implode( ' ', $entry->references ),
 				'status'     => '+active',
 			);
+
+			// Set the Priority if specified as a flag.
+			$priority = parse_fields_flags_for_field( $entry->flag, 'priority' );
+			if ( $priority ) {
+				$data['priority'] = $priority;
+			}
 
 			/** This filter is documented in gp-includes/things/original.php */
 			$data = apply_filters( 'gp_import_original_array', $data, $entry );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -587,6 +587,11 @@ class GP_Translation extends GP_Thing {
 				unset( $row->$member );
 			}
 			$row->row_id    = $row->original_id . ( $row->id ? "-$row->id" : '' );
+			if ( isset( $row->priority ) ) {
+				$row->flags     = array(
+					'priority=' . GP_Original::$priorities[ $row->priority ],
+				);
+			}
 			$translations[] = new Translation_Entry( (array) $row );
 		}
 		unset( $rows );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -591,7 +591,7 @@ class GP_Translation extends GP_Thing {
 
 			if ( isset( $row->priority ) ) {
 				$row->flags = array(
-					GP_Original::$priorities[ $row->priority ] . '-priority',
+					'gp-priority: ' . GP_Original::$priorities[ $row->priority ],
 				);
 			}
 

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -591,7 +591,7 @@ class GP_Translation extends GP_Thing {
 
 			if ( isset( $row->priority ) ) {
 				$row->flags = array(
-					'priority=' . GP_Original::$priorities[ $row->priority ],
+					GP_Original::$priorities[ $row->priority ] . '-priority',
 				);
 			}
 

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -586,12 +586,15 @@ class GP_Translation extends GP_Thing {
 				$member = "translation_$i";
 				unset( $row->$member );
 			}
-			$row->row_id    = $row->original_id . ( $row->id ? "-$row->id" : '' );
+
+			$row->row_id = $row->original_id . ( $row->id ? "-$row->id" : '' );
+
 			if ( isset( $row->priority ) ) {
-				$row->flags     = array(
+				$row->flags = array(
 					'priority=' . GP_Original::$priorities[ $row->priority ],
 				);
 			}
+
 			$translations[] = new Translation_Entry( (array) $row );
 		}
 		unset( $rows );

--- a/tests/phpunit/testcases/tests_things/test_thing_original.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_original.php
@@ -330,9 +330,9 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 
 		$translations = $this->create_translations_with(
 			array(
-				array( 'singular' => 'baba', 'flags' => array( 'low-priority' ) ),
+				array( 'singular' => 'baba', 'flags' => array( 'gp-priority: low' ) ),
 				array( 'singular' => 'baba baba' ),
-				array( 'singular' => 'baba baba baba', 'flags' => array( 'high-priority' ) ),
+				array( 'singular' => 'baba baba baba', 'flags' => array( 'gp-priority: high' ) ),
 			)
 		);
 

--- a/tests/phpunit/testcases/tests_things/test_thing_original.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_original.php
@@ -333,16 +333,19 @@ class GP_Test_Thing_Original extends GP_UnitTestCase {
 				array( 'singular' => 'baba', 'flags' => array( 'gp-priority: low' ) ),
 				array( 'singular' => 'baba baba' ),
 				array( 'singular' => 'baba baba baba', 'flags' => array( 'gp-priority: high' ) ),
+				array( 'singular' => 'priority flag should be ignored.', 'flags' => array( 'gp-priority: unexpected' ) ),
 			)
 		);
 
 		$original->import_for_project( $project, $translations );
 
 		$originals_for_project = $original->by_project_id( $project->id );
-		$this->assertEquals( 3, count( $originals_for_project ) );
-		$this->assertEquals( -1, $originals_for_project[0]->priority );
-		$this->assertEquals( 0, $originals_for_project[1]->priority );
-		$this->assertEquals( 1, $originals_for_project[2]->priority );
+		$this->assertEquals( 4, count( $originals_for_project ) );
+
+		$this->assertEquals( -1, $originals_for_project[0]->priority, 'Existing string should have been updated to be low-priority.' );
+		$this->assertEquals( 0, $originals_for_project[1]->priority, 'New string should have imported as normal priority.' );
+		$this->assertEquals( 1, $originals_for_project[2]->priority, 'New string should have imported as high priority.' );
+		$this->assertEquals( 0, $originals_for_project[3]->priority, 'New string with invalid priority flag should have imported as normal priority.' );
 	}
 
 }


### PR DESCRIPTION
Fixes #1340

This allows for the .po file to contain a `high-priority` flag, removing the need for external code to update the database afterwards.

Note: This does not reset the priority to `normal` unless `normal-priority` is explicitly added.

The flags looked at are therefor: `low-priority`, `normal-priority`, `high-priority`, and `hidden-priority`

~~I went with the format of `priority=TEXT` due to the way I started down this rabbit hole.~~

~~Potentially this could be changed to just being `low-priority`, `normal-priority`, `high-priority`, `hidden-priority` instead, actual flags rather than a key-value pair. I'm creating this for code-review on the approach.~~

~~No~~ tests included, but it does work (at least on WordPress.org)