### PR TITLE
Add an action gp_after_project_form_fields to enable additional fields to be added

### DIFF
--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -36,9 +36,9 @@
 	<?php
 		/**
 		 * Fires after the default project form fields.
-		 * 
+		 *
 		 * @since 4.0.0
-		 * 
+		 *
 		 * @param GP_Project $project The project being reendered.
 		 */
 		do_action( 'gp_after_project_form_fields', $project );

--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -36,6 +36,9 @@
 	<?php
 		/**
 		 * Fires after the default project form fields.
+		 * @since 4.0.0
+		 * 
+		 * @param GP_Project $project The project being reendered.
 		 */
 		do_action( 'gp_after_project_form_fields', $project );
 	?>

--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -32,6 +32,13 @@
 	<dd><?php echo gp_projects_dropdown( 'project[parent_project_id]', $project->parent_project_id, array(), $project->id ); ?></dd>
 
 	<dt><label for="project[active]"><?php _e( 'Active', 'glotpress' ); ?></label> <input type="checkbox" id="project[active]" name="project[active]" <?php gp_checked( $project->active ); ?> /></dt>
+
+	<?php
+		/**
+		 * Fires after the default project form fields.
+		 */
+		do_action( 'gp_after_project_form_fields' );
+	?>
 </dl>
 
 <?php echo gp_js_focus_on( 'project[name]' ); ?>

--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -36,6 +36,7 @@
 	<?php
 		/**
 		 * Fires after the default project form fields.
+		 * 
 		 * @since 4.0.0
 		 * 
 		 * @param GP_Project $project The project being reendered.

--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -37,7 +37,7 @@
 		/**
 		 * Fires after the default project form fields.
 		 */
-		do_action( 'gp_after_project_form_fields' );
+		do_action( 'gp_after_project_form_fields', $project );
 	?>
 </dl>
 


### PR DESCRIPTION
## What?
This PR introduces a new action `gp_after_project_form_fields` with developers can use to add additional form fields to GlotPress projects.

## Why?
Currently, plugins extending GlotPress need to override the whole template file in order to add additional form fields. This new action would allow them to easily place them after the default fields.

## How?
This PR closes #969

When the project form is submitted, the additional form fields can be saved [as described in the issue](https://github.com/GlotPress/GlotPress/issues/969#issuecomment-1293344163).
