### PR TITLE
1169: Fix Glossary Tooltip to match terms with multiple words and words with hyphens

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -97,6 +97,8 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 		}
 
 		$terms[] = $quoted_term;
+
+		// Add common suffixes for single word terms.
 		$terms[] = $quoted_term . 's';
 
 		if ( 'y' === substr( $value->term, -1 ) ) {
@@ -167,11 +169,13 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		}
 	}
 
-	// Sort glossary entries with priority to multiple word terms and words with hyphens.
+	// Sort glossary entries by word count, to search first for multiple word terms, words with hyphens or both.
 	usort(
 		$glossary_entries_terms_array,
 		function( $a, $b ) {
-			return preg_match( '/[\s-]/', $b ) <=> preg_match( '/[\s-]/', $a );
+			$a_words = preg_split( '/[\s-]/', $a );
+			$b_words = preg_split( '/[\s-]/', $b );
+			return count( $b_words ) <=> count( $a_words );
 		}
 	);
 

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -86,6 +86,14 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 	foreach ( $glossary_entries as $key => $value ) {
 		$terms = array();
 
+		// Check if is multiple word term.
+		if ( preg_match( '/\s/', $value->term ) ) {
+
+			// Don't add similar terms to multiple word term.
+			$glossary_entries_terms[ $key ] = $value->term;
+			continue;
+		}
+
 		$quoted_term = preg_quote( $value->term, '/' );
 
 		$terms[] = $quoted_term;

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -233,7 +233,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 
 	// Add glossary terms to the plural if we have one.
 	if ( $translation->plural ) {
-		// Split the singular string on glossary terms boundaries.
+		// Split the plural string on glossary terms boundaries.
 		$plural_split    = preg_split( '/' . $terms_search . '/i', $translation->plural, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 		$plural_combined = '';
 

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -183,8 +183,8 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 	}
 	$terms_search = implode( '|', $terms_search );
 
-	// Split the singular string on word boundaries.
-	$singular_split    = preg_split( '/\b/', $translation->singular );
+	// Split the singular string on glossary terms boundaries.
+	$singular_split    = preg_split( '/' . $terms_search . '/i', $translation->singular, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 	$singular_combined = '';
 
 	// Loop through each chunk of the split to find glossary terms.
@@ -196,7 +196,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		$lower_chunk = strtolower( $chunk );
 
 		// Search the glossary terms for a matching entry.
-		if ( false !== array_search( $lower_chunk, $glossary_entries_terms_array, true ) ) {
+		if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {
 			$glossary_data = array();
 
 			// Add glossary data for each matching entry.
@@ -233,8 +233,8 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 
 	// Add glossary terms to the plural if we have one.
 	if ( $translation->plural ) {
-		// Split the plural string on word boundaries.
-		$plural_split    = preg_split( '/\b/', $translation->plural );
+		// Split the singular string on glossary terms boundaries.
+		$plural_split    = preg_split( '/' . $terms_search . '/i', $translation->plural, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 		$plural_combined = '';
 
 		// Loop through each chunk of the split to find glossary terms.
@@ -246,7 +246,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 			$lower_chunk = strtolower( $chunk );
 
 			// Search the glossary terms for a matching entry.
-			if ( false !== array_search( $lower_chunk, $glossary_entries_terms_array, true ) ) {
+			if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {
 				$glossary_data = array();
 
 				// Add glossary data for each matching entry.

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -105,10 +105,13 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ves';
 		} elseif ( 'fe' === substr( $value->term, -2 ) ) {
 			$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'ves';
+		} elseif ( 'e' === substr( $value->term, -1 ) ) {
+			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ed';
+			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ion';
+			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ing';
+		} elseif ( 'an' === substr( $value->term, -2 ) ) {
+			$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'en';
 		} else {
-			if ( 'an' === substr( $value->term, -2 ) ) {
-				$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'en';
-			}
 			$terms[] = $quoted_term . 'es';
 			$terms[] = $quoted_term . 'ed';
 			$terms[] = $quoted_term . 'ing';

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -167,6 +167,22 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		}
 	}
 
+	// Sort glossary entries with priority to multiple word terms.
+	usort(
+		$glossary_entries_terms_array,
+		function( $a, $b ) {
+			return preg_match( '/\s/', $b ) <=> preg_match( '/\s/', $a );
+		}
+	);
+
+	// Set terms search string.
+	$terms_search = array();
+	foreach ( $glossary_entries_terms_array as $term ) {
+		// Add word boundaries to search term.
+		$terms_search[] = '(\b' . $term . '\b)';
+	}
+	$terms_search = implode( '|', $terms_search );
+
 	// Split the singular string on word boundaries.
 	$singular_split    = preg_split( '/\b/', $translation->singular );
 	$singular_combined = '';

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -86,37 +86,38 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 	foreach ( $glossary_entries as $key => $value ) {
 		$terms = array();
 
-		$quoted_term = preg_quote( $value->term, '/' );
+		$term = $value->term;
 
 		// Check if is multiple word term.
-		if ( preg_match( '/\s/', $quoted_term ) ) {
+		if ( preg_match( '/\s/', $term ) ) {
 
 			// Don't add suffix to terms with multiple words.
-			$glossary_entries_terms[ $key ] = $quoted_term;
+			$glossary_entries_terms[ $key ] = $term;
 			continue;
 		}
 
-		$terms[] = $quoted_term;
+		// Add single word term.
+		$terms[] = $term;
 
 		// Add common suffixes for single word terms.
-		$terms[] = $quoted_term . 's';
+		$terms[] = $term . 's';
 
-		if ( 'y' === substr( $value->term, -1 ) ) {
-			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ies';
-		} elseif ( 'f' === substr( $value->term, -1 ) ) {
-			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ves';
-		} elseif ( 'fe' === substr( $value->term, -2 ) ) {
-			$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'ves';
-		} elseif ( 'e' === substr( $value->term, -1 ) ) {
-			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ed';
-			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ion';
-			$terms[] = preg_quote( substr( $value->term, 0, -1 ), '/' ) . 'ing';
-		} elseif ( 'an' === substr( $value->term, -2 ) ) {
-			$terms[] = preg_quote( substr( $value->term, 0, -2 ), '/' ) . 'en';
+		if ( 'y' === substr( $term, -1 ) ) {
+			$terms[] = substr( $term, 0, -1 ) . 'ies';
+		} elseif ( 'f' === substr( $term, -1 ) ) {
+			$terms[] = substr( $term, 0, -1 ) . 'ves';
+		} elseif ( 'fe' === substr( $term, -2 ) ) {
+			$terms[] = substr( $term, 0, -2 ) . 'ves';
+		} elseif ( 'e' === substr( $term, -1 ) ) {
+			$terms[] = substr( $term, 0, -1 ) . 'ed';
+			$terms[] = substr( $term, 0, -1 ) . 'ion';
+			$terms[] = substr( $term, 0, -1 ) . 'ing';
+		} elseif ( 'an' === substr( $term, -2 ) ) {
+			$terms[] = substr( $term, 0, -2 ) . 'en';
 		} else {
-			$terms[] = $quoted_term . 'es';
-			$terms[] = $quoted_term . 'ed';
-			$terms[] = $quoted_term . 'ing';
+			$terms[] = $term . 'es';
+			$terms[] = $term . 'ed';
+			$terms[] = $term . 'ing';
 		}
 
 		$glossary_entries_terms[ $key ] = implode( '|', $terms );
@@ -183,7 +184,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 	$terms_search = array();
 	foreach ( $glossary_entries_terms_array as $term ) {
 		// Add word boundaries to search term.
-		$terms_search[] = '(\b' . $term . '\b)';
+		$terms_search[] = '(\b' . preg_quote( $term, '/' ) . '\b)';
 	}
 	$terms_search = implode( '|', $terms_search );
 
@@ -197,7 +198,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		$escaped_chunk = esc_translation( $chunk );
 
 		// Create a lower case version to compare with the glossary terms.
-		$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
+		$lower_chunk = strtolower( $chunk );
 
 		// Search the glossary terms for a matching entry.
 		if ( in_array( $lower_chunk, $glossary_entries_terms_array, true ) ) {
@@ -247,7 +248,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 			$escaped_chunk = esc_translation( $chunk );
 
 			// Create a lower case version to compare with the glossary terms.
-			$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
+			$lower_chunk = strtolower( $chunk );
 
 			// Search the glossary terms for a matching entry.
 			if ( in_array( $lower_chunk, $glossary_entries_terms_array, true ) ) {

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -167,11 +167,11 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		}
 	}
 
-	// Sort glossary entries with priority to multiple word terms.
+	// Sort glossary entries with priority to multiple word terms and words with hyphens.
 	usort(
 		$glossary_entries_terms_array,
 		function( $a, $b ) {
-			return preg_match( '/\s/', $b ) <=> preg_match( '/\s/', $a );
+			return preg_match( '/[\s-]/', $b ) <=> preg_match( '/[\s-]/', $a );
 		}
 	);
 
@@ -193,7 +193,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		$escaped_chunk = esc_translation( $chunk );
 
 		// Create a lower case version to compare with the glossary terms.
-		$lower_chunk = strtolower( $chunk );
+		$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
 
 		// Search the glossary terms for a matching entry.
 		if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {
@@ -243,7 +243,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 			$escaped_chunk = esc_translation( $chunk );
 
 			// Create a lower case version to compare with the glossary terms.
-			$lower_chunk = strtolower( $chunk );
+			$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
 
 			// Search the glossary terms for a matching entry.
 			if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -27,11 +27,11 @@ function prepare_original( $text ) {
 		$text
 	);
 
-	// Wrap full HTML tags with a notranslate class
+	// Wrap full HTML tags with a notranslate class.
 	$text = preg_replace( '/(&lt;.+?&gt;)/', '<span class="notranslate">\\1</span>', $text );
-	// Break out & back into notranslate for translatable attributes
+	// Break out & back into notranslate for translatable attributes.
 	$text = preg_replace( '/(title|aria-label)=([\'"])([^\\2]+?)\\2/', '\\1=\\2</span>\\3<span class="notranslate">\\2', $text );
-	// Wrap placeholders with notranslate
+	// Wrap placeholders with notranslate.
 	$text = preg_replace( '/(%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX])/', '<span class="notranslate">\\1</span>', $text );
 
 	// Put the glossaries back!

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -86,15 +86,15 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 	foreach ( $glossary_entries as $key => $value ) {
 		$terms = array();
 
-		// Check if is multiple word term.
-		if ( preg_match( '/\s/', $value->term ) ) {
+		$quoted_term = preg_quote( $value->term, '/' );
 
-			// Don't add similar terms to multiple word term.
-			$glossary_entries_terms[ $key ] = $value->term;
+		// Check if is multiple word term.
+		if ( preg_match( '/\s/', $quoted_term ) ) {
+
+			// Don't add suffix to terms with multiple words.
+			$glossary_entries_terms[ $key ] = $quoted_term;
 			continue;
 		}
-
-		$quoted_term = preg_quote( $value->term, '/' );
 
 		$terms[] = $quoted_term;
 		$terms[] = $quoted_term . 's';

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -108,10 +108,6 @@ function gp_sort_glossary_entries_terms( $glossary_entries ) {
 			$terms[] = substr( $term, 0, -1 ) . 'ves';
 		} elseif ( 'fe' === substr( $term, -2 ) ) {
 			$terms[] = substr( $term, 0, -2 ) . 'ves';
-		} elseif ( 'e' === substr( $term, -1 ) ) {
-			$terms[] = substr( $term, 0, -1 ) . 'ed';
-			$terms[] = substr( $term, 0, -1 ) . 'ion';
-			$terms[] = substr( $term, 0, -1 ) . 'ing';
 		} elseif ( 'an' === substr( $term, -2 ) ) {
 			$terms[] = substr( $term, 0, -2 ) . 'en';
 		} else {

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -200,7 +200,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 		$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
 
 		// Search the glossary terms for a matching entry.
-		if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {
+		if ( in_array( $lower_chunk, $glossary_entries_terms_array, true ) ) {
 			$glossary_data = array();
 
 			// Add glossary data for each matching entry.
@@ -250,7 +250,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary,
 			$lower_chunk = strtolower( preg_quote( $chunk, '/' ) );
 
 			// Search the glossary terms for a matching entry.
-			if ( in_array( $lower_chunk, $glossary_entries_terms_array ) ) {
+			if ( in_array( $lower_chunk, $glossary_entries_terms_array, true ) ) {
 				$glossary_data = array();
 
 				// Add glossary data for each matching entry.

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -29,4 +29,128 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
 	}
 
+	/**
+	 * Expects matching a term with a space between words [color scheme].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_spaces_in_glossary() {
+		$test_string = 'Please set your favorite color scheme.';
+		$orig = '';
+		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">color scheme</span>.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'color scheme',
+			'part_of_speech' => 'noun',
+			'translation' => 'paleta de cores',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching a term with an hyphen [color-scheme].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_hyphens_in_glossary() {
+		$test_string = 'Please set your favorite color-scheme.';
+		$orig = '';
+		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">color-scheme</span>.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'color-scheme',
+			'part_of_speech' => 'noun',
+			'translation' => 'paleta de cores',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching a term with space and hyphen mixed [GlotPress WP-Team].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_spaces_and_hyphens_in_glossary() {
+		$test_string = 'Prowdly built by your GlotPress WP-Team.';
+		$orig = '';
+		$expected_result = 'Prowdly built by your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;Equipa-WP do GlotPress&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">GlotPress WP-Team</span>.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'GlotPress WP-Team',
+			'part_of_speech' => 'noun',
+			'translation' => 'Equipa-WP do GlotPress',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
+	/**
+	 * Expects matching the 3 words term [admin color scheme] instead of the 2 words term [color scheme] or single word term [admin].
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_word_count_priority_in_glossary() {
+		$test_string = 'Please set your admin color scheme.';
+		$orig = '';
+		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores da administração&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entries = array(
+			array(
+				'term' => 'admin',
+				'part_of_speech' => 'noun',
+				'translation' => 'administração',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'color scheme',
+				'part_of_speech' => 'noun',
+				'translation' => 'paleta de cores',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'admin color scheme',
+				'part_of_speech' => 'noun',
+				'translation' => 'paleta de cores da administração',
+				'glossary_id' => $glossary->id,
+			),
+		);
+
+		foreach ( $glossary_entries as $glossary_entry ) {
+			GP::$glossary_entry->create_and_select( $glossary_entry );
+		}
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+	}
+
 }

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -35,7 +35,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_spaces_in_glossary() {
 		$test_string = 'Please set your favorite color scheme.';
 		$orig = '';
-		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">color scheme</span>.';
+		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">color scheme</span>.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -47,7 +47,6 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'paleta de cores',
 			'glossary_id' => $glossary->id,
-			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -63,7 +62,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_hyphens_in_glossary() {
 		$test_string = 'Please set your favorite color-scheme.';
 		$orig = '';
-		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">color-scheme</span>.';
+		$expected_result = 'Please set your favorite <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">color-scheme</span>.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -75,7 +74,6 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'paleta de cores',
 			'glossary_id' => $glossary->id,
-			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -91,7 +89,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_spaces_and_hyphens_in_glossary() {
 		$test_string = 'Prowdly built by your GlotPress WP-Team.';
 		$orig = '';
-		$expected_result = 'Prowdly built by your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;Equipa-WP do GlotPress&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">GlotPress WP-Team</span>.';
+		$expected_result = 'Prowdly built by your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;Equipa-WP do GlotPress&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">GlotPress WP-Team</span>.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -103,7 +101,6 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'Equipa-WP do GlotPress',
 			'glossary_id' => $glossary->id,
-			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -119,7 +116,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_word_count_priority_in_glossary() {
 		$test_string = 'Please set your admin color scheme.';
 		$orig = '';
-		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores do administrador&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';
+		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores do administrador&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -132,21 +129,18 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 				'part_of_speech' => 'noun',
 				'translation' => 'administrador',
 				'glossary_id' => $glossary->id,
-				'comment' => '',
 			),
 			array(
 				'term' => 'color scheme',
 				'part_of_speech' => 'noun',
 				'translation' => 'paleta de cores',
 				'glossary_id' => $glossary->id,
-				'comment' => '',
 			),
 			array(
 				'term' => 'admin color scheme',
 				'part_of_speech' => 'noun',
 				'translation' => 'paleta de cores do administrador',
 				'glossary_id' => $glossary->id,
-				'comment' => '',
 			),
 		);
 

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -116,7 +116,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	function test_map_glossary_entries_to_translation_originals_with_word_count_priority_in_glossary() {
 		$test_string = 'Please set your admin color scheme.';
 		$orig = '';
-		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores da administração&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';
+		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores do administrador&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:&quot;&quot;,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';
 
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
@@ -127,7 +127,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			array(
 				'term' => 'admin',
 				'part_of_speech' => 'noun',
-				'translation' => 'administração',
+				'translation' => 'administrador',
 				'glossary_id' => $glossary->id,
 			),
 			array(
@@ -139,7 +139,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			array(
 				'term' => 'admin color scheme',
 				'part_of_speech' => 'noun',
-				'translation' => 'paleta de cores da administração',
+				'translation' => 'paleta de cores do administrador',
 				'glossary_id' => $glossary->id,
 			),
 		);

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -113,7 +113,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	/**
 	 * Expects matching the 3 words term [admin color scheme] instead of the 2 words term [color scheme] or single word term [admin].
 	 */
-	function test_map_glossary_entries_to_translation_originals_with_word_count_priority_in_glossary() {
+	function test_map_glossary_entries_to_translation_originals_with_word_count_priority() {
 		$test_string = 'Please set your admin color scheme.';
 		$orig = '';
 		$expected_result = 'Please set your <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;paleta de cores do administrador&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">admin color scheme</span>.';

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -47,6 +47,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'paleta de cores',
 			'glossary_id' => $glossary->id,
+			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -74,6 +75,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'paleta de cores',
 			'glossary_id' => $glossary->id,
+			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -101,6 +103,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 			'part_of_speech' => 'noun',
 			'translation' => 'Equipa-WP do GlotPress',
 			'glossary_id' => $glossary->id,
+			'comment' => '',
 		);
 
 		GP::$glossary_entry->create_and_select( $glossary_entry );
@@ -129,18 +132,21 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 				'part_of_speech' => 'noun',
 				'translation' => 'administrador',
 				'glossary_id' => $glossary->id,
+				'comment' => '',
 			),
 			array(
 				'term' => 'color scheme',
 				'part_of_speech' => 'noun',
 				'translation' => 'paleta de cores',
 				'glossary_id' => $glossary->id,
+				'comment' => '',
 			),
 			array(
 				'term' => 'admin color scheme',
 				'part_of_speech' => 'noun',
 				'translation' => 'paleta de cores do administrador',
 				'glossary_id' => $glossary->id,
+				'comment' => '',
 			),
 		);
 


### PR DESCRIPTION
Summary of the improvements:

- [x] Don't add suffixes to terms with **multiple words** (eg: `color scheme`) - https://github.com/GlotPress/GlotPress-WP/commit/98c4bf9043e45693f50a17bb02163e7a75172e59
- [-] ~Add suffixes for words ending with **e** (eg: `delet[ed]`, `delet[ion]`, `delet[ing]` ) - https://github.com/GlotPress/GlotPress-WP/commit/c6b7519b66a3f6ec3fbbf17983d5088e27e84895~ (reverted to add in another PR)
- [x] Sort by word count and alphabetically, to first search terms with **muiltiple words** and **words with hyphens** https://github.com/GlotPress/GlotPress-WP/commit/b7a1b948a9ac2d97113a1d4d4d06273c087ae138, https://github.com/GlotPress/GlotPress-WP/commit/cf5a8a4dd97fe4f9105636cf86dd2ed2d9cd4a25 and https://github.com/GlotPress/GlotPress-WP/pull/1359/commits/2e2b234cf2ce69f4c7f8402905ac39ebfa8ce4ab
  Search priorities:
  - Priority 1:
    - `admin color scheme`
  - Priority 2:
    - `admin color`
    - `color scheme`
    - `color-scheme`
  - Priority 3:
    - `color`
    - `scheme`

Fixes #1169 