### PR TITLE
Update the Facebook locale for es_MX

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -900,7 +900,7 @@ class GP_Locales {
 		$es_mx->wp_locale = 'es_MX';
 		$es_mx->slug = 'es-mx';
 		$es_mx->google_code = 'es';
-		$es_mx->facebook_locale = 'es_MX';
+		$es_mx->facebook_locale = 'es_LA';
 
 		$es_pe = new GP_Locale();
 		$es_pe->english_name = 'Spanish (Peru)';


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The `facebook_locale` property for `es_MX` is incorrect. The correct value is `es_LA`. Currently, Facebook only [supports](https://developers.facebook.com/docs/messenger-platform/messenger-profile/supported-locales/) `es_ES` (Spanish for Spain) and `es_LA` (Spanish for Latin America). The correct one for `es_MX`(Spanish for Mexico) is `es_LA`.

