### PR TITLE
Local: Jump to next

### DIFF
--- a/assets/css/inline-translation-loader.css
+++ b/assets/css/inline-translation-loader.css
@@ -20,7 +20,7 @@
 #translator-pop-out {
 	display: none;
 	width: 212px;
-    height: 97px;
+    height: auto;
     background: white;
     bottom: 108px;
     right: 24px;

--- a/assets/js/inline-translation-loader.js
+++ b/assets/js/inline-translation-loader.js
@@ -72,6 +72,10 @@
 			}
 		} );
 
+		if ( jumpToNextOnSave() ) {
+			$( '#inline-jump-next-switch' ).prop( 'checked', true );
+		}
+
 		// only show the button when the translator has been loaded
 		runWhenTranslatorIsLoaded( function() {
 			$( '#translator-launcher' ).show();
@@ -106,6 +110,9 @@
 			}
 
 			return !! document.cookie.match( /autoinlinetranslation=1/ );
+		}
+		function jumpToNextOnSave() {
+			return !! document.cookie.match( /inlinejumptonext=1/ );
 		}
 	} );
 }( jQuery ) );

--- a/assets/js/inline-translation-loader.js
+++ b/assets/js/inline-translation-loader.js
@@ -64,6 +64,14 @@
 			} );
 		} );
 
+		$( document.body ).on( 'change', '#inline-jump-next-switch', function() {
+			if ( $( this ).prop( 'checked' ) ) {
+				document.cookie = 'inlinejumptonext=1;path=/';
+			} else {
+				document.cookie = 'inlinejumptonext=;expires=Sat,%201%20Jan%202000%2000:00:00%20GMT;path=/';
+			}
+		} );
+
 		// only show the button when the translator has been loaded
 		runWhenTranslatorIsLoaded( function() {
 			$( '#translator-launcher' ).show();

--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -597,6 +597,12 @@ class GP_Inline_Translation {
 						<span><?php _e( 'Inline Translation Status', 'glotpress' ); ?></span>
 					</li>
 					<li>
+						<label>
+							<input id="inline-jump-next-switch" type="checkbox">
+						</label>
+						<span><?php _e( 'Jump to next on save', 'glotpress' ); ?></span>
+					</li>
+					<li>
 						<a id="gp-show-translation-list" href="#"><?php _e( 'View list of strings', 'glotpress' ); ?></a>
 					</li>
 					<li class="inline-stats">

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -222,10 +222,8 @@ registerPopoverHandlers = function() {
 					translationPair.updateAllTranslations( data[ originalId ], currentUserId );
 					makeTranslatable( translationPair, $node );
 					notifyTranslated( translationPair );
-					
-					var nextUntranslated = jQuery('.translator-translatable.translator-untranslated');
-					nextUntranslated.webuiPopover('show');
 
+					jQuery( '.translator-translatable.translator-untranslated' ).webuiPopover( 'show' );
 				} ).fail( function() {
 					debug( 'Submitting new translation failed', translation );
 				} );

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -223,7 +223,7 @@ registerPopoverHandlers = function() {
 					makeTranslatable( translationPair, $node );
 					notifyTranslated( translationPair );
 
-					jQuery( '.translator-translatable.translator-untranslated' ).webuiPopover( 'show' );
+					jQuery( '.translator-translatable.translator-untranslated:visible' ).webuiPopover( 'show' );
 				} ).fail( function() {
 					debug( 'Submitting new translation failed', translation );
 				} );

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -223,7 +223,9 @@ registerPopoverHandlers = function() {
 					makeTranslatable( translationPair, $node );
 					notifyTranslated( translationPair );
 
-					jQuery( '.translator-translatable.translator-untranslated:visible' ).webuiPopover( 'show' );
+					if ( !! document.cookie.match( /inlinejumptonext=1/ ) ) {
+						jQuery( '.translator-translatable.translator-untranslated:visible' ).webuiPopover( 'show' );
+					}
 				} ).fail( function() {
 					debug( 'Submitting new translation failed', translation );
 				} );

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -222,6 +222,10 @@ registerPopoverHandlers = function() {
 					translationPair.updateAllTranslations( data[ originalId ], currentUserId );
 					makeTranslatable( translationPair, $node );
 					notifyTranslated( translationPair );
+					
+					var nextUntranslated = jQuery('.translator-translatable.translator-untranslated');
+					nextUntranslated.webuiPopover('show');
+
 				} ).fail( function() {
 					debug( 'Submitting new translation failed', translation );
 				} );


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
On saving a translation in the inline translation mode on a page, the popover is displayed on the next untranslated item found within the dom.

## Why?
Improve inline translation workflow, as the popover automatically displays on the next untranslated string. User is also able to enable or disable this feature.

## How?
Looks for the next untranslated string  in the dom and displays the inline translation popover over it.

## Testing Instructions
1. Enable `Jump to next` by checking the checkbox in the inline settings.
<img width="273" alt="Screenshot 2023-04-13 at 02 56 10" src="https://user-images.githubusercontent.com/2834132/231626994-2ccda03b-9a35-4b17-8411-fb084c6c84ae.png">

2. Right click on a string to translate it, then save
3. The popover shows on the next untranslated string.

## Screenshots or screencast <!-- if applicable -->
![jump-to-next_2](https://user-images.githubusercontent.com/2834132/231629119-91c6b50e-102c-4935-a95b-2906024dacbc.gif)


