### PR TITLE
Explain when the wp_locale filed should be used

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -9,7 +9,7 @@ class GP_Locale {
 	public $lang_code_iso_639_2 = null;
 	public $lang_code_iso_639_3 = null;
 	public $country_code;
-	public $wp_locale;
+	public $wp_locale; // This should only be set for locales that is offically supported on translate.wordpress.org.
 	public $slug;
 	public $nplurals = 2;
 	public $plural_expression = 'n != 1';

--- a/locales/locales.php
+++ b/locales/locales.php
@@ -9,7 +9,7 @@ class GP_Locale {
 	public $lang_code_iso_639_2 = null;
 	public $lang_code_iso_639_3 = null;
 	public $country_code;
-	public $wp_locale; // This should only be set for locales that is offically supported on translate.wordpress.org.
+	public $wp_locale; // This should only be set for locales that are offically supported on translate.wordpress.org.
 	public $slug;
 	public $nplurals = 2;
 	public $plural_expression = 'n != 1';


### PR DESCRIPTION
## What?
In our GlotPress chat, @ocean90 mentioned that the `wp_locale` should only be set when the language is officially supported on translate.wordpress.org: https://wordpress.slack.com/archives/C02RP4R9F/p1669797958749989

## How?
By adding a comment for the variable, we'll make this piece of documentation part of the file.
