### PR TITLE
Add a filter to modify the sidebar

### DIFF
--- a/gp-templates/translation-row-editor-meta.php
+++ b/gp-templates/translation-row-editor-meta.php
@@ -52,7 +52,7 @@ $more_links['history'] = '<a tabindex="-1" href="' . esc_url( $original_history 
  * @param GP_Translation $translation Translation object.
  */
 $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_links, $project, $locale, $translation_set, $translation );
-
+ob_start();
 ?>
 <div class="meta">
 	<h3><?php _e( 'Meta', 'glotpress' ); ?></h3>
@@ -163,3 +163,17 @@ $more_links = apply_filters( 'gp_translation_row_template_more_links', $more_lin
 		</dt>
 	</dl>
 </div>
+<?php
+$meta_sidebar = ob_get_clean();
+/**
+ * Filter the content in the sidebar.
+ *
+ * @since 4.0.0
+ *
+ * @param string $meta_sidebar Default content for the sidebar.
+ * @param array  $defined_vars The defined vars.
+ */
+$meta_sidebar = apply_filters( 'gp_right_sidebar', $meta_sidebar, get_defined_vars() );
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo $meta_sidebar;


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a filter to be able to modify the sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We are adding some tabs in the sidebar [here](https://github.com/GlotPress/gp-translation-helpers/pull/148), so we need a filter to modify the sidebar content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR:
1. Adds a new filter. 
2. Modify the current info, storing the sidebar content into the `$meta_sidebar` variable, so it can be used in the filter. 
3. Add the new method `gp_link_user_get()` to create the link without printing it.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->
1. Enable the [gp-translation-helpers](https://github.com/GlotPress/gp-translation-helpers) plugin, in the `tabs-sidebar` branch.
2. See the new content in the sidebar.