### PR TITLE
[1523] Get supported formats extensions dynamically

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -566,6 +566,31 @@ function gp_get_import_file_format( $selected_format, $filename ) {
 }
 
 /**
+ * Gets the list of format extensions prefixed with leading delimiters "." ( eg.: '.po' ).
+ *
+ * @since 4.0.0
+ *
+ * @return array   Supported format file extensions.
+ */
+function gp_get_format_extensions() {
+
+	$format_extensions = array();
+
+	// Get all the supported format extensions.
+	foreach ( GP::$formats as $format ) {
+		$format_extensions = array_merge( $format_extensions, $format->get_file_extensions() );
+	}
+
+	// Remove any duplicates added by alternate extensions.
+	$format_extensions = array_unique( $format_extensions );
+
+	// Prefix with delimiter ".".
+	$format_extensions = preg_replace( '/^/', '.', $format_extensions );
+
+	return $format_extensions;
+}
+
+/**
  * Displays the GlotPress administrator option in the user profile screen for WordPress administrators.
  *
  * @since 2.0.0

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -24,19 +24,30 @@ if ( 'originals' === $kind ) {
 
 gp_title( $gp_title );
 gp_tmpl_header();
-?>
 
+$format_extensions      = array();
+$format_options         = array();
+$format_options['auto'] = __( 'Auto Detect', 'glotpress' );
+foreach ( GP::$formats as $slug => $format ) {
+	$format_extensions[] = '.' . pathinfo( '.' . $format->extension )['extension'];
+	if ( ! empty( $format->alt_extensions ) ) {
+		foreach ( $format->alt_extensions as $alt_extension ) {
+			$format_extensions[] = '.' . pathinfo( '.' . $alt_extension )['extension'];
+		}
+	}
+	$format_options[ $slug ] = $format->name;
+}
+
+// Remove duplicates.
+$format_extensions = array_unique( $format_extensions );
+
+?>
 <h2><?php echo 'originals' == $kind ? __( 'Import Originals', 'glotpress' ) : __( 'Import Translations', 'glotpress' ); ?></h2>
 <form action="" method="post" enctype="multipart/form-data">
 	<dl>
 	<dt><label for="import-file"><?php _e( 'Import File:', 'glotpress' ); ?></label></dt>
-	<dd><input type="file" name="import-file" id="import-file" accept=".xml,.po,.pot,.mo,.resx,.strings,.properties,.json" /></dd>
+	<dd><input type="file" name="import-file" id="import-file" accept="<?php esc_attr_e( implode( ',', $format_extensions ) ); ?>" /></dd>
 <?php
-	$format_options         = array();
-	$format_options['auto'] = __( 'Auto Detect', 'glotpress' );
-	foreach ( GP::$formats as $slug => $format ) {
-		$format_options[ $slug ] = $format->name;
-	}
 
 	$status_options = array();
 	if ( isset( $can_import_current ) && $can_import_current ) {

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -25,19 +25,12 @@ if ( 'originals' === $kind ) {
 gp_title( $gp_title );
 gp_tmpl_header();
 
-$format_extensions = array();
-foreach ( GP::$formats as $format ) {
-	$format_extensions = array_merge( $format_extensions, $format->get_file_extensions() );
-}
-// Remove redundant alternate extensions that have the same ending and add leading '.'.
-$format_extensions = array_unique( preg_replace( '/^(\w*\.)*/', '.', $format_extensions ) );
-
 ?>
 <h2><?php echo 'originals' == $kind ? __( 'Import Originals', 'glotpress' ) : __( 'Import Translations', 'glotpress' ); ?></h2>
 <form action="" method="post" enctype="multipart/form-data">
 	<dl>
 	<dt><label for="import-file"><?php _e( 'Import File:', 'glotpress' ); ?></label></dt>
-	<dd><input type="file" name="import-file" id="import-file" accept="<?php echo esc_attr( implode( ',', $format_extensions ) ); ?>" /></dd>
+	<dd><input type="file" name="import-file" id="import-file" accept="<?php echo esc_attr( implode( ',', gp_get_format_extensions() ) ); ?>" /></dd>
 <?php
 
 	$format_options         = array();

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -25,21 +25,12 @@ if ( 'originals' === $kind ) {
 gp_title( $gp_title );
 gp_tmpl_header();
 
-$format_extensions      = array();
-$format_options         = array();
-$format_options['auto'] = __( 'Auto Detect', 'glotpress' );
-foreach ( GP::$formats as $slug => $format ) {
-	$format_extensions[] = '.' . pathinfo( '.' . $format->extension )['extension'];
-	if ( ! empty( $format->alt_extensions ) ) {
-		foreach ( $format->alt_extensions as $alt_extension ) {
-			$format_extensions[] = '.' . pathinfo( '.' . $alt_extension )['extension'];
-		}
-	}
-	$format_options[ $slug ] = $format->name;
+$format_extensions = array();
+foreach ( GP::$formats as $format ) {
+	$format_extensions = array_merge( $format_extensions, $format->get_file_extensions() );
 }
-
-// Remove duplicates.
-$format_extensions = array_unique( $format_extensions );
+// Remove redundant alternate extensions that have the same ending and add leading '.'.
+$format_extensions = array_unique( preg_replace( '/^(\w*\.)*/', '.', $format_extensions ) );
 
 ?>
 <h2><?php echo 'originals' == $kind ? __( 'Import Originals', 'glotpress' ) : __( 'Import Translations', 'glotpress' ); ?></h2>
@@ -48,6 +39,12 @@ $format_extensions = array_unique( $format_extensions );
 	<dt><label for="import-file"><?php _e( 'Import File:', 'glotpress' ); ?></label></dt>
 	<dd><input type="file" name="import-file" id="import-file" accept="<?php echo esc_attr( implode( ',', $format_extensions ) ); ?>" /></dd>
 <?php
+
+	$format_options         = array();
+	$format_options['auto'] = __( 'Auto Detect', 'glotpress' );
+	foreach ( GP::$formats as $slug => $format ) {
+		$format_options[ $slug ] = $format->name;
+	}
 
 	$status_options = array();
 	if ( isset( $can_import_current ) && $can_import_current ) {

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -46,7 +46,7 @@ $format_extensions = array_unique( $format_extensions );
 <form action="" method="post" enctype="multipart/form-data">
 	<dl>
 	<dt><label for="import-file"><?php _e( 'Import File:', 'glotpress' ); ?></label></dt>
-	<dd><input type="file" name="import-file" id="import-file" accept="<?php esc_attr_e( implode( ',', $format_extensions ) ); ?>" /></dd>
+	<dd><input type="file" name="import-file" id="import-file" accept="<?php echo esc_attr( implode( ',', $format_extensions ) ); ?>" /></dd>
 <?php
 
 	$status_options = array();


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Dynamically generate the supported formats file extensions for file imports.

## Why?
If a plugin adds a new file format, dynamically get all the available extensions.

## How?
Use the set Formats.

## Testing Instructions
Go to the project import dialog and click the button to upload.


Fix #1523 