### PR TITLE
Set as old the previous translations with changes requested

### DIFF
--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -33,14 +33,15 @@ class GP_Route_Project extends GP_Route_Main {
 		foreach ( $translation_sets as $set ) {
 			$locale = GP_Locales::by_slug( $set->locale );
 
-			$set->name_with_locale   = $set->name_with_locale();
-			$set->current_count      = $set->current_count();
-			$set->untranslated_count = $set->untranslated_count();
-			$set->waiting_count      = $set->waiting_count();
-			$set->fuzzy_count        = $set->fuzzy_count();
-			$set->percent_translated = $set->percent_translated();
-			$set->all_count          = $set->all_count();
-			$set->wp_locale          = $locale->wp_locale;
+			$set->name_with_locale       = $set->name_with_locale();
+			$set->current_count          = $set->current_count();
+			$set->untranslated_count     = $set->untranslated_count();
+			$set->waiting_count          = $set->waiting_count();
+			$set->changesrequested_count = $set->changesrequested_count();
+			$set->fuzzy_count            = $set->fuzzy_count();
+			$set->percent_translated     = $set->percent_translated();
+			$set->all_count              = $set->all_count();
+			$set->wp_locale              = $locale->wp_locale;
 			if ( $this->api ) {
 				$set->last_modified = $set->current_count ? $set->last_modified() : false;
 			}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -327,6 +327,8 @@ class GP_Route_Translation extends GP_Route_Main {
 			} else {
 				if ( 'current' === $set_status ) {
 					$translation->set_status( 'current' );
+				} else {
+					$translation->set_status( 'waiting' );
 				}
 
 				$translations = GP::$translation->for_translation( $project, $translation_set, 'no-limit', array( 'translation_id' => $translation->id ), array() );

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -396,9 +396,9 @@ class GP_Translation_Set extends GP_Thing {
 	}
 
 	/**
-	 * Retrieves the number of waiting translations.
+	 * Retrieves the number of "changes requested" translations.
 	 *
-	 * @return int Number of waiting translations.
+	 * @return int Number of "changes requested" translations.
 	 */
 	public function changesrequested_count() {
 		if ( ! isset( $this->changesrequested_count ) ) {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -721,7 +721,7 @@ class GP_Translation extends GP_Thing {
 			$can_set_status = true;
 		}
 
-		if ( ! is_bool( $can_set_status ) && ( 'current' === $desired_status || 'rejected' === $desired_status ) ) {
+		if ( ! is_bool( $can_set_status ) && ( 'current' === $desired_status || 'rejected' === $desired_status || 'changesrequested' === $desired_status ) ) {
 			if ( ! GP::$permission->current_user_can( 'approve', 'translation', $this->id, array( 'translation' => $this ) ) ) {
 				$can_set_status = false;
 			}

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -667,7 +667,7 @@ class GP_Translation extends GP_Thing {
 	}
 
 	/**
-	 * Sets as old the other changesrequested and waiting translations for the same original and user,
+	 * Sets as old the other changesrequested translations for the same original and user,
 	 * setting the current one as waiting.
 	 *
 	 * @return bool|null

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -523,7 +523,7 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( 1, $set->waiting_count() );
 	}
 
-	function test_when_update_the_same_changedrequested_translation_two_timesit_is_set_to_old_status() {
+	function test_when_update_the_same_changedrequested_translation_two_times_it_is_set_to_old_status() {
 		$user1 = $this->factory->user->create();
 		$user2 = $this->factory->user->create();
 


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When a translator suggests different translations for the same original and the validator request changes for these translations, the old translations are not marked as "old", so we have the history in the main table.

Fixes https://github.com/GlotPress/GlotPress/issues/1496.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR solves the problem explained in https://github.com/GlotPress/GlotPress/issues/1496.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR sets the previous translations with "changesrequested" status as old:
- When a new translation is suggested.
- When a new translation for the same user is set as changesrequested. This case should never happen, because we should not have 1 translation in changesrequested and another in suggested, but it is simply to avoid possible edge cases. 

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

You can follow the steps available in https://github.com/GlotPress/GlotPress/issues/1496 to test this PR.

## Screenshots or screencast <!-- if applicable -->

See https://github.com/GlotPress/GlotPress/issues/1496.