### PR TITLE
Check JSON for double array to fix fatal error

### DIFF
--- a/gp-includes/formats/format-json.php
+++ b/gp-includes/formats/format-json.php
@@ -106,6 +106,9 @@ class GP_Format_JSON extends GP_Format {
 			}
 
 			$args['translations'] = (array) $value;
+			if ( ! is_string( $args['translations'][0] ) ) {
+				continue;
+			}
 
 			$entries->add_entry( new Translation_Entry( $args ) );
 		}

--- a/gp-includes/formats/format-json.php
+++ b/gp-includes/formats/format-json.php
@@ -106,7 +106,7 @@ class GP_Format_JSON extends GP_Format {
 			}
 
 			$args['translations'] = (array) $value;
-			if ( ! empty( $args['translations'][0] ) && ! is_string( $args['translations'][0] ) ) {
+			if ( empty( $args['translations'][0] ) || ! is_string( $args['translations'][0] ) ) {
 				continue;
 			}
 

--- a/gp-includes/formats/format-json.php
+++ b/gp-includes/formats/format-json.php
@@ -106,7 +106,7 @@ class GP_Format_JSON extends GP_Format {
 			}
 
 			$args['translations'] = (array) $value;
-			if ( ! is_string( $args['translations'][0] ) ) {
+			if ( ! empty( $args['translations'][0] ) && ! is_string( $args['translations'][0] ) ) {
 				continue;
 			}
 

--- a/gp-includes/formats/format-json.php
+++ b/gp-includes/formats/format-json.php
@@ -107,7 +107,7 @@ class GP_Format_JSON extends GP_Format {
 
 			$args['translations'] = (array) $value;
 			if ( empty( $args['translations'][0] ) || ! is_string( $args['translations'][0] ) ) {
-				continue;
+				$args['translations'] = array();
 			}
 
 			$entries->add_entry( new Translation_Entry( $args ) );


### PR DESCRIPTION


## What?
This PR fixes the fatal error thrown below;
> ```E_ERROR: Uncaught TypeError: Argument 2 passed to GP_Builtin_Translation_Warnings::warning_named_placeholders() must be of the type string, array given, called in /home/wporg/public_html/wp-content/plugins/glotpress/gp-includes/warnings.php on line 101 and defined in /home/wporg/public_html/wp-content/plugins/glotpress/gp-includes/warnings.php:671```

## Why?
It throws a fatal error.

## How?
The error is caused when a JSON file with a double array e.g `{"%s unread item":[["a ungelesen","b ungelesen"]]}` is imported into a project

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->