### PR TITLE
Show the exact amount of spaces added or missing on the translation warnings

### DIFF
--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -842,29 +842,75 @@ class GP_Builtin_Translation_Warnings {
 
 		$warnings = array();
 		if ( $original_start_spaces && ! $translation_start_spaces ) {
-			$warnings[] = __( 'The translation appears to be missing one or more spaces at the beginning.', 'glotpress' );
+			$warnings[] = sprintf(
+				/* translators: 1: Number of spaces at the beginning of the original string. */
+				_n(
+					'The translation appears to be missing %d space at the beginning.',
+					'The translation appears to be missing %d spaces at the beginning.',
+					$original_start_spaces,
+					'glotpress'
+				),
+				$original_start_spaces
+			);
 		}
 		if ( ( ! $original_start_spaces ) && $translation_start_spaces ) {
-			$warnings[] = __( 'The translation appears to be adding one or more spaces at the beginning.', 'glotpress' );
+			$warnings[] = sprintf(
+				/* translators: 1: Number of spaces at the beginning of the translation string. */
+				_n(
+					'The translation appears to be adding %d space at the beginning.',
+					'The translation appears to be adding %d spaces at the beginning.',
+					$translation_start_spaces,
+					'glotpress'
+				),
+				$translation_start_spaces
+			);
 		}
 		if ( ( $original_end_spaces ) && ( ! $translation_end_spaces ) ) {
-			$warnings[] = __( 'The translation appears to be missing one or more spaces at the end.', 'glotpress' );
+			$warnings[] = sprintf(
+				/* translators: 1: Number of spaces at the end of the original string. */
+				_n(
+					'The translation appears to be missing %d space at the end.',
+					'The translation appears to be missing %d spaces at the end.',
+					$original_end_spaces,
+					'glotpress'
+				),
+				$original_end_spaces
+			);
 		}
 		if ( ! $original_end_spaces && $translation_end_spaces ) {
-			$warnings[] = __( 'The translation appears to be adding one or more spaces at the end.', 'glotpress' );
+			$warnings[] = sprintf(
+				/* translators: 1: Number of spaces at the end of the translation string. */
+				_n(
+					'The translation appears to be adding %d space at the end.',
+					'The translation appears to be adding %d spaces at the end.',
+					$translation_end_spaces,
+					'glotpress'
+				),
+				$translation_end_spaces
+			);
 		}
 		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces !== $translation_start_spaces ) ) {
 			$warnings[] = sprintf(
 				/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
-				__( 'Expected %1$s space(s) at the beginning, got %2$s.', 'glotpress' ),
+				_n(
+					'Expected %1$d space at the beginning, got %2$d.',
+					'Expected %1$d spaces at the beginning, got %2$d.',
+					$original_start_spaces,
+					'glotpress'
+				),
 				$original_start_spaces,
 				$translation_start_spaces
 			);
 		}
 		if ( $original_end_spaces && $translation_end_spaces && ( $original_end_spaces !== $translation_end_spaces ) ) {
 			$warnings[] = sprintf(
-			/* translators: 1: Number of spaces at the end of the original string. 2: Number of spaces at the end of the translation string. */
-				__( 'Expected %1$s space(s) at the end, got %2$s.', 'glotpress' ),
+				/* translators: 1: Number of spaces at the end of the original string. 2: Number of spaces at the end of the translation string. */
+				_n(
+					'Expected %1$d space at the end, got %2$d.',
+					'Expected %1$d spaces at the end, got %2$d.',
+					$original_end_spaces,
+					'glotpress'
+				),
 				$original_end_spaces,
 				$translation_end_spaces
 			);

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -670,43 +670,43 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			' Original string',
 			'Cadea traducida',
-			'The translation appears to be missing one or more spaces at the beginning.' );
+			'The translation appears to be missing 1 space at the beginning.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'Original string',
 			' Cadea traducida',
-			'The translation appears to be adding one or more spaces at the beginning.' );
+			'The translation appears to be adding 1 space at the beginning.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'Original string ',
 			'Cadea traducida',
-			'The translation appears to be missing one or more spaces at the end.' );
+			'The translation appears to be missing 1 space at the end.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'Original string',
 			'Cadea traducida ',
-			'The translation appears to be adding one or more spaces at the end.' );
+			'The translation appears to be adding 1 space at the end.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			' Original string',
 			'   Cadea traducida',
-			'Expected 1 space(s) at the beginning, got 3.' );
+			'Expected 1 space at the beginning, got 3.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'   Original string',
 			' Cadea traducida',
-			'Expected 3 space(s) at the beginning, got 1.' );
+			'Expected 3 spaces at the beginning, got 1.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'Original string ',
 			'Cadea traducida   ',
-			'Expected 1 space(s) at the end, got 3.' );
+			'Expected 1 space at the end, got 3.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'Original string   ',
 			'Cadea traducida ',
-			'Expected 3 space(s) at the end, got 1.' );
+			'Expected 3 spaces at the end, got 1.' );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			'   Original string   ',
 			' Cadea traducida ',
-			"Expected 3 space(s) at the beginning, got 1.\nExpected 3 space(s) at the end, got 1." );
+			"Expected 3 spaces at the beginning, got 1.\nExpected 3 spaces at the end, got 1." );
 		$this->assertHasWarningsAndContainsOutput( 'unexpected_start_end_space',
 			' Original string ',
 			'   Cadea traducida   ',
-			"Expected 1 space(s) at the beginning, got 3.\nExpected 1 space(s) at the end, got 3." );
+			"Expected 1 space at the beginning, got 3.\nExpected 1 space at the end, got 3." );
 	}
 
 	public function test_chained_warnings() {

--- a/tests/phpunit/testcases/test_builtin_warnings.php
+++ b/tests/phpunit/testcases/test_builtin_warnings.php
@@ -900,7 +900,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 				array(
 					'tags'                        => 'Missing tags from translation. Expected: <p> </p>',
 					'placeholders'                => 'Extra %% placeholder in translation.',
-					'unexpected_start_end_space'  => "The translation appears to be missing one or more spaces at the beginning.\nThe translation appears to be adding one or more spaces at the end."
+					'unexpected_start_end_space'  => "The translation appears to be missing 1 space at the beginning.\nThe translation appears to be adding 1 space at the end."
 				),
 			)
 		);
@@ -912,7 +912,7 @@ class GP_Test_Builtin_Translation_Warnings extends GP_UnitTestCase {
 				array(
 					'tags'                        => 'Missing tags from translation. Expected: <p> </p>',
 					'placeholders'                => 'Extra %% placeholder in translation.',
-					'unexpected_start_end_space'  => "Expected 4 space(s) at the beginning, got 1.\nExpected 1 space(s) at the end, got 5."
+					'unexpected_start_end_space'  => "Expected 4 spaces at the beginning, got 1.\nExpected 1 space at the end, got 5."
 				),
 			)
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
Specify the spaces added or missing in the translation warnings

## Why?
Add more detailed and specific info on the warnings.

## How?
I am using the `_n()` to show the number of spaces.

## Screenshots

![imagem](https://user-images.githubusercontent.com/7371591/191304332-7c640417-c3b8-4f86-9890-19fa0bfbfc86.png)
![imagem](https://user-images.githubusercontent.com/7371591/191304415-2c00c8b2-3aac-4675-94dd-fd1df8b3aaed.png)
![imagem](https://user-images.githubusercontent.com/7371591/191304623-32451d84-6e3f-46c6-adf2-515a5bcbe0e4.png)

Related to the warnings introduced in #1427 

Fixes #1489