### PR TITLE
Local: JIT Create Translation

### DIFF
--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -379,10 +379,20 @@ class GP_Inline_Translation {
 						'context'    => $entry->context,
 						'singular'   => $entry->singular,
 						'plural'     => $entry->plural,
+						'status'     => '+active',
 					)
 				);
 
-				// TODO: add translation.
+				if ( $translation !== $entry->singular ) {
+					$translation_record = GP::$translation->create(
+						array(
+							'original_id'        => $original_record->id,
+							'translation_set_id' => $translation_sets[ $projects[0]->id ]->id,
+							'translation_0'      => $translation,
+							'status'             => 'current',
+						)
+					);
+				}
 			} else {
 				return false;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
Not only just-in-time create an original but also the associated translation in the local GlotPress.

## Why?
When original and translation cannot be prefilled from PO file or translate.wordpress.org, the translation should also be created.

## How?
When a translation passes through the gettext filter, we can create it in the Local GlotPress.
