### PR TITLE
Add the Entry as context to the gp_import_original_array filter.

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -250,8 +250,9 @@ class GP_Original extends GP_Thing {
 			 *                              are separated by spaces.
 			 *     @type string $status     Status of the imported original.
 			 * }
+			 * @param Translation_Entry $entry The Translation entry.
 			 */
-			$data = apply_filters( 'gp_import_original_array', $data );
+			$data = apply_filters( 'gp_import_original_array', $data, $entry );
 
 			// Original exists, let's update it.
 			if ( isset( $originals_by_key[ $entry->key() ] ) ) {
@@ -289,7 +290,7 @@ class GP_Original extends GP_Thing {
 			);
 
 			/** This filter is documented in gp-includes/things/original.php */
-			$data = apply_filters( 'gp_import_original_array', $data );
+			$data = apply_filters( 'gp_import_original_array', $data, $entry );
 
 			// Search for match in the dropped strings and existing obsolete strings.
 			$close_original = $this->closest_original( $entry->key(), $comparison_array );

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -250,7 +250,7 @@ class GP_Original extends GP_Thing {
 			 *                              are separated by spaces.
 			 *     @type string $status     Status of the imported original.
 			 * }
-			 * @param Translation_Entry $entry The Translation entry.
+			 * @param Translation_Entry $entry The translation entry.
 			 */
 			$data = apply_filters( 'gp_import_original_array', $data, $entry );
 


### PR DESCRIPTION
While working on #1341 I noticed that the `gp_import_original_array` filter doesn't pass the `$entry` being processed.

This made it impossible to implement the logic as a plugin, but also makes the filter far less useful.