### PR TITLE
Remove unused if block

### DIFF
--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -512,10 +512,6 @@ class GP_Inline_Translation {
 		echo 'gpInlineTranslationData = ', wp_json_encode( $this->get_inline_translation_object( $locale_code ), JSON_PRETTY_PRINT ), ';';
 		echo '</script>';
 
-		if ( $this->translator_launcher_displayed ) {
-			return true;
-		}
-
 		?><div id="translator-launcher" class="translator">
 			<a href="" title="<?php esc_attr_e( 'Inline Translation' ); ?>">
 				<span class="dashicons dashicons-admin-site-alt3">


### PR DESCRIPTION
## What?
An unused if block is removed

## Why?
It throws a warning 
`Warning: Undefined property: GP_Inline_Translation::$translator_launcher_displayed in /glotpress/gp-includes/inline-translation.php on line 515](https://github.com/GlotPress/GlotPress/blob/cd06c47f27f69c68760f697b191bba1be208f49e/gp-includes/inline-translation.php#L515)`

