### PR TITLE
Added sort by string length

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -671,6 +671,10 @@ function gp_get_sort_by_fields() {
 			'title'       => __( 'Filename in source', 'glotpress' ),
 			'sql_sort_by' => 'o.references',
 		),
+		'length'                => array(
+			'title'       => __( 'String length', 'glotpress' ),
+			'sql_sort_by' => 'LENGTH(o.singular) %s',
+		),
 		'random'                    => array(
 			'title'       => __( 'Random', 'glotpress' ),
 			'sql_sort_by' => 'o.priority DESC, RAND()',

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -671,8 +671,8 @@ function gp_get_sort_by_fields() {
 			'title'       => __( 'Filename in source', 'glotpress' ),
 			'sql_sort_by' => 'o.references',
 		),
-		'length'                => array(
-			'title'       => __( 'String length', 'glotpress' ),
+		'length'                    => array(
+			'title'       => __( 'Original length', 'glotpress' ),
 			'sql_sort_by' => 'LENGTH(o.singular) %s',
 		),
 		'random'                    => array(


### PR DESCRIPTION
During the translation process, the string length can be very important. Sometimes it's easier to translate rather long strings as the reference is less important and the string stands for itself. In other times, short strings are easier, at least to progress quickly.

Last but not least, sorting by string length allows to locate too short or malformed translations like " and " more quickly.

This PR just adds the sort by string property.