### PR TITLE
Update minimum required PHP version to 7.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '7.4', '7.3', '7.2' ]
+        php: [ '7.4' ]
         wordpress: [ 'latest', 'nightly' ]
         multisite: [ false ]
         coverage: [ false ]

--- a/glotpress.php
+++ b/glotpress.php
@@ -3,10 +3,10 @@
  * Plugin Name: GlotPress
  * Plugin URI: https://wordpress.org/plugins/glotpress/
  * Description: GlotPress is a tool to help translators collaborate.
- * Version: 3.1.0-alpha.0
+ * Version: 4.0.0-alpha.0
  * Requires at least: 4.6
  * Tested up to: 5.9
- * Requires PHP: 7.2
+ * Requires PHP: 7.4
  * Author: the GlotPress team
  * Author URI: https://glotpress.blog
  * License: GPLv2 or later
@@ -29,7 +29,7 @@
  * @package GlotPress
  */
 
-define( 'GP_VERSION', '3.1.0-alpha.0' );
+define( 'GP_VERSION', '4.0.0-alpha.0' );
 define( 'GP_DB_VERSION', '980' );
 define( 'GP_CACHE_VERSION', '3.0' );
 define( 'GP_ROUTING', true );
@@ -37,7 +37,7 @@ define( 'GP_PLUGIN_FILE', __FILE__ );
 define( 'GP_PATH', __DIR__ . '/' );
 define( 'GP_INC', 'gp-includes/' );
 define( 'GP_WP_REQUIRED_VERSION', '4.6' );
-define( 'GP_PHP_REQUIRED_VERSION', '7.2' );
+define( 'GP_PHP_REQUIRED_VERSION', '7.4' );
 
 /**
  * Displays an admin notice on the plugins page that GlotPress has been disabled and why..

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: A5hleyRich, akibjorklund, akirk, amieiro, atimmer, bradt, ChantalC
 Tags: translation
 Requires at least: 4.6
 Tested up to: 5.9
-Requires PHP: 7.2
+Requires PHP: 7.4
 Stable tag: 3.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Previously: #819, #1118

Also mentioned in #1357, PHP support should only be limited to PHP versions with [active security support](https://www.php.net/supported-versions.php).

Bumping the requirement will allow us to use `mb_str_split()` for #1408.