### PR TITLE
Locales: Correct de_AT country_code, add fa_AF country code.

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -394,7 +394,7 @@ class GP_Locales {
 		$bn_bd->wp_locale = 'bn_BD';
 		$bn_bd->slug = 'bn';
 		$bn_bd->google_code = 'bn';
-		$bn_bd->alphabet  ='bengali';
+		$bn_bd->alphabet = 'bengali';
 
 		$bn_in = new GP_Locale();
 		$bn_in->english_name = 'Bengali (India)';
@@ -407,7 +407,7 @@ class GP_Locales {
 		$bn_in->facebook_locale = 'bn_IN';
 		$bn_in->nplurals = 2;
 		$bn_in->plural_expression = 'n > 1';
-		$bn_in->alphabet  ='bengali';
+		$bn_in->alphabet = 'bengali';
 
 		$bo = new GP_Locale();
 		$bo->english_name = 'Tibetan';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -619,7 +619,7 @@ class GP_Locales {
 		$de_at->english_name = 'German (Austria)';
 		$de_at->native_name = 'Deutsch (Österreich)';
 		$de_at->lang_code_iso_639_1 = 'de';
-		$de_at->country_code = 'de';
+		$de_at->country_code = 'at';
 		$de_at->wp_locale = 'de_AT';
 		$de_at->slug = 'de-at';
 		$de_at->google_code = 'de';
@@ -1001,6 +1001,7 @@ class GP_Locales {
 		$fa_af->native_name = '(فارسی (افغانستان';
 		$fa_af->lang_code_iso_639_1 = 'fa';
 		$fa_af->lang_code_iso_639_2 = 'fas';
+		$fa_af->country_code = 'af';
 		$fa_af->wp_locale = 'fa_AF';
 		$fa_af->slug = 'fa-af';
 		$fa_af->nplurals = 2;


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We're using the GP_Locales for various purposes on WordPress.org, and in one of them I noticed some irregularities in some country_codes listed.
 - de_AT lists the country code as `de`, instead of `at`
 - fa_AF doesn't list the country code, but includes the country specifier in the locale, so might as well define `country_code`.

Notably, I've ignored the following locales, which specify a country in the WP locale:
 - fa_IR (Persian) - appears to just be the root Persian language, fa_AF above is a variant of Persian?
 - ms_MY (Malay) - Is the only Malay included, so no need to specify that it's the Malaysian Malay.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Although not the intended use-cases, this had resulted in:
 - `de_DE` and `de_AT` being localised to `de` rather than `de` and `at`. `de_CH` is correctly set to `ch`.
 - `fa_AF` being listed as just `fa` as it doesn't specify the country code.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->