### PR TITLE
Improve translation strings consistency and comments to translators

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -489,7 +489,7 @@ class GP_Route_Translation extends GP_Route_Main {
 					case 'changesrequested':
 						$message = sprintf(
 						/* translators: %s: Translations count. */
-							_n( 'Error requesting changes in %s translation.', 'Error requesting changes in %s translations.', $error, 'glotpress' ),
+							_n( 'Error with requesting changes in %s translation.', 'Error with requesting changes in %s translations.', $error, 'glotpress' ),
 							$error
 						);
 						break;

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -843,7 +843,7 @@ class GP_Builtin_Translation_Warnings {
 		$warnings = array();
 		if ( $original_start_spaces && ! $translation_start_spaces ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the beginning of the original string. */
+				/* translators: %d: Number of spaces at the beginning of the original string. */
 				_n(
 					'The translation appears to be missing %d space at the beginning.',
 					'The translation appears to be missing %d spaces at the beginning.',
@@ -855,7 +855,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( ( ! $original_start_spaces ) && $translation_start_spaces ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the beginning of the translation string. */
+				/* translators: %d: Number of spaces at the beginning of the translation string. */
 				_n(
 					'The translation appears to be adding %d space at the beginning.',
 					'The translation appears to be adding %d spaces at the beginning.',
@@ -867,7 +867,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( ( $original_end_spaces ) && ( ! $translation_end_spaces ) ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the end of the original string. */
+				/* translators: %d: Number of spaces at the end of the original string. */
 				_n(
 					'The translation appears to be missing %d space at the end.',
 					'The translation appears to be missing %d spaces at the end.',
@@ -879,7 +879,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( ! $original_end_spaces && $translation_end_spaces ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the end of the translation string. */
+				/* translators: %d: Number of spaces at the end of the translation string. */
 				_n(
 					'The translation appears to be adding %d space at the end.',
 					'The translation appears to be adding %d spaces at the end.',

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -891,7 +891,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( $original_start_spaces && $translation_start_spaces && ( $original_start_spaces !== $translation_start_spaces ) ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the beginning of the original string. 2: Number of spaces at the beginning of the translation string. */
+				/* translators: 1: Number of spaces at the beginning of the original string (singular/plural). 2: Number of spaces at the beginning of the translation string. */
 				_n(
 					'Expected %1$d space at the beginning, got %2$d.',
 					'Expected %1$d spaces at the beginning, got %2$d.',
@@ -904,7 +904,7 @@ class GP_Builtin_Translation_Warnings {
 		}
 		if ( $original_end_spaces && $translation_end_spaces && ( $original_end_spaces !== $translation_end_spaces ) ) {
 			$warnings[] = sprintf(
-				/* translators: 1: Number of spaces at the end of the original string. 2: Number of spaces at the end of the translation string. */
+				/* translators: 1: Number of spaces at the end of the original string (singular/plural). 2: Number of spaces at the end of the translation string. */
 				_n(
 					'Expected %1$d space at the end, got %2$d.',
 					'Expected %1$d spaces at the end, got %2$d.',


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
Fix/improve the below issues with translation strings.
- [x] Merge `Error with requesting changes in %s translation.` and `Error requesting changes in %s translation.`, using the first one for consistency with other similar strings: `Error with approving %s translation.` and `Error with rejecting %s translation.`
- [x] Fix some comments to translators where single `%d` is used instead of numbered placeholders.
- [x] Desambiguate the singular/plural placeholder where multiple placeholders are used, but only one is used for `_n()` singular/plural

This was based on [this chat](https://wordpress.slack.com/archives/C02RP4R9F/p1680532409408619) with @tobifjellner on Slack.