### PR TITLE
Glossary: Add new validation methods to validate terms

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -448,6 +448,30 @@ function gp_is_one_of( $value, $list ) {
 }
 
 /**
+ * Checks if the passed value has only ASCII characters.
+ *
+ * @since 3.0.0
+ *
+ * @param string $value The value you want to check.
+ * @return bool
+ */
+function gp_is_ascii_string( $value ) {
+	return preg_replace( "/[^\x20-\x7E\p{L}]/", '', $value ) === $value;
+}
+
+/**
+ * Checks if the passed value starts and end with a word character.
+ *
+ * @since 3.0.0
+ *
+ * @param string $value The value you want to check.
+ * @return bool
+ */
+function gp_is_starting_or_ending_with_a_word_character( $value ) {
+	return (bool) preg_match( '/\b' . preg_quote( $value, '/' ) . '\b/i', $value );
+}
+
+/**
  * Acts the same as core PHP setcookie() but its arguments are run through the gp_set_cookie filter.
  *
  * If the filter returns false, setcookie() isn't called.

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -460,14 +460,14 @@ function gp_is_ascii_string( $value ) {
 }
 
 /**
- * Checks if the passed value starts and end with a word character.
+ * Checks if the passed value starts and ends with a word character.
  *
  * @since 3.0.0
  *
  * @param string $value The value you want to check.
  * @return bool
  */
-function gp_is_starting_or_ending_with_a_word_character( $value ) {
+function gp_is_starting_and_ending_with_a_word_character( $value ) {
 	return (bool) preg_match( '/\b' . preg_quote( $value, '/' ) . '\b/i', $value );
 }
 

--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -80,7 +80,7 @@ class GP_Glossary_Entry extends GP_Thing {
 	public function restrict_fields( $rules ) {
 		$rules->term_should_not_be( 'empty' );
 		$rules->term_should_be( 'consisting_only_of_ASCII_characters' );
-		$rules->term_should_be( 'starting_or_ending_with_a_word_character' );
+		$rules->term_should_be( 'starting_and_ending_with_a_word_character' );
 		$rules->part_of_speech_should_not_be( 'empty' );
 		$rules->part_of_speech_should_be( 'one_of', $this->parts_of_speech );
 		$rules->glossary_id_should_be( 'positive_int' );

--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -79,6 +79,8 @@ class GP_Glossary_Entry extends GP_Thing {
 	 */
 	public function restrict_fields( $rules ) {
 		$rules->term_should_not_be( 'empty' );
+		$rules->term_should_be( 'consisting_only_of_ASCII_characters' );
+		$rules->term_should_be( 'starting_or_ending_with_a_word_character' );
 		$rules->part_of_speech_should_not_be( 'empty' );
 		$rules->part_of_speech_should_be( 'one_of', $this->parts_of_speech );
 		$rules->glossary_id_should_be( 'positive_int' );

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -227,4 +227,4 @@ GP_Validators::register( 'between', 'gp_is_between' );
 GP_Validators::register( 'between_exclusive', 'gp_is_between_exclusive' );
 GP_Validators::register( 'one_of', 'gp_is_one_of' );
 GP_Validators::register( 'consisting_only_of_ASCII_characters', 'gp_is_ascii_string' );
-GP_Validators::register( 'starting_or_ending_with_a_word_character', 'gp_is_starting_or_ending_with_a_word_character' );
+GP_Validators::register( 'starting_and_ending_with_a_word_character', 'gp_is_starting_and_ending_with_a_word_character' );

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -226,3 +226,5 @@ GP_Validators::register( 'null', 'gp_is_null' );
 GP_Validators::register( 'between', 'gp_is_between' );
 GP_Validators::register( 'between_exclusive', 'gp_is_between_exclusive' );
 GP_Validators::register( 'one_of', 'gp_is_one_of' );
+GP_Validators::register( 'consisting_only_of_ASCII_characters', 'gp_is_ascii_string' );
+GP_Validators::register( 'starting_or_ending_with_a_word_character', 'gp_is_starting_or_ending_with_a_word_character' );

--- a/tests/phpunit/testcases/test_validation.php
+++ b/tests/phpunit/testcases/test_validation.php
@@ -76,8 +76,8 @@ class GP_Test_Validation extends GP_UnitTestCase {
 		$this->assertEquals( false, $f( 'ãbc' ) );
 	}
 
-	function test_is_starting_or_ending_with_a_word_character() {
-		$callback = GP_Validators::get( 'starting_or_ending_with_a_word_character' );
+	function test_is_starting_and_ending_with_a_word_character() {
+		$callback = GP_Validators::get( 'starting_and_ending_with_a_word_character' );
 		$f = $callback['positive'];
 		$this->assertEquals( true, $f( 'a' ) );
 		$this->assertEquals( true, $f( 'foo bar' ) );

--- a/tests/phpunit/testcases/test_validation.php
+++ b/tests/phpunit/testcases/test_validation.php
@@ -63,4 +63,27 @@ class GP_Test_Validation extends GP_UnitTestCase {
 		$this->assertEquals( true, $f( 3, array( 1, 2, 3 ) ) );
 		$this->assertEquals( false, $f( '1', array( 1, 2, 3 ) ) );
 	}
+
+	function test_is_ascii_string() {
+		$callback = GP_Validators::get( 'consisting_only_of_ASCII_characters' );
+		$f = $callback['positive'];
+		$this->assertEquals( true, $f( 'a' ) );
+		$this->assertEquals( true, $f( 'AbC' ) );
+		$this->assertEquals( true, $f( 'foo bar' ) );
+		$this->assertEquals( true, $f( '&' ) );
+		$this->assertEquals( true, $f( '123abc' ) );
+		$this->assertEquals( false, $f( 'äbc' ) );
+		$this->assertEquals( false, $f( 'ãbc' ) );
+	}
+
+	function test_is_starting_or_ending_with_a_word_character() {
+		$callback = GP_Validators::get( 'starting_or_ending_with_a_word_character' );
+		$f = $callback['positive'];
+		$this->assertEquals( true, $f( 'a' ) );
+		$this->assertEquals( true, $f( 'foo bar' ) );
+		$this->assertEquals( true, $f( 'a & b' ) );
+		$this->assertEquals( false, $f( 'a ' ) );
+		$this->assertEquals( false, $f( '-foo' ) );
+		$this->assertEquals( false, $f( 'Hello world.' ) );
+	}
 }


### PR DESCRIPTION
Fixes #1363.

Move the current check into two validation methods to get more helpful error messages:

* The field term is invalid and should be starting and ending with a word character!
* The field term is invalid and should be consisting only of ASCII characters!

Previous message: "Glossary terms cannot contain word break or multi-byte characters!"

Hide whitespace changes for easier review: https://github.com/GlotPress/GlotPress-WP/pull/1364/files?w=1