### PR TITLE
Bulk status change: Fix bulk rejection

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -476,7 +476,7 @@ class GP_Route_Translation extends GP_Route_Main {
 							$error
 						);
 						break;
-					case 'rejected':
+					case 'reject':
 						$message = sprintf(
 						/* translators: %s: Translations count. */
 							_n( 'Error with rejecting %s translation.', 'Error with rejecting %s translations.', $error, 'glotpress' ),
@@ -500,7 +500,7 @@ class GP_Route_Translation extends GP_Route_Main {
 							$ok
 						);
 						break;
-					case 'rejected':
+					case 'reject':
 						$message .= sprintf(
 						/* translators: %s: Translations count. */
 							_n( 'The remaining %s translation was rejected successfully.', 'The remaining %s translations were rejected successfully.', $ok, 'glotpress' ),
@@ -525,7 +525,7 @@ class GP_Route_Translation extends GP_Route_Main {
 							$error
 						);
 						break;
-					case 'rejected':
+					case 'reject':
 						$this->errors[] = sprintf(
 						/* translators: %s: Translations count. */
 							_n( 'Error with rejecting %s translation.', 'Error with rejecting all %s translations.', $error, 'glotpress' ),

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -422,7 +422,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			case 'approve':
 				$new_status = 'current';
 				break;
-			case 'rejected':
+			case 'reject':
 				$new_status = 'rejected';
 				break;
 			case 'changesrequested':
@@ -451,7 +451,7 @@ class GP_Route_Translation extends GP_Route_Main {
 						$ok
 					);
 					break;
-				case 'rejected':
+				case 'reject':
 					$this->notices[] = sprintf(
 					/* translators: %d: Translations count. */
 						_n( '%d translation was rejected.', '%d translations were rejected.', $ok, 'glotpress' ),


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As a follow up to #1451, it looks like the `action` POST variable was looked at incorrectly, causing a PHP Notice:

```
E_NOTICE: Undefined variable: new_status in wp-content/plugins/glotpress/gp-includes/routes/translation.php:438
```

Based on https://github.com/amieiro/GlotPress-WP/blob/develop/gp-includes/routes/translation.php#L375-L381 it looks like the correct is `reject`, which is confirmed from the POST data attached to the above notice containing 'reject'.

I believe this is potentially causing bulk rejections to fail, based on re-attempts after failure.

Additionally, `$new_status` should probably be pre-set to `rejected` before the `switch`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->