### PR TITLE
1423: Add "Last Modified" column to Glossary

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -671,6 +671,14 @@ table.glossary .gp-column-comments {
 	width: 30%;
 }
 
+table.glossary .gp-column-modified {
+	width: 10%;
+}
+
+table.glossary td.date-modified {
+	white-space: nowrap;
+}
+
 table.permissions .gp-column-actions,
 table.glossary .gp-column-actions,
 table.translations .gp-column-actions {

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -13,7 +13,7 @@
 	$date_modified           = strtotime( $entry->date_modified );
 	$date_modified_formatted = sprintf(
 		/* translators: 1: Modified date. 2: Modified time. */
-		esc_html__( '%1$s at %2$s', 'glotpress' ),
+		__( '%1$s at %2$s', 'glotpress' ),
 		wp_date( get_option( 'date_format' ), $date_modified ),
 		wp_date( get_option( 'time_format' ), $date_modified )
 	);

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -9,6 +9,16 @@
 		echo make_clickable( nl2br( esc_html( $entry->comment ) ) );
 		?>
 	</td>
+	<td class="date-modified" data-text="<?php echo esc_attr( $entry->date_modified ); ?>">
+		<?php
+		printf(
+			/* translators: 1: Modified date. 2: Modified time. */
+			esc_html__( '%1$s at %2$s', 'glotpress' ),
+			date_i18n( get_option( 'date_format' ), strtotime( $entry->date_modified ) ),
+			date_i18n( get_option( 'time_format' ), strtotime( $entry->date_modified ) )
+		);
+		?>
+	</td>
 
 	<?php if ( $can_edit ) : ?>
 		<td class="actions">
@@ -17,7 +27,7 @@
 	<?php endif; ?>
 </tr>
 <tr id="editor-<?php echo esc_attr( $entry->id ); ?>" class="hide-if-js editor">
-	<td colspan="5">
+	<td colspan="6">
 		<div class="strings">
 			<dl>
 				<dt><label for="glossary_entry_term_<?php echo esc_attr( $entry->id ); ?>"><?php _ex( 'Original term:', 'glossary entry', 'glotpress' ); ?></label></dt>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -14,8 +14,8 @@
 		printf(
 			/* translators: 1: Modified date. 2: Modified time. */
 			esc_html__( '%1$s at %2$s', 'glotpress' ),
-			date_i18n( get_option( 'date_format' ), strtotime( $entry->date_modified ) ),
-			date_i18n( get_option( 'time_format' ), strtotime( $entry->date_modified ) )
+			date_i18n( get_option( 'date_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) ),
+			date_i18n( get_option( 'time_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) )
 		);
 		?>
 	</td>
@@ -64,8 +64,8 @@
 					printf(
 						/* translators: 1: Modified date. 2: Modified time. */
 						esc_html__( '%1$s at %2$s', 'glotpress' ),
-						date_i18n( get_option( 'date_format' ), strtotime( $entry->date_modified ) ),
-						date_i18n( get_option( 'time_format' ), strtotime( $entry->date_modified ) )
+						date_i18n( get_option( 'date_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) ),
+						date_i18n( get_option( 'time_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) )
 					);
 					?>
 				</dd>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -61,7 +61,7 @@
 			<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
 			<dl>
 				<dt><?php _e( 'Last Modified:', 'glotpress' ); ?></dt>
-				<dd><?php echo esc_html( $date_modified_formated ); ?></dd>
+				<dd><?php echo esc_html( $date_modified_formatted ); ?></dd>
 			</dl>
 			<?php if ( $entry->user_login ) : ?>
 			<dl>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -61,9 +61,7 @@
 			<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
 			<dl>
 				<dt><?php _e( 'Last Modified:', 'glotpress' ); ?></dt>
-				<dd>
-					<?php echo esc_html( $date_modified_formated ); ?>
-				</dd>
+				<dd><?php echo esc_html( $date_modified_formated ); ?></dd>
 			</dl>
 			<?php if ( $entry->user_login ) : ?>
 			<dl>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -59,7 +59,16 @@
 			<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
 			<dl>
 				<dt><?php _e( 'Last Modified:', 'glotpress' ); ?></dt>
-				<dd><?php echo esc_html( $entry->date_modified ); ?></dd>
+				<dd>
+					<?php
+					printf(
+						/* translators: 1: Modified date. 2: Modified time. */
+						esc_html__( '%1$s at %2$s', 'glotpress' ),
+						date_i18n( get_option( 'date_format' ), strtotime( $entry->date_modified ) ),
+						date_i18n( get_option( 'time_format' ), strtotime( $entry->date_modified ) )
+					);
+					?>
+				</dd>
 			</dl>
 			<?php if ( $entry->user_login ) : ?>
 			<dl>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -10,8 +10,8 @@
 		?>
 	</td>
 	<?php
-	$date_modified          = strtotime( get_date_from_gmt( $entry->date_modified ) );
-	$date_modified_formated = sprintf(
+	$date_modified           = strtotime( $entry->date_modified );
+	$date_modified_formatted = sprintf(
 		/* translators: 1: Modified date. 2: Modified time. */
 		esc_html__( '%1$s at %2$s', 'glotpress' ),
 		date_i18n( get_option( 'date_format' ), $date_modified ),

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -9,15 +9,17 @@
 		echo make_clickable( nl2br( esc_html( $entry->comment ) ) );
 		?>
 	</td>
-	<td class="date-modified" data-text="<?php echo esc_attr( $entry->date_modified ); ?>">
-		<?php
-		printf(
-			/* translators: 1: Modified date. 2: Modified time. */
-			esc_html__( '%1$s at %2$s', 'glotpress' ),
-			date_i18n( get_option( 'date_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) ),
-			date_i18n( get_option( 'time_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) )
-		);
-		?>
+	<?php
+	$date_modified          = strtotime( get_date_from_gmt( $entry->date_modified ) );
+	$date_modified_formated = sprintf(
+		/* translators: 1: Modified date. 2: Modified time. */
+		esc_html__( '%1$s at %2$s', 'glotpress' ),
+		date_i18n( get_option( 'date_format' ), $date_modified ),
+		date_i18n( get_option( 'time_format' ), $date_modified )
+	);
+	?>
+	<td class="date-modified" data-text="<?php echo esc_attr( $date_modified ); ?>">
+		<?php echo esc_html( $date_modified_formated ); ?>
 	</td>
 
 	<?php if ( $can_edit ) : ?>
@@ -60,14 +62,7 @@
 			<dl>
 				<dt><?php _e( 'Last Modified:', 'glotpress' ); ?></dt>
 				<dd>
-					<?php
-					printf(
-						/* translators: 1: Modified date. 2: Modified time. */
-						esc_html__( '%1$s at %2$s', 'glotpress' ),
-						date_i18n( get_option( 'date_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) ),
-						date_i18n( get_option( 'time_format' ), strtotime( get_date_from_gmt( $entry->date_modified ) ) )
-					);
-					?>
+					<?php echo esc_html( $date_modified_formated ); ?>
 				</dd>
 			</dl>
 			<?php if ( $entry->user_login ) : ?>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -19,7 +19,7 @@
 	);
 	?>
 	<td class="date-modified" data-text="<?php echo esc_attr( $date_modified ); ?>">
-		<?php echo esc_html( $date_modified_formated ); ?>
+		<?php echo esc_html( $date_modified_formatted ); ?>
 	</td>
 
 	<?php if ( $can_edit ) : ?>

--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -14,8 +14,8 @@
 	$date_modified_formatted = sprintf(
 		/* translators: 1: Modified date. 2: Modified time. */
 		esc_html__( '%1$s at %2$s', 'glotpress' ),
-		date_i18n( get_option( 'date_format' ), $date_modified ),
-		date_i18n( get_option( 'time_format' ), $date_modified )
+		wp_date( get_option( 'date_format' ), $date_modified ),
+		wp_date( get_option( 'time_format' ), $date_modified )
 	);
 	?>
 	<td class="date-modified" data-text="<?php echo esc_attr( $date_modified ); ?>">

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -65,6 +65,7 @@ if ( $glossary_description ) {
 			<th class="gp-column-part-of-speech"><?php _ex( 'Part of speech', 'glossary entry', 'glotpress' ); ?></th>
 			<th class="gp-column-translation"><?php _ex( 'Translation', 'glossary entry', 'glotpress' ); ?></th>
 			<th class="gp-column-comments"><?php _ex( 'Comments', 'glossary entry', 'glotpress' ); ?></th>
+			<th class="gp-column-modified" data-sorter="text"><?php _ex( 'Last Modified', 'glossary entry', 'glotpress' ); ?></th>
 			<?php if ( $can_edit ) : ?>
 				<th class="gp-column-actions">&mdash;</th>
 			<?php endif; ?>
@@ -79,7 +80,7 @@ if ( $glossary_description ) {
 	} else {
 		?>
 		<tr>
-			<td colspan="5">
+			<td colspan="6">
 				<?php _e( 'No glossary entries yet.', 'glotpress' ); ?>
 			</td>
 		</tr>


### PR DESCRIPTION
This PR already includes the `data-sorter` for tablesorter added on https://github.com/GlotPress/GlotPress/pull/1426

- [x] Add **Last Modified** column to Glossary
- [x] Add `data-sorter` to column to set as sorteable
- [x] Add timestamp `data-text` to row data to sort alphabetically
- [x] Format data and time both in row and editor
- [x] Fix timezone offset

Fixes #1423 