### PR TITLE
Add a template for the PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to GlotPress?
+_Put an `x` in the boxes that apply_:
+
+- [ ] Bugfix.
+- [ ] New feature.
+- [ ] Code style update (formatting, renaming).
+- [ ] Refactoring (no functional changes, no API changes).
+- [ ] Documentation update.
+- [ ] Other change (please, describe):
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have created and issue explaining the problem (put the link to the issue here).
+- [ ] I have read the [contribution](https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md) guide.
+- [ ] The pull request is small, so it can be easily reviewed.
+- [ ] I have added the documentation to the methods and another relevant pieces of the code.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] Lint and unit tests pass locally with my changes.
+- [ ] I have added necessary documentation (if appropriate).
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,19 @@
-## Proposed changes
+<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
+https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+## What?
+<!-- In a few words, what is the PR actually doing? -->
 
-## Types of changes
+## Why?
+<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 
-What types of changes does your code introduce to GlotPress?
-_Put an `x` in the boxes that apply_:
+## How?
+<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
 
-- [ ] Bugfix.
-- [ ] New feature.
-- [ ] Code style update (formatting, renaming).
-- [ ] Refactoring (no functional changes, no API changes).
-- [ ] Documentation update.
-- [ ] Other change (please, describe):
+## Testing Instructions
+<!-- Please include step-by-step instructions on how to test this PR. -->
+<!-- 1. Open a original string in a project. -->
+<!-- 2. Add the translation. -->
+<!-- 3. etc. -->
 
-## Checklist
-
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-
-- [ ] I have created and issue explaining the problem (put the link to the issue here).
-- [ ] I have read the [contribution](https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md) guide.
-- [ ] The pull request is small, so it can be easily reviewed.
-- [ ] I have added the documentation to the methods and another relevant pieces of the code.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] Lint and unit tests pass locally with my changes.
-- [ ] I have added necessary documentation (if appropriate).
-
-## Further comments
-
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+## Screenshots or screencast <!-- if applicable -->


### PR DESCRIPTION
This PR adds a template for the PR, so the person who sends the PR has to explain a few details around the PR, and the maintainer will have more information to review it.

More info about template PR on GitHub can be found [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).