### PR TITLE
Fixes deprecation notice in PHP8 for usort returning bool

### DIFF
--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -169,6 +169,6 @@ class GP_Route_Locale extends GP_Route_Main {
 	}
 
 	private function sort_sets_by_project_id( $a, $b ) {
-		return $a->project_id > $b->project_id;
+		return $a->project_id <=> $b->project_id;
 	}
 }

--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -165,7 +165,7 @@ class GP_Route_Locale extends GP_Route_Main {
 	}
 
 	private function sort_locales( $a, $b ) {
-		return $a->english_name > $b->english_name;
+		return $a->english_name <=> $b->english_name;
 	}
 
 	private function sort_sets_by_project_id( $a, $b ) {

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -49,7 +49,7 @@ class GP_Route_Project extends GP_Route_Main {
 		usort(
 			$translation_sets,
 			function( $a, $b ) {
-				return( $a->current_count < $b->current_count );
+				return( $a->current_count <=> $b->current_count );
 			}
 		);
 


### PR DESCRIPTION
Fixes https://github.com/GlotPress/GlotPress/issues/1463

https://lindevs.com/sort-comparison-functions-that-return-boolean-value-is-deprecated-in-php-8-0/