### PR TITLE
Add the alphabet for each locale

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -16,6 +16,7 @@ class GP_Locale {
 	public $google_code = null;
 	public $preferred_sans_serif_font_family = null;
 	public $facebook_locale = null;
+	public $alphabet = 'latin';
 
 	/**
 	 *
@@ -132,6 +133,7 @@ class GP_Locales {
 		$ae->lang_code_iso_639_1 = 'ae';
 		$ae->lang_code_iso_639_2 = 'ave';
 		$ae->slug = 'ae';
+		$ae->alphabet = 'avestan';
 
 		$af = new GP_Locale();
 		$af->english_name = 'Afrikaans';
@@ -151,6 +153,7 @@ class GP_Locales {
 		$ak->lang_code_iso_639_2 = 'aka';
 		$ak->slug = 'ak';
 		$ak->facebook_locale = 'ak_GH';
+		$ak->alphabet = 'adinkra';
 
 		$am = new GP_Locale();
 		$am->english_name = 'Amharic';
@@ -161,6 +164,7 @@ class GP_Locales {
 		$am->wp_locale = 'am';
 		$am->slug = 'am';
 		$am->facebook_locale = 'am_ET';
+		$am->alphabet = 'geez';
 
 		$an = new GP_Locale();
 		$an->english_name = 'Aragonese';
@@ -185,6 +189,7 @@ class GP_Locales {
 		$ar->preferred_sans_serif_font_family = 'Tahoma';
 		$ar->google_code = 'ar';
 		$ar->facebook_locale = 'ar_AR';
+		$ar->alphabet = 'arabic';
 
 		$arq = new GP_Locale();
 		$arq->english_name = 'Algerian Arabic';
@@ -197,6 +202,7 @@ class GP_Locales {
 		$arq->nplurals = 6;
 		$arq->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))))';
 		$arq->text_direction = 'rtl';
+		$arq->alphabet = 'arabic';
 
 		$ary = new GP_Locale();
 		$ary->english_name = 'Moroccan Arabic';
@@ -209,6 +215,7 @@ class GP_Locales {
 		$ary->nplurals = 6;
 		$ary->plural_expression = '(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))))';
 		$ary->text_direction = 'rtl';
+		$ary->alphabet = 'arabic';
 
 		$as = new GP_Locale();
 		$as->english_name = 'Assamese';
@@ -220,6 +227,7 @@ class GP_Locales {
 		$as->wp_locale = 'as';
 		$as->slug = 'as';
 		$as->facebook_locale = 'as_IN';
+		$as->alphabet = 'assamese';
 
 		$ast = new GP_Locale();
 		$ast->english_name = 'Asturian';
@@ -236,6 +244,7 @@ class GP_Locales {
 		$av->lang_code_iso_639_1 = 'av';
 		$av->lang_code_iso_639_2 = 'ava';
 		$av->slug = 'av';
+		$av->alphabet = 'cyrillic';
 
 		$ay = new GP_Locale();
 		$ay->english_name = 'Aymara';
@@ -268,6 +277,7 @@ class GP_Locales {
 		$azb->wp_locale = 'azb';
 		$azb->slug = 'azb';
 		$azb->text_direction = 'rtl';
+		$azb->alphabet = 'persian';
 
 		$az_tr = new GP_Locale();
 		$az_tr->english_name = 'Azerbaijani (Turkey)';
@@ -285,6 +295,7 @@ class GP_Locales {
 		$ba->lang_code_iso_639_2 = 'bak';
 		$ba->wp_locale = 'ba';
 		$ba->slug = 'ba';
+		$ba->alphabet = 'cyrillic';
 
 		$bal = new GP_Locale();
 		$bal->english_name = 'Catalan (Balear)';
@@ -304,6 +315,7 @@ class GP_Locales {
 		$bcc->nplurals = 1;
 		$bcc->plural_expression = '0';
 		$bcc->text_direction = 'rtl';
+		$bcc->alphabet = 'balochi';
 
 		$be = new GP_Locale();
 		$be->english_name = 'Belarusian';
@@ -317,6 +329,7 @@ class GP_Locales {
 		$be->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$be->google_code = 'be';
 		$be->facebook_locale = 'be_BY';
+		$be->alphabet = 'cyrillic';
 
 		$bg = new GP_Locale();
 		$bg->english_name = 'Bulgarian';
@@ -328,6 +341,7 @@ class GP_Locales {
 		$bg->slug = 'bg';
 		$bg->google_code = 'bg';
 		$bg->facebook_locale = 'bg_BG';
+		$bg->alphabet = 'cyrillic';
 
 		$bgn = new GP_Locale();
 		$bgn->english_name = 'Western Balochi';
@@ -337,6 +351,7 @@ class GP_Locales {
 		$bgn->wp_locale = 'bgn';
 		$bgn->slug = 'bgn';
 		$bgn->text_direction = 'rtl';
+		$bgn->alphabet = 'balochi';
 
 		$bh = new GP_Locale();
 		$bh->english_name = 'Bihari';
@@ -344,6 +359,7 @@ class GP_Locales {
 		$bh->lang_code_iso_639_1 = 'bh';
 		$bh->lang_code_iso_639_2 = 'bih';
 		$bh->slug = 'bh';
+		$bh->alphabet = 'devanagari';
 
 		$bho = new GP_Locale();
 		$bho->english_name = 'Bhojpuri';
@@ -352,6 +368,7 @@ class GP_Locales {
 		$bho->country_code = 'in';
 		$bho->wp_locale = 'bho';
 		$bho->slug = 'bho';
+		$bho->alphabet = 'devanagari';
 
 		$bi = new GP_Locale();
 		$bi->english_name = 'Bislama';
@@ -376,6 +393,7 @@ class GP_Locales {
 		$bn_bd->wp_locale = 'bn_BD';
 		$bn_bd->slug = 'bn';
 		$bn_bd->google_code = 'bn';
+		$bn_bd->alphabet  ='bengali';
 
 		$bn_in = new GP_Locale();
 		$bn_in->english_name = 'Bengali (India)';
@@ -388,6 +406,7 @@ class GP_Locales {
 		$bn_in->facebook_locale = 'bn_IN';
 		$bn_in->nplurals = 2;
 		$bn_in->plural_expression = 'n > 1';
+		$bn_in->alphabet  ='bengali';
 
 		$bo = new GP_Locale();
 		$bo->english_name = 'Tibetan';
@@ -398,6 +417,7 @@ class GP_Locales {
 		$bo->slug = 'bo';
 		$bo->nplurals = 1;
 		$bo->plural_expression = '0';
+		$bo->alphabet = 'tibetan';
 
 		$br = new GP_Locale();
 		$br->english_name = 'Breton';
@@ -419,6 +439,7 @@ class GP_Locales {
 		$brx->country_code = 'in';
 		$brx->wp_locale = 'brx';
 		$brx->slug = 'brx';
+		$brx->alphabet = 'devanagari';
 
 		$bs = new GP_Locale();
 		$bs->english_name = 'Bosnian';
@@ -459,6 +480,7 @@ class GP_Locales {
 		$ce->lang_code_iso_639_1 = 'ce';
 		$ce->lang_code_iso_639_2 = 'che';
 		$ce->slug = 'ce';
+		$ce->alphabet = 'cyrillic';
 
 		$ceb = new GP_Locale();
 		$ceb->english_name = 'Cebuano';
@@ -487,6 +509,7 @@ class GP_Locales {
 		$ckb->slug = 'ckb';
 		$ckb->text_direction = 'rtl';
 		$ckb->facebook_locale = 'cb_IQ';
+		$ckb->alphabet = 'sorani';
 
 		$co = new GP_Locale();
 		$co->english_name = 'Corsican';
@@ -516,6 +539,7 @@ class GP_Locales {
 		$cr->lang_code_iso_639_2 = 'cre';
 		$cr->country_code = 'ca';
 		$cr->slug = 'cr';
+		$cr->alphabet = 'syllabics';
 
 		$cs = new GP_Locale();
 		$cs->english_name = 'Czech';
@@ -544,6 +568,7 @@ class GP_Locales {
 		$cu->lang_code_iso_639_1 = 'cu';
 		$cu->lang_code_iso_639_2 = 'chu';
 		$cu->slug = 'cu';
+		$cu->alphabet = 'cyrillic';
 
 		$cv = new GP_Locale();
 		$cv->english_name = 'Chuvash';
@@ -552,6 +577,7 @@ class GP_Locales {
 		$cv->lang_code_iso_639_2 = 'chv';
 		$cv->country_code = 'ru';
 		$cv->slug = 'cv';
+		$cv->alphabet = 'cyrillic';
 
 		$cy = new GP_Locale();
 		$cy->english_name = 'Welsh';
@@ -625,6 +651,7 @@ class GP_Locales {
 		$dv->wp_locale = 'dv';
 		$dv->slug = 'dv';
 		$dv->text_direction = 'rtl';
+		$dv->alphabet = 'thaana';
 
 		$dzo = new GP_Locale();
 		$dzo->english_name = 'Dzongkha';
@@ -636,6 +663,7 @@ class GP_Locales {
 		$dzo->slug = 'dzo';
 		$dzo->nplurals = 1;
 		$dzo->plural_expression = '0';
+		$dzo->alphabet  = 'tibetan';
 
 		$ewe = new GP_Locale();
 		$ewe->english_name = 'Ewe';
@@ -657,12 +685,14 @@ class GP_Locales {
 		$el->slug = 'el';
 		$el->google_code = 'el';
 		$el->facebook_locale = 'el_GR';
+		$el->alphabet = 'greek';
 
 		$el_po = new GP_Locale();
 		$el_po->english_name = 'Greek (Polytonic)';
 		$el_po->native_name = 'Greek (Polytonic)'; // TODO.
 		$el_po->country_code = 'gr';
 		$el_po->slug = 'el-po';
+		$el_po->alphabet  = 'polytonic';
 
 		$emoji = new GP_Locale();
 		$emoji->english_name = 'Emoji';
@@ -672,6 +702,7 @@ class GP_Locales {
 		$emoji->slug = 'art-xemoji';
 		$emoji->nplurals = 1;
 		$emoji->plural_expression = '0';
+		$emoji->alphabet = 'emoji';
 
 		$en = new GP_Locale();
 		$en->english_name = 'English';
@@ -961,6 +992,7 @@ class GP_Locales {
 		$fa->text_direction = 'rtl';
 		$fa->google_code = 'fa';
 		$fa->facebook_locale = 'fa_IR';
+		$fa->alphabet = 'persian';
 
 		$fa_af = new GP_Locale();
 		$fa_af->english_name = 'Persian (Afghanistan)';
@@ -973,6 +1005,7 @@ class GP_Locales {
 		$fa_af->plural_expression = 'n > 1';
 		$fa_af->text_direction = 'rtl';
 		$fa_af->google_code = 'fa';
+		$fa_af->alphabet = 'persian';
 
 		$ff_sn = new GP_Locale();
 		$ff_sn->english_name = 'Fulah';
@@ -1176,6 +1209,7 @@ class GP_Locales {
 		$gu->slug = 'gu';
 		$gu->google_code = 'gu';
 		$gu->facebook_locale = 'gu_IN';
+		$gu->alphabet = 'gujarati';
 
 		$ha = new GP_Locale();
 		$ha->english_name = 'Hausa (Arabic)';
@@ -1185,6 +1219,7 @@ class GP_Locales {
 		$ha->slug = 'ha';
 		$ha->text_direction = 'rtl';
 		$ha->google_code = 'ha';
+		$ha->alphabet = 'arabic';
 
 		$hat = new GP_Locale();
 		$hat->english_name = 'Haitian Creole';
@@ -1224,6 +1259,7 @@ class GP_Locales {
 		$haz->wp_locale = 'haz';
 		$haz->slug = 'haz';
 		$haz->text_direction = 'rtl';
+		$haz->alphabet = 'arabic';
 
 		$he = new GP_Locale();
 		$he->english_name = 'Hebrew';
@@ -1235,6 +1271,7 @@ class GP_Locales {
 		$he->text_direction = 'rtl';
 		$he->google_code = 'iw';
 		$he->facebook_locale = 'he_IL';
+		$he->alphabet = 'hebrew';
 
 		$hi = new GP_Locale();
 		$hi->english_name = 'Hindi';
@@ -1246,6 +1283,7 @@ class GP_Locales {
 		$hi->slug = 'hi';
 		$hi->google_code = 'hi';
 		$hi->facebook_locale = 'hi_IN';
+		$hi->alphabet = 'devanagari';
 
 		$hr = new GP_Locale();
 		$hr->english_name = 'Croatian';
@@ -1292,6 +1330,7 @@ class GP_Locales {
 		$hy->slug = 'hy';
 		$hy->google_code = 'hy';
 		$hy->facebook_locale = 'hy_AM';
+		$hy->alphabet = 'armenian';
 
 		$ia = new GP_Locale();
 		$ia->english_name = 'Interlingua';
@@ -1344,6 +1383,7 @@ class GP_Locales {
 		$ike->slug = 'ike';
 		$ike->nplurals = 3;
 		$ike->plural_expression = '(n == 1) ? 0 : ((n == 2) ? 1 : 2)';
+		$ike->alphabet = 'syllabics';
 
 		$ilo = new GP_Locale();
 		$ilo->english_name = 'Iloko';
@@ -1387,6 +1427,7 @@ class GP_Locales {
 		$ja->facebook_locale = 'ja_JP';
 		$ja->nplurals = 1;
 		$ja->plural_expression = '0';
+		$ja->alphabet = 'kanji';
 
 		$jv = new GP_Locale();
 		$jv->english_name = 'Javanese';
@@ -1411,6 +1452,7 @@ class GP_Locales {
 		$ka->plural_expression = '0';
 		$ka->google_code = 'ka';
 		$ka->facebook_locale = 'ka_GE';
+		$ka->alphabet = 'georgian';
 
 		$kaa = new GP_Locale();
 		$kaa->english_name = 'Karakalpak';
@@ -1463,6 +1505,7 @@ class GP_Locales {
 		$kk->slug = 'kk';
 		$kk->google_code = 'kk';
 		$kk->facebook_locale = 'kk_KZ';
+		$kk->alphabet = 'cyrillic';
 
 		$km = new GP_Locale();
 		$km->english_name = 'Khmer';
@@ -1476,6 +1519,7 @@ class GP_Locales {
 		$km->plural_expression = '0';
 		$km->google_code = 'km';
 		$km->facebook_locale = 'km_KH';
+		$km->alphabet = 'khmer';
 
 		$kmr = new GP_Locale();
 		$kmr->english_name = 'Kurdish (Kurmanji)';
@@ -1497,6 +1541,7 @@ class GP_Locales {
 		$kn->slug = 'kn';
 		$kn->google_code = 'kn';
 		$kn->facebook_locale = 'kn_IN';
+		$kn->alphabet = 'kannada';
 
 		$ko = new GP_Locale();
 		$ko->english_name = 'Korean';
@@ -1510,6 +1555,7 @@ class GP_Locales {
 		$ko->plural_expression = '0';
 		$ko->google_code = 'ko';
 		$ko->facebook_locale = 'ko_KR';
+		$ko->alphabet = 'hangul';
 
 		$ks = new GP_Locale();
 		$ks->english_name = 'Kashmiri';
@@ -1517,6 +1563,7 @@ class GP_Locales {
 		$ks->lang_code_iso_639_1 = 'ks';
 		$ks->lang_code_iso_639_2 = 'kas';
 		$ks->slug = 'ks';
+		$ks->alphabet = 'devanagari';
 
 		$kir = new GP_Locale();
 		$kir->english_name = 'Kyrgyz';
@@ -1530,6 +1577,7 @@ class GP_Locales {
 		$kir->nplurals = 1;
 		$kir->plural_expression = '0';
 		$kir->google_code = 'ky';
+		$kir->alphabet = 'cyrillic';
 
 		$la = new GP_Locale();
 		$la->english_name = 'Latin';
@@ -1599,6 +1647,7 @@ class GP_Locales {
 		$lo->plural_expression = '0';
 		$lo->google_code = 'lo';
 		$lo->facebook_locale = 'lo_LA';
+		$lo->alphabet = 'lao';
 
 		$lt = new GP_Locale();
 		$lt->english_name = 'Lithuanian';
@@ -1644,6 +1693,7 @@ class GP_Locales {
 		$mai->country_code = 'in';
 		$mai->wp_locale = 'mai';
 		$mai->slug = 'mai';
+		$mai->alphabet = 'devanagari';
 
 		$me = new GP_Locale();
 		$me->english_name = 'Montenegrin';
@@ -1681,6 +1731,7 @@ class GP_Locales {
 		$mhr->lang_code_iso_639_3 = 'mhr';
 		$mhr->country_code = 'ru';
 		$mhr->slug = 'mhr';
+		$mhr->alphabet = 'cyrillic';
 
 		$mk = new GP_Locale();
 		$mk->english_name = 'Macedonian';
@@ -1694,6 +1745,7 @@ class GP_Locales {
 		$mk->plural_expression = 'n % 10 != 1 || n % 100 == 11';
 		$mk->google_code = 'mk';
 		$mk->facebook_locale = 'mk_MK';
+		$mk->alphabet = 'cyrillic';
 
 		$ml = new GP_Locale();
 		$ml->english_name = 'Malayalam';
@@ -1705,6 +1757,7 @@ class GP_Locales {
 		$ml->slug = 'ml';
 		$ml->google_code = 'ml';
 		$ml->facebook_locale = 'ml_IN';
+		$ml->alphabet = 'malayalam';
 
 		$mlt = new GP_Locale();
 		$mlt->english_name = 'Maltese';
@@ -1730,6 +1783,7 @@ class GP_Locales {
 		$mn->slug = 'mn';
 		$mn->google_code = 'mn';
 		$mn->facebook_locale = 'mn_MN';
+		$mn->alphabet = 'cyrillic';
 
 		$mr = new GP_Locale();
 		$mr->english_name = 'Marathi';
@@ -1740,6 +1794,7 @@ class GP_Locales {
 		$mr->slug = 'mr';
 		$mr->google_code = 'mr';
 		$mr->facebook_locale = 'mr_IN';
+		$mr->alphabet = 'devanagari';
 
 		$mri = new GP_Locale();
 		$mri->english_name = 'Maori';
@@ -1759,6 +1814,7 @@ class GP_Locales {
 		$mrj->lang_code_iso_639_3 = 'mrj';
 		$mrj->country_code = 'ru';
 		$mrj->slug = 'mrj';
+		$mrj->alphabet = 'cyrillic';
 
 		$ms = new GP_Locale();
 		$ms->english_name = 'Malay';
@@ -1787,6 +1843,7 @@ class GP_Locales {
 		$my->wp_locale = 'my_MM';
 		$my->slug = 'mya';
 		$my->google_code = 'my';
+		$my->alphabet = 'burmese';
 
 		$ne = new GP_Locale();
 		$ne->english_name = 'Nepali';
@@ -1798,6 +1855,7 @@ class GP_Locales {
 		$ne->slug = 'ne';
 		$ne->google_code = 'ne';
 		$ne->facebook_locale = 'ne_NP';
+		$ne->alphabet = 'devanagari';
 
 		$nb = new GP_Locale();
 		$nb->english_name = 'Norwegian (Bokmål)';
@@ -1860,6 +1918,7 @@ class GP_Locales {
 		$nqo->wp_locale = 'nqo';
 		$nqo->slug = 'nqo';
 		$nqo->text_direction = 'rtl';
+		$nqo->alphabet = 'nko';
 
 		$nso = new GP_Locale();
 		$nso->english_name = 'Northern Sotho';
@@ -1898,6 +1957,7 @@ class GP_Locales {
 		$ory->wp_locale = 'ory';
 		$ory->slug = 'ory';
 		$ory->facebook_locale = 'or_IN';
+		$ory->alphabet = 'odia';
 
 		$os = new GP_Locale();
 		$os->english_name = 'Ossetic';
@@ -1906,6 +1966,7 @@ class GP_Locales {
 		$os->lang_code_iso_639_2 = 'oss';
 		$os->wp_locale = 'os';
 		$os->slug = 'os';
+		$os->alphabet = 'cyrillic';
 
 		$pa = new GP_Locale();
 		$pa->english_name = 'Panjabi (India)';
@@ -1919,6 +1980,7 @@ class GP_Locales {
 		$pa->nplurals = 2;
 		$pa->plural_expression = 'n > 1';
 		$pa->facebook_locale = 'pa_IN';
+		$pa->alphabet = 'gurmukhi';
 
 		$pa_pk = new GP_Locale();
 		$pa_pk->english_name = 'Punjabi (Pakistan)';
@@ -1931,6 +1993,7 @@ class GP_Locales {
 		$pa_pk->nplurals = 2;
 		$pa_pk->plural_expression = 'n > 1';
 		$pa_pk->google_code = 'pa';
+		$pa_pk->alphabet = 'shahmukhi';
 
 		$pap_cw = new GP_Locale();
 		$pap_cw->english_name = 'Papiamento (Curaçao and Bonaire)';
@@ -2040,6 +2103,7 @@ class GP_Locales {
 		$ps->slug = 'ps';
 		$ps->text_direction = 'rtl';
 		$ps->facebook_locale = 'ps_AF';
+		$ps->alphabet = 'pashto';
 
 		$rhg = new GP_Locale();
 		$rhg->english_name = 'Rohingya';
@@ -2086,6 +2150,7 @@ class GP_Locales {
 		$ru->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$ru->google_code = 'ru';
 		$ru->facebook_locale = 'ru_RU';
+		$ru->alphabet = 'cyrillic';
 
 		$rue = new GP_Locale();
 		$rue->english_name = 'Rusyn';
@@ -2094,6 +2159,7 @@ class GP_Locales {
 		$rue->slug = 'rue';
 		$rue->nplurals = 3;
 		$rue->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
+		$rue->alphabet = 'cyrillic';
 
 		$rup = new GP_Locale();
 		$rup->english_name = 'Aromanian';
@@ -2111,6 +2177,7 @@ class GP_Locales {
 		$sah->country_code = 'ru';
 		$sah->wp_locale = 'sah';
 		$sah->slug = 'sah';
+		$sah->alphabet = 'cyrillic';
 
 		$sa_in = new GP_Locale();
 		$sa_in->english_name = 'Sanskrit';
@@ -2122,6 +2189,7 @@ class GP_Locales {
 		$sa_in->wp_locale = 'sa_IN';
 		$sa_in->slug = 'sa-in';
 		$sa_in->facebook_locale = 'sa_IN';
+		$sa_in->alphabet = 'brahmic';
 
 		$scn = new GP_Locale();
 		$scn->english_name = 'Sicilian';
@@ -2141,6 +2209,7 @@ class GP_Locales {
 		$si->slug = 'si';
 		$si->google_code = 'si';
 		$si->facebook_locale = 'si_LK';
+		$si->alphabet = 'sinhala';
 
 		$sk = new GP_Locale();
 		$sk->english_name = 'Slovak';
@@ -2165,6 +2234,7 @@ class GP_Locales {
 		$skr->nplurals = 2;
 		$skr->plural_expression = 'n > 1';
 		$skr->text_direction = 'rtl';
+		$skr->alphabet = 'saraiki';
 
 		$sl = new GP_Locale();
 		$sl->english_name = 'Slovenian';
@@ -2198,6 +2268,7 @@ class GP_Locales {
 		$snd->wp_locale = 'snd';
 		$snd->slug = 'snd';
 		$snd->text_direction = 'rtl';
+		$snd->alphabet = 'arabic';
 
 		$so = new GP_Locale();
 		$so->english_name = 'Somali';
@@ -2242,6 +2313,7 @@ class GP_Locales {
 		$sr->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$sr->google_code = 'sr';
 		$sr->facebook_locale = 'sr_RS';
+		$sr->alphabet = 'cyrillic';
 
 		$srd = new GP_Locale();
 		$srd->english_name = 'Sardinian';
@@ -2303,6 +2375,7 @@ class GP_Locales {
 		$syr->country_code = 'iq';
 		$syr->wp_locale = 'syr';
 		$syr->slug = 'syr';
+		$syr->alphabet = 'syriac';
 
 		$szl = new GP_Locale();
 		$szl->english_name = 'Silesian';
@@ -2325,6 +2398,7 @@ class GP_Locales {
 		$ta->slug = 'ta';
 		$ta->google_code = 'ta';
 		$ta->facebook_locale = 'ta_IN';
+		$ta->alphabet = 'tamil';
 
 		$ta_lk = new GP_Locale();
 		$ta_lk->english_name = 'Tamil (Sri Lanka)';
@@ -2335,6 +2409,7 @@ class GP_Locales {
 		$ta_lk->wp_locale = 'ta_LK';
 		$ta_lk->slug = 'ta-lk';
 		$ta_lk->google_code = 'ta';
+		$ta_lk->alphabet = 'tamil';
 
 		$tah = new GP_Locale();
 		$tah->english_name = 'Tahitian';
@@ -2357,6 +2432,7 @@ class GP_Locales {
 		$te->slug = 'te';
 		$te->google_code = 'te';
 		$te->facebook_locale = 'te_IN';
+		$te->alphabet = 'telugu';
 
 		$tg = new GP_Locale();
 		$tg->english_name = 'Tajik';
@@ -2368,6 +2444,7 @@ class GP_Locales {
 		$tg->slug = 'tg';
 		$tg->google_code = 'tg';
 		$tg->facebook_locale = 'tg_TJ';
+		$tg->alphabet = 'cyrillic';
 
 		$th = new GP_Locale();
 		$th->english_name = 'Thai';
@@ -2380,6 +2457,7 @@ class GP_Locales {
 		$th->plural_expression = '0';
 		$th->google_code = 'th';
 		$th->facebook_locale = 'th_TH';
+		$th->alphabet = 'thai';
 
 		$tir = new GP_Locale();
 		$tir->english_name = 'Tigrinya';
@@ -2391,6 +2469,7 @@ class GP_Locales {
 		$tir->slug = 'tir';
 		$tir->nplurals = 1;
 		$tir->plural_expression = '0';
+		$tir->alphabet = 'geez';
 
 		$tlh = new GP_Locale();
 		$tlh->english_name = 'Klingon';
@@ -2436,6 +2515,7 @@ class GP_Locales {
 		$tt_ru->nplurals = 1;
 		$tt_ru->plural_expression = '0';
 		$tt_ru->facebook_locale = 'tt_RU';
+		$tt_ru->alphabet = 'cyrillic';
 
 		$tuk = new GP_Locale();
 		$tuk->english_name = 'Turkmen';
@@ -2466,12 +2546,14 @@ class GP_Locales {
 		$tzm->slug = 'tzm';
 		$tzm->nplurals = 2;
 		$tzm->plural_expression = 'n > 1';
+		$tzm->alphabet = 'tifinagh';
 
 		$udm = new GP_Locale();
 		$udm->english_name = 'Udmurt';
 		$udm->native_name = 'Удмурт кыл';
 		$udm->lang_code_iso_639_2 = 'udm';
 		$udm->slug = 'udm';
+		$udm->alphabet = 'cyrillic';
 
 		$ug = new GP_Locale();
 		$ug->english_name = 'Uighur';
@@ -2482,6 +2564,7 @@ class GP_Locales {
 		$ug->wp_locale = 'ug_CN';
 		$ug->slug = 'ug';
 		$ug->text_direction = 'rtl';
+		$ug->alphabet = 'uyghur';
 
 		$uk = new GP_Locale();
 		$uk->english_name = 'Ukrainian';
@@ -2495,6 +2578,7 @@ class GP_Locales {
 		$uk->plural_expression = '(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2)';
 		$uk->google_code = 'uk';
 		$uk->facebook_locale = 'uk_UA';
+		$uk->alphabet = 'cyrillic';
 
 		$ur = new GP_Locale();
 		$ur->english_name = 'Urdu';
@@ -2507,6 +2591,7 @@ class GP_Locales {
 		$ur->text_direction = 'rtl';
 		$ur->google_code = 'ur';
 		$ur->facebook_locale = 'ur_PK';
+		$ur->alphabet = 'persian';
 
 		$uz = new GP_Locale();
 		$uz->english_name = 'Uzbek';
@@ -2581,6 +2666,7 @@ class GP_Locales {
 		$xmf->lang_code_iso_639_3 = 'xmf';
 		$xmf->country_code = 'ge';
 		$xmf->slug = 'xmf';
+		$xmf->alphabet = 'georgian';
 
 		$yi = new GP_Locale();
 		$yi->english_name = 'Yiddish';
@@ -2590,6 +2676,7 @@ class GP_Locales {
 		$yi->slug = 'yi';
 		$yi->text_direction = 'rtl';
 		$yi->google_code = 'yi';
+		$yi->alphabet = 'hebrew';
 
 		$yor = new GP_Locale();
 		$yor->english_name = 'Yoruba';
@@ -2613,6 +2700,7 @@ class GP_Locales {
 		$zgh->slug = 'zgh';
 		$zgh->nplurals = 2;
 		$zgh->plural_expression = 'n >= 2 && (n < 11 || n > 99)';
+		$zgh->alphabet = 'tifinagh';
 
 		$zh = new GP_Locale();
 		$zh->english_name = 'Chinese';
@@ -2622,6 +2710,7 @@ class GP_Locales {
 		$zh->slug = 'zh';
 		$zh->nplurals = 1;
 		$zh->plural_expression = '0';
+		$zh->alphabet = 'hanyu';
 
 		$zh_cn = new GP_Locale();
 		$zh_cn->english_name = 'Chinese (China)';
@@ -2635,6 +2724,7 @@ class GP_Locales {
 		$zh_cn->plural_expression = '0';
 		$zh_cn->google_code = 'zh-CN';
 		$zh_cn->facebook_locale = 'zh_CN';
+		$zh_cn->alphabet = 'simplified-chinese';
 
 		$zh_hk = new GP_Locale();
 		$zh_hk->english_name = 'Chinese (Hong Kong)';
@@ -2647,6 +2737,7 @@ class GP_Locales {
 		$zh_hk->nplurals = 1;
 		$zh_hk->plural_expression = '0';
 		$zh_hk->facebook_locale = 'zh_HK';
+		$zh_hk->alphabet = 'simplified-chinese';
 
 		$zh_sg = new GP_Locale();
 		$zh_sg->english_name = 'Chinese (Singapore)';
@@ -2658,6 +2749,7 @@ class GP_Locales {
 		$zh_sg->slug = 'zh-sg';
 		$zh_sg->nplurals = 1;
 		$zh_sg->plural_expression = '0';
+		$zh_sg->alphabet = 'hanyu';
 
 		$zh_tw = new GP_Locale();
 		$zh_tw->english_name = 'Chinese (Taiwan)';
@@ -2671,6 +2763,7 @@ class GP_Locales {
 		$zh_tw->plural_expression = '0';
 		$zh_tw->google_code = 'zh-TW';
 		$zh_tw->facebook_locale = 'zh_TW';
+		$zh_tw->alphabet = 'hanyu';
 
 		$zul = new GP_Locale();
 		$zul->english_name = 'Zulu';


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds the alphabet for each locale. I set, by default, the Latin alphabet.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The alphabet can be used for a lot of decisions depending on the alphabet: counting letters and words, starting uppercase, finish symbols (points, ...), so it can be used as base for another improvements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds a new property ($alphabet), and have Latin as default value. Then adds the alphabet for each locale if its alphabet it is not the default.