### PR TITLE
Adds a warning for added or removed spaces at the beginning or at the end of the translation

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -815,4 +815,56 @@ class GP_Builtin_Translation_Warnings {
 
 		return $error;
 	}
+
+	/**
+	 * Adds a warning for added or removed spaces at the beginning or at the end of the translation.
+	 *
+	 * @since 4.0.0
+	 * @access public
+	 *
+	 * @param string $original    The original string.
+	 * @param string $translation The translated string.
+	 *
+	 * @return string|true True if check is OK, otherwise warning message.
+	 */
+	public function warning_unexpected_start_end_space( string $original, string $translation ) {
+		$original_start_spaces    = strlen( $original ) - strlen( ltrim( $original, ' ' ) );
+		$original_end_spaces      = strlen( $original ) - strlen( rtrim( $original, ' ' ) );
+		$translation_start_spaces = strlen( $translation ) - strlen( ltrim( $translation, ' ' ) );
+		$translation_end_spaces   = strlen( $translation ) - strlen( rtrim( $translation, ' ' ) );
+
+		$warnings = array();
+		if ( ( $original_start_spaces ) && ( ! $translation_start_spaces ) ) {
+			$warnings[] = __( 'The translation appears to be missing one or more spaces at the beginning.', 'glotpress' );
+		}
+		if ( ( ! $original_start_spaces ) && $translation_start_spaces ) {
+			$warnings[] = __( 'The translation appears to be adding one or more spaces at the beginning.', 'glotpress' );
+		}
+		if ( ( $original_end_spaces ) && ( ! $translation_end_spaces ) ) {
+			$warnings[] = __( 'The translation appears to be missing one or more spaces at the end.', 'glotpress' );
+		}
+		if ( ! $original_end_spaces && $translation_end_spaces ) {
+			$warnings[] = __( 'The translation appears to be adding one or more spaces at the end.', 'glotpress' );
+		}
+		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces != $translation_start_spaces ) ) {
+			$warnings[] = sprintf(
+			/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
+				__( 'Expected %1$s space(s) at the beginning, got %2$s.', 'glotpress' ),
+				$original_start_spaces,
+				$translation_start_spaces
+			);
+		}
+		if ( $original_end_spaces && $translation_end_spaces && ( $original_end_spaces != $translation_end_spaces ) ) {
+			$warnings[] = sprintf(
+			/* translators: 1: Number of spaces at the end of the original string. 2: Number of spaces at the end of the translation string. */
+				__( 'Expected %1$s space(s) at the end, got %2$s.', 'glotpress' ),
+				$original_end_spaces,
+				$translation_end_spaces
+			);
+		}
+		if ( empty( $warnings ) ) {
+			return true;
+		}
+		return implode( "\n", $warnings );
+	}
 }

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -828,10 +828,17 @@ class GP_Builtin_Translation_Warnings {
 	 * @return string|true True if check is OK, otherwise warning message.
 	 */
 	public function warning_unexpected_start_end_space( string $original, string $translation ) {
-		$original_start_spaces    = mb_strlen( $original ) - mb_strlen( ltrim( $original, ' ' ) );
-		$original_end_spaces      = mb_strlen( $original ) - mb_strlen( rtrim( $original, ' ' ) );
-		$translation_start_spaces = mb_strlen( $translation ) - mb_strlen( ltrim( $translation, ' ' ) );
-		$translation_end_spaces   = mb_strlen( $translation ) - mb_strlen( rtrim( $translation, ' ' ) );
+		preg_match( '/^( *)/D', $original, $m );
+		$original_start_spaces = strlen( $m[0] );
+
+		preg_match( '/^( *)/D', $translation, $m );
+		$translation_start_spaces = strlen( $m[0] );
+
+		preg_match( '/( *)$/D', $original, $m );
+		$original_end_spaces = strlen( $m[0] );
+
+		preg_match( '/( *)$/D', $translation, $m );
+		$translation_end_spaces = strlen( $m[0] );
 
 		$warnings = array();
 		if ( $original_start_spaces && ! $translation_start_spaces ) {

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -848,7 +848,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces != $translation_start_spaces ) ) {
 			$warnings[] = sprintf(
-			/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
+				/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
 				__( 'Expected %1$s space(s) at the beginning, got %2$s.', 'glotpress' ),
 				$original_start_spaces,
 				$translation_start_spaces

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -834,7 +834,7 @@ class GP_Builtin_Translation_Warnings {
 		$translation_end_spaces   = strlen( $translation ) - strlen( rtrim( $translation, ' ' ) );
 
 		$warnings = array();
-		if ( ( $original_start_spaces ) && ( ! $translation_start_spaces ) ) {
+		if ( $original_start_spaces && ! $translation_start_spaces ) {
 			$warnings[] = __( 'The translation appears to be missing one or more spaces at the beginning.', 'glotpress' );
 		}
 		if ( ( ! $original_start_spaces ) && $translation_start_spaces ) {

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -828,10 +828,10 @@ class GP_Builtin_Translation_Warnings {
 	 * @return string|true True if check is OK, otherwise warning message.
 	 */
 	public function warning_unexpected_start_end_space( string $original, string $translation ) {
-		$original_start_spaces    = strlen( $original ) - strlen( ltrim( $original, ' ' ) );
-		$original_end_spaces      = strlen( $original ) - strlen( rtrim( $original, ' ' ) );
-		$translation_start_spaces = strlen( $translation ) - strlen( ltrim( $translation, ' ' ) );
-		$translation_end_spaces   = strlen( $translation ) - strlen( rtrim( $translation, ' ' ) );
+		$original_start_spaces    = mb_strlen( $original ) - mb_strlen( ltrim( $original, ' ' ) );
+		$original_end_spaces      = mb_strlen( $original ) - mb_strlen( rtrim( $original, ' ' ) );
+		$translation_start_spaces = mb_strlen( $translation ) - mb_strlen( ltrim( $translation, ' ' ) );
+		$translation_end_spaces   = mb_strlen( $translation ) - mb_strlen( rtrim( $translation, ' ' ) );
 
 		$warnings = array();
 		if ( $original_start_spaces && ! $translation_start_spaces ) {
@@ -846,7 +846,7 @@ class GP_Builtin_Translation_Warnings {
 		if ( ! $original_end_spaces && $translation_end_spaces ) {
 			$warnings[] = __( 'The translation appears to be adding one or more spaces at the end.', 'glotpress' );
 		}
-		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces != $translation_start_spaces ) ) {
+		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces !== $translation_start_spaces ) ) {
 			$warnings[] = sprintf(
 				/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
 				__( 'Expected %1$s space(s) at the beginning, got %2$s.', 'glotpress' ),
@@ -854,7 +854,7 @@ class GP_Builtin_Translation_Warnings {
 				$translation_start_spaces
 			);
 		}
-		if ( $original_end_spaces && $translation_end_spaces && ( $original_end_spaces != $translation_end_spaces ) ) {
+		if ( $original_end_spaces && $translation_end_spaces && ( $original_end_spaces !== $translation_end_spaces ) ) {
 			$warnings[] = sprintf(
 			/* translators: 1: Number of spaces at the end of the original string. 2: Number of spaces at the end of the translation string. */
 				__( 'Expected %1$s space(s) at the end, got %2$s.', 'glotpress' ),

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -184,7 +184,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$warnings = $this->getMockBuilder( 'GP_Translation_Warnings' )->getMock();
 		// we check for the number of warnings, because PHPUnit doesn't allow
 		// us to check if each argument is a callable
-		$warnings->expects( $this->exactly( 10 ) )->method( 'add' )->will( $this->returnValue( true ) );
+		$warnings->expects( $this->exactly( 11 ) )->method( 'add' )->will( $this->returnValue( true ) );
 		$this->w->add_all( $warnings );
 	}
 
@@ -662,6 +662,53 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		);
 	}
 
+	public function test_unexpected_start_end_space() {
+		$this->assertNoWarnings( 'unexpected_start_end_space', 'Original string', 'Cadea traducida' );
+		$this->assertNoWarnings( 'unexpected_start_end_space', ' Original string', ' Cadea traducida' );
+		$this->assertNoWarnings( 'unexpected_start_end_space', 'Original string ', 'Cadea traducida ' );
+		$this->assertNoWarnings( 'unexpected_start_end_space', ' Original string ', ' Cadea traducida ' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			' Original string',
+			'Cadea traducida',
+			'The translation appears to be missing one or more spaces at the beginning.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'Original string',
+			' Cadea traducida',
+			'The translation appears to be adding one or more spaces at the beginning.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'Original string ',
+			'Cadea traducida',
+			'The translation appears to be missing one or more spaces at the end.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'Original string',
+			'Cadea traducida ',
+			'The translation appears to be adding one or more spaces at the end.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			' Original string',
+			'   Cadea traducida',
+			'Expected 1 space(s) at the beginning, got 3.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'   Original string',
+			' Cadea traducida',
+			'Expected 3 space(s) at the beginning, got 1.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'Original string ',
+			'Cadea traducida   ',
+			'Expected 1 space(s) at the end, got 3.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'Original string   ',
+			'Cadea traducida ',
+			'Expected 3 space(s) at the end, got 1.' );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			'   Original string   ',
+			' Cadea traducida ',
+			"Expected 3 space(s) at the beginning, got 1.\nExpected 3 space(s) at the end, got 1." );
+		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
+			' Original string ',
+			'   Cadea traducida   ',
+			"Expected 1 space(s) at the beginning, got 3.\nExpected 1 space(s) at the end, got 3." );
+	}
+
 	public function test_chained_warnings() {
 		$this->tw = new GP_Translation_Warnings();
 		$this->w  = new GP_Builtin_Translation_Warnings();
@@ -842,6 +889,30 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 					'should_not_end_on_newline'   => 'Translation should not end on newline.',
 					'should_not_begin_on_newline' => 'Translation should not begin on newline.',
 					'placeholders'                => 'Extra %% placeholder in translation.',
+				),
+			)
+		);
+		$this->assertContainsOutput(
+			' <p><a href="%s">100 percent</a></p>',
+			null,
+			array( "<a href=\"%s\">100%%</a> " ),
+			array(
+				array(
+					'tags'                        => 'Missing tags from translation. Expected: <p> </p>',
+					'placeholders'                => 'Extra %% placeholder in translation.',
+					'unexpected_start_end_space'  => "The translation appears to be missing one or more spaces at the beginning.\nThe translation appears to be adding one or more spaces at the end."
+				),
+			)
+		);
+		$this->assertContainsOutput(
+			'    <p><a href="%s">100 percent</a></p> ',
+			null,
+			array( " <a href=\"%s\">100%%</a>     " ),
+			array(
+				array(
+					'tags'                        => 'Missing tags from translation. Expected: <p> </p>',
+					'placeholders'                => 'Extra %% placeholder in translation.',
+					'unexpected_start_end_space'  => "Expected 4 space(s) at the beginning, got 1.\nExpected 1 space(s) at the end, got 5."
 				),
 			)
 		);


### PR DESCRIPTION
It is very usual that some strings to translate have empty spaces at their beginning or at the end. 
The translators don't see if their translations have these empty spaces.

This PR adds some checks to warn the translators about these missing or unexpected spaces in their translations.

![image](https://user-images.githubusercontent.com/1667814/166879270-74b6707b-065d-4341-8860-0bb22a784eed.png)

![image](https://user-images.githubusercontent.com/1667814/166879468-b453dc9c-9e19-4d7c-9756-5df8f4bf96e9.png)

![image](https://user-images.githubusercontent.com/1667814/166879687-0d026666-0c38-40f6-8b02-21afb1e95ce7.png)
