### PR TITLE
Router: Fix notice accessing undefined variable

### DIFF
--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -31,7 +31,11 @@ class GP_Router {
 	 */
 	public function request_uri() {
 		global $wp;
-		return urldecode( '/' . rtrim( $wp->query_vars['gp_route'], '/' ) );
+		$gp_route = '';
+		if ( isset( $wp->query_vars['gp_route'] ) ) {
+			$gp_route = $wp->query_vars['gp_route'];
+		}
+		return urldecode( '/' . rtrim( $gp_route, '/' ) );
 	}
 
 	public function request_method() {


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
When accessing a URL that doesn't define the `gp_route` query_var, a notice is thrown.

## Why?
Trying to avoid any notices.

## How?
Check the variable.
