### PR TITLE
Speed improvement for gp_levenshtein().

### DIFF
--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -96,12 +96,13 @@ function gp_levenshtein( $str1, $str2, $length1, $length2 ) {
 		return 0;
 	}
 
-	$bytelength1 = strlen( $str1 );
-	$bytelength2 = strlen( $str2 );
+	if ( $length1 <= 255 && $length2 <= 255 ) {
+		$bytelength1 = strlen( $str1 );
+		$bytelength2 = strlen( $str2 );
 
-	if ( $bytelength1 === $length1 && $bytelength1 <= 255
-		 && $bytelength2 === $length2 && $bytelength2 <= 255 ) {
-		return levenshtein( $str1, $str2 );
+		if ( $bytelength1 === $length1 && $bytelength2 === $length2 ) {
+			return levenshtein( $str1, $str2 );
+		}
 	}
 
 	$chars1 = preg_split( '//u', $str1, null, PREG_SPLIT_NO_EMPTY );

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -104,13 +104,16 @@ function gp_levenshtein( $str1, $str2, $length1, $length2 ) {
 		return levenshtein( $str1, $str2 );
 	}
 
+	$chars1 = preg_split( '//u', $str1, null, PREG_SPLIT_NO_EMPTY );
+	$chars2 = preg_split( '//u', $str2, null, PREG_SPLIT_NO_EMPTY );
+
 	$prevRow = range( 0, $length2 );
 	for ( $i = 0; $i < $length1; $i++ ) {
 		$currentRow    = array();
 		$currentRow[0] = $i + 1;
-		$c1            = mb_substr( $str1, $i, 1 );
+		$c1            = $chars1[ $i ];
 		for ( $j = 0; $j < $length2; $j++ ) {
-			$c2            = mb_substr( $str2, $j, 1 );
+			$c2            = $chars2[ $j ];
 			$insertions    = $prevRow[ $j + 1 ] + 1;
 			$deletions     = $currentRow[ $j ] + 1;
 			$substitutions = $prevRow[ $j ] + ( ( $c1 != $c2 ) ? 1 : 0 );

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -105,8 +105,8 @@ function gp_levenshtein( $str1, $str2, $length1, $length2 ) {
 		}
 	}
 
-	$chars1 = preg_split( '//u', $str1, -1, PREG_SPLIT_NO_EMPTY );
-	$chars2 = preg_split( '//u', $str2, -1, PREG_SPLIT_NO_EMPTY );
+	$chars1 = mb_str_split( $str1 );
+	$chars2 = mb_str_split( $str2 );
 
 	$prevRow = range( 0, $length2 );
 	foreach ( $chars1 as $i => $c1 ) {

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -109,12 +109,10 @@ function gp_levenshtein( $str1, $str2, $length1, $length2 ) {
 	$chars2 = preg_split( '//u', $str2, null, PREG_SPLIT_NO_EMPTY );
 
 	$prevRow = range( 0, $length2 );
-	for ( $i = 0; $i < $length1; $i++ ) {
+	foreach ( $chars1 as $i => $c1 ) {
 		$currentRow    = array();
 		$currentRow[0] = $i + 1;
-		$c1            = $chars1[ $i ];
-		for ( $j = 0; $j < $length2; $j++ ) {
-			$c2            = $chars2[ $j ];
+		foreach ( $chars2 as $j => $c2 ) {
 			$insertions    = $prevRow[ $j + 1 ] + 1;
 			$deletions     = $currentRow[ $j ] + 1;
 			$substitutions = $prevRow[ $j ] + ( ( $c1 != $c2 ) ? 1 : 0 );

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -105,8 +105,8 @@ function gp_levenshtein( $str1, $str2, $length1, $length2 ) {
 		}
 	}
 
-	$chars1 = preg_split( '//u', $str1, null, PREG_SPLIT_NO_EMPTY );
-	$chars2 = preg_split( '//u', $str2, null, PREG_SPLIT_NO_EMPTY );
+	$chars1 = preg_split( '//u', $str1, -1, PREG_SPLIT_NO_EMPTY );
+	$chars2 = preg_split( '//u', $str2, -1, PREG_SPLIT_NO_EMPTY );
 
 	$prevRow = range( 0, $length2 );
 	foreach ( $chars1 as $i => $c1 ) {


### PR DESCRIPTION
gp_levenshtein():
 * Avoid the use of `mb_substr()` for significant speed improvements
 * Improve code readability; don't recalculate string length
 * Improve code readability; use a foreach loop rather than for + assignments

On longer strings (~500char) splitting these into an array before processing it character-by-character results in a 2x speed increase.

On my random WordPress.org page dataset, this results in a speed improvement of ~700ms ~= 310ms per call of `gp_string_similarity()`, which is basically just `gp_levenshtein()`.
Non-scientific measurement though, re-running a script with ~200 calls to gp_string_similarity() multiple times with changing the code back and forth.

Some of these changes are not strictly likely to be faster in all scenario's, but at least here seems that `foreach` is more efficient than `for` with an additional assignment here.

This was found by a `.po` import taking 100% CPU for several minutes, caused by a project having a significant number of obsoleted originals, most of which were long strings, so the C implementation wasn't being used.

Note: I also went looking for more optimized variants of this algorithm, there's probably something more that can be done by removing `gp_string_similarity()`'s percentage calculation and passing through the raw distance to future calls to abort early in the string if it's a long-way-away from the source string and a closer match has already been found.

The algorithm in use here is this: https://en.wikipedia.org/wiki/Levenshtein_distance#Iterative_with_two_matrix_rows