### PR TITLE
Local: Add a Contribute Back view

### DIFF
--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -577,6 +577,22 @@ class GP_Local {
 	 * @return void
 	 */
 	public function sync_to_wordpress_org_overview() {
+		if ( ! empty( $_POST['_wpnonce'] ) && ! empty( $_POST['translation'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'sync_translations' ) ) {
+			$translations_by_project_translation_set = array();
+			foreach ( array_keys( $_POST['translation'] ) as $id ) {
+				$translations_by_project_translation_set[ $_POST['project'][ $id ] ][ $_POST['translation_set'][ $id ] ][] = $id;
+			}
+			?>
+			<p>
+			Would send these translations: <tt>[project][translation_set] =&gt; id</tt>
+			</p>
+			<pre>
+			<?php
+			var_dump( $translations_by_project_translation_set ); // phpcs:ignore
+			?>
+			</pre>
+			<?php
+		}
 		include __DIR__ . '/../gp-templates/helper-functions.php';
 		global $wpdb;
 
@@ -645,16 +661,36 @@ class GP_Local {
 			<?php
 			switch ( strtok( $current_project->path, '/' ) ) {
 				case 'local-wp':
-					echo 'WordPress ';
+					echo esc_html(
+						sprintf(
+							// translators: %s is the name of the WordPress translation project, such as Administration.
+							__( 'WordPress %s' ),
+							$current_project->name
+						)
+					);
 					break;
 				case 'local-plugins':
-					echo 'Plugin ';
+					echo esc_html(
+						sprintf(
+							// translators: %s is a plugin name.
+							__( 'Plugin: %s' ),
+							$current_project->name
+						)
+					);
 					break;
 				case 'local-themes':
-					echo 'Theme ';
+					echo esc_html(
+						sprintf(
+							// translators: %s is a theme name.
+							__( 'Theme: %s' ),
+							$current_project->name
+						)
+					);
 					break;
+				default:
+					echo esc_html( $current_project->name );
 			}
-			echo esc_html( $current_project->name );
+
 			echo ' ';
 			echo gp_link_project_get( $current_project, '<span class="dashicons dashicons-external"></span>', array( 'target' => '_blank' ) );
 			?>
@@ -732,6 +768,7 @@ class GP_Local {
 				</span>
 			</p>
 			<form action="" method="post">
+				<?php wp_nonce_field( 'sync_translations' ); ?>
 		<?php foreach ( $translations as $translation ) : ?>
 			<?php
 			$table_start( $translation );
@@ -741,8 +778,8 @@ class GP_Local {
 			<tr class="status-<?php echo esc_attr( $translation->status ); ?> priority-<?php echo esc_attr( $translation->priority ); ?> has-translations">
 				<td class="sync">
 					<input type="checkbox" name="translation[<?php echo esc_attr( $translation->id ); ?>]" value="1" checked="checked" />
-					<input type="hidden" name="project[<?php echo esc_attr( $translation->id ); ?>]" value="translation[<?php echo esc_attr( $translation->project_id ); ?>]" />
-					<input type="hidden" name="translation_set[<?php echo esc_attr( $translation->id ); ?>]" value="translation[<?php echo esc_attr( $translation->translation_set_id ); ?>]" />
+					<input type="hidden" name="project[<?php echo esc_attr( $translation->id ); ?>]" value="<?php echo esc_attr( $translation->project_id ); ?>" />
+					<input type="hidden" name="translation_set[<?php echo esc_attr( $translation->id ); ?>]" value="<?php echo esc_attr( $translation->translation_set_id ); ?>" />
 				</td>
 				<td class="original">
 					<span class="original-text"><?php echo prepare_original( esc_translation( $translation->singular ) ); ?></span>

--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -101,8 +101,8 @@ class GP_Local {
 			);
 			add_submenu_page(
 				'glotpress',
-				esc_html__( 'Sync to w.org', 'glotpress' ),
-				esc_html__( 'Sync to w.org', 'glotpress' ),
+				esc_html__( 'Contribute back', 'glotpress' ),
+				esc_html__( 'Contribute back', 'glotpress' ),
 				'read',
 				'glotpress-sync',
 				array( $this, 'sync_to_wordpress_org_overview' ),
@@ -706,8 +706,22 @@ class GP_Local {
 		</style>
 		<div class="wrap">
 			<h1>
-				<?php esc_html_e( 'Sync to WordPress.org', 'glotpress' ); ?>
+				<?php esc_html_e( 'Contribute back', 'glotpress' ); ?>
 			</h1>
+			<p>
+				<span>
+					<?php esc_html_e( 'Thank you for contributing back to WordPress.org!', 'glotpress' ); ?>
+				</span>
+				<span>
+					<?php echo esc_html(
+					sprintf(
+						// translators: %s is the user's language.
+						__( 'These are all %s translations that you have created in your Local GlotPress and are now ready to be sent back to WordPress.org.', 'glotpress' ),
+						$gp_locale->native_name
+						)
+					); ?>
+				</span>
+			</p>
 			<form action="" method="post">
 		<?php foreach ( $translations as $translation ) : ?>
 			<?php

--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -590,7 +590,7 @@ class GP_Local {
 			$gp_locale->wp_locale    = $locale_code;
 		}
 
-		$translations = $wpdb->get_results(
+		$translations    = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT
 					p.id AS project_id,
@@ -621,23 +621,28 @@ class GP_Local {
 			)
 		);
 		$current_project = false;
-		$table_end = function() use ( $current_project ) {
+		$table_end       = function() use ( $current_project ) {
 			if ( ! $current_project ) {
 				return;
 			}
-			?></tbody></table><?php
+			?>
+			</tbody></table>
+			<?php
 		};
 
 		$table_start = function( $translation ) use ( &$current_project ) {
-			if ( $current_project && $current_project->id == $translation->project_id ) {
+			if ( $current_project && intval( $translation->project_id ) === $current_project->id ) {
 				return;
 			}
 			if ( $current_project ) {
-				?></tbody></table><?php
+				?>
+				</tbody></table>
+				<?php
 			}
 			$current_project = GP::$project->get( $translation->project_id );
 			?>
-			<h2><?php
+			<h2>
+			<?php
 			switch ( strtok( $current_project->path, '/' ) ) {
 				case 'local-wp':
 					echo 'WordPress ';
@@ -654,9 +659,11 @@ class GP_Local {
 			echo gp_link_project_get( $current_project, '<span class="dashicons dashicons-external"></span>', array( 'target' => '_blank' ) );
 			?>
 			</h2>
-			<p><?php
+			<p>
+			<?php
 			echo esc_html( $current_project->description );
-			?></p>
+			?>
+			</p>
 			<table class="translations widefat">
 				<thead>
 					<tr>
@@ -713,13 +720,15 @@ class GP_Local {
 					<?php esc_html_e( 'Thank you for contributing back to WordPress.org!', 'glotpress' ); ?>
 				</span>
 				<span>
-					<?php echo esc_html(
-					sprintf(
+					<?php
+					echo esc_html(
+						sprintf(
 						// translators: %s is the user's language.
-						__( 'These are all %s translations that you have created in your Local GlotPress and are now ready to be sent back to WordPress.org.', 'glotpress' ),
-						$gp_locale->native_name
+							__( 'These are all %s translations that you have created in your Local GlotPress and are now ready to be sent back to WordPress.org.', 'glotpress' ),
+							$gp_locale->native_name
 						)
-					); ?>
+					);
+					?>
 				</span>
 			</p>
 			<form action="" method="post">
@@ -727,9 +736,9 @@ class GP_Local {
 			<?php
 			$table_start( $translation );
 			$original_permalink = gp_url_project_locale( $current_project, $gp_locale->slug, $translation->translation_set_slug, array( 'filters[original_id]' => $translation->original_id ) );
-			$user = get_userdata( $translation->user_id );
+			$user               = get_userdata( $translation->user_id );
 			?>
-			<tr class="status-<?php echo esc_attr( $translation->status); ?> priority-<?php echo esc_attr( $translation->priority); ?> has-translations">
+			<tr class="status-<?php echo esc_attr( $translation->status ); ?> priority-<?php echo esc_attr( $translation->priority ); ?> has-translations">
 				<td class="sync">
 					<input type="checkbox" name="translation[<?php echo esc_attr( $translation->id ); ?>]" value="1" checked="checked" />
 					<input type="hidden" name="project[<?php echo esc_attr( $translation->id ); ?>]" value="translation[<?php echo esc_attr( $translation->project_id ); ?>]" />
@@ -742,7 +751,16 @@ class GP_Local {
 					<span class="translation-text"><?php echo prepare_original( esc_translation( $translation->translation_0 ) ); ?></span>
 				</td>
 				<td class="meta">
-					<?php printf( __( '%s ago' ), esc_html( human_time_diff( strtotime( $translation->date_modified ) ) ) ); ?> by <?php echo esc_html( $user->display_name ); ?>
+					<?php
+					echo esc_html(
+						sprintf(
+							// translators: %s is a relative human time.
+							__( '%s ago' ),
+							human_time_diff( strtotime( $translation->date_modified ) )
+						)
+					);
+					?>
+					by <?php echo esc_html( $user->display_name ); ?>
 				</td>
 				<td class="actions">
 					<a href="<?php echo esc_url( $original_permalink ); ?>" target="_blank"><span class="dashicons dashicons-external"></span></a>
@@ -752,7 +770,8 @@ class GP_Local {
 		endforeach;
 		$table_end();
 
-		?></tbody></table>
+		?>
+		</tbody></table>
 		<p>
 			<button class="button button-primary">Sync to WordPress.org</button>
 		</p>


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
A view in the GlotPress wp-admin that shows what the user will be syncing.

## Why?
We'll want to enable the user to contribute back to translate.wordpress.org. Before they send off translations, they should be able to verify them.

## Testing Instructions
Open via the wp-admin GlotPress menu > Contribute back

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-03-08 at 15-02-10 Contribute back ‹ akirk blog — WordPress](https://user-images.githubusercontent.com/203408/223732894-bc7a389c-f2ac-4fe1-99bf-82f09ba85b9c.png)


![Screenshot 2023-03-08 at 15-50-54 Contribute back ‹ akirk blog — WordPress](https://user-images.githubusercontent.com/203408/223745781-c28cbd01-ecf2-491b-93c5-42af4f5185f1.png)
