### PR TITLE
Set as old the previous translations with waiting status for this user

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -682,6 +682,15 @@ class GP_Translation extends GP_Thing {
 				'status'             => 'changesrequested',
 			)
 		)
+		&& $this->update(
+			array( 'status' => 'old' ),
+			array(
+				'original_id'        => $this->original_id,
+				'translation_set_id' => $this->translation_set_id,
+				'user_id'            => $this->user_id,
+				'status'             => 'waiting',
+			)
+		)
 		&& $this->save(
 			array(
 				'status'                => 'waiting',

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -584,4 +584,23 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( 1, count( $waiting_translations ) );
 		$this->assertEquals( 1, $set->waiting_count() );
 	}
+
+	function test_when_update_a_waiting_translation_it_is_set_to_old_status() {
+		$user = $this->factory->user->create();
+
+		wp_set_current_user( $user );
+		$set = $this->factory->translation_set->create_with_project_and_locale( );
+		$original = $this->factory->original->create( array( 'project_id' => $set->project_id ) );
+		$translation_old = $this->factory->translation->create( array( 'user_id' => $user, 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'waiting' ) );
+		$this->assertTrue( $translation_old->set_as_waiting() );
+		$translation_waiting = $this->factory->translation->create( array( 'user_id' => $user, 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'waiting' ) );
+		$this->assertTrue( $translation_waiting->set_as_waiting() ); //$translation_old is now old
+
+		$old_translations = GP::$translation->for_translation( $set->project, $set, 0, array( 'status' => 'old' ) );
+		$waiting_translations = GP::$translation->for_translation( $set->project, $set, 0, array( 'status' => 'waiting' ) );
+
+		$this->assertEquals( 1, $set->waiting_count() );
+		$this->assertEquals( 1, count( $waiting_translations ) );
+		$this->assertEquals( 1, count( $old_translations ) );
+	}
 }

--- a/tests/phpunit/testcases/tests_things/test_thing_translation.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation.php
@@ -603,4 +603,31 @@ class GP_Test_Thing_Translation extends GP_UnitTestCase {
 		$this->assertEquals( 1, count( $waiting_translations ) );
 		$this->assertEquals( 1, count( $old_translations ) );
 	}
+
+	function test_when_update_a_waiting_translation_it_is_set_to_old_status_and_dont_set_as_old_the_suggestions_from_other_users() {
+		$user1 = $this->factory->user->create();
+		$user2 = $this->factory->user->create();
+
+		$set = $this->factory->translation_set->create_with_project_and_locale( );
+		$original = $this->factory->original->create( array( 'project_id' => $set->project_id ) );
+
+		wp_set_current_user( $user1 );
+		$translation1_old = $this->factory->translation->create( array( 'user_id' => $user1, 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'waiting' ) );
+		$this->assertTrue( $translation1_old->set_as_waiting() );
+
+		wp_set_current_user( $user2 );
+		$translation2 = $this->factory->translation->create( array( 'user_id' => $user2, 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'waiting' ) );
+		$this->assertTrue( $translation2->set_as_waiting() );
+
+		wp_set_current_user( $user1 );
+		$translation1_waiting = $this->factory->translation->create( array( 'user_id' => $user1, 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'waiting' ) );
+		$this->assertTrue( $translation1_waiting->set_as_waiting() ); //$translation1_old is now old
+
+		$old_translations = GP::$translation->for_translation( $set->project, $set, 0, array( 'status' => 'old' ) );
+		$waiting_translations = GP::$translation->for_translation( $set->project, $set, 0, array( 'status' => 'waiting' ) );
+
+		$this->assertEquals( 2, $set->waiting_count() );
+		$this->assertEquals( 2, count( $waiting_translations ) );
+		$this->assertEquals( 1, count( $old_translations ) );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When a translator suggests more than 1 translation for the same original, the previous ones maintain the `waiting` status. I think we should set the previous translations as `old`, because the new suggestion has improved the previous ones.

Fixes https://github.com/GlotPress/GlotPress/issues/1498.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the same user adds a new suggestion for the same original, I think the new suggestion is an improvement to the previous ones, so it doesn't make sense to have the old translations in `waiting` status. The best approach is to change the previous translations' status to `old`. If the translator is using this as a communication platform with the validator, she has the feedback tool to do this at https://translate.wordpress.org/, and soon she will have the same tool in the GlotPress core (currently, in the [gp-translation-helpers](https://github.com/GlotPress/gp-translation-helpers)) plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When the new suggestion is stored with the `waiting` status, the previous translations for the same original, the same translation set (project and language), the same translator and in `waiting` status are set to `old`.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

I have added 2 tests. If you want to test it manually, you need:
1. Suggest a translation (T1) to an original.
2. Suggest a different translation (T2) for the same original.
3. Review the history for this original and see that the first translation (T1) is in `old` status and the new translation (T2) is in `waiting` status.
4. After adding T1, with another user (e.g. in another browser), you can add a different translation (T2) for the same original and when you add T3, you can see T1 in `old` status and T2 and T3 in `waiting` status.
 
## Screenshots or screencast <!-- if applicable -->

The previous translations for the `user1` has been set as `old`. It doesn't affect the user2' translations.

![image](https://user-images.githubusercontent.com/1667814/204575438-8540dd53-16e8-4cd2-a8c5-bd47bba0f594.png)
