### PR TITLE
Inline Translation: Make it work in the customizer

### DIFF
--- a/assets/css/inline-translation.css
+++ b/assets/css/inline-translation.css
@@ -245,7 +245,7 @@
   }
 }
 .webui-popover {
-	z-index: 100000;
+	z-index: 999999999;
 	direction: ltr;
 }
 
@@ -346,4 +346,8 @@ iframe.translator-untranslatable::after {
 
 iframe.translator-untranslatable {
 	border: 1px dotted #00f !important;
+}
+
+.webui-popover > .arrow {
+	margin: 0;
 }

--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -461,10 +461,9 @@ class GP_Inline_Translation {
 	 */
 	public function load_translator( $locale_code = null ) {
 		global $wp_customize;
-		if ( isset( $wp_customize ) && !doing_action( 'customize_controls_print_footer_scripts' ) ) {
+		if ( isset( $wp_customize ) && ! doing_action( 'customize_controls_print_footer_scripts' ) ) {
 			return false;
 		}
-
 
 		if ( ! $locale_code ) {
 			$locale_code = get_locale();

--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -85,6 +85,7 @@ class GP_Inline_Translation {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		add_action( 'admin_footer', array( $this, 'load_admin_translator' ), 1000 );
+		add_action( 'customize_controls_print_footer_scripts', array( $this, 'load_admin_translator' ), 1000 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		add_action( 'wp_ajax_inform_translator', array( $this, 'load_ajax_translator' ), 1000 );
@@ -459,6 +460,12 @@ class GP_Inline_Translation {
 	 * @return     bool  Whethe the tranlator code was printed.
 	 */
 	public function load_translator( $locale_code = null ) {
+		global $wp_customize;
+		if ( isset( $wp_customize ) && !doing_action( 'customize_controls_print_footer_scripts' ) ) {
+			return false;
+		}
+
+
 		if ( ! $locale_code ) {
 			$locale_code = get_locale();
 		}
@@ -470,6 +477,10 @@ class GP_Inline_Translation {
 		echo '<script type="text','/javascript">';
 		echo 'gpInlineTranslationData = ', wp_json_encode( $this->get_inline_translation_object( $locale_code ), JSON_PRETTY_PRINT ), ';';
 		echo '</script>';
+
+		if ( $this->translator_launcher_displayed ) {
+			return true;
+		}
 
 		?><div id="translator-launcher" class="translator">
 			<a href="" title="<?php esc_attr_e( 'Inline Translation' ); ?>">

--- a/inline-translation/css/custom.css
+++ b/inline-translation/css/custom.css
@@ -1,5 +1,5 @@
 .webui-popover {
-	z-index: 100000;
+	z-index: 999999999;
 	direction: ltr;
 }
 
@@ -100,4 +100,8 @@ iframe.translator-untranslatable::after {
 
 iframe.translator-untranslatable {
 	border: 1px dotted #00f !important;
+}
+
+.webui-popover > .arrow {
+	margin: 0;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
The Inline Translator didn't work on the Customizer.

## Why?
Also the customizer uses translation, so you should be able to change them there.

## How?
Add some filters, special handling and update the CSS.

## Testing Instructions
Activate the Inline Translator on the Customizer.

## Screenshots or screencast <!-- if applicable -->
<img width="741" alt="Screenshot 2023-02-23 at 13 47 17" src="https://user-images.githubusercontent.com/203408/220910903-b8cc77f5-1fb8-4d65-b9ce-741cbfd0f747.png">

