### PR TITLE
Local: Show notices when the inline translation won't work

### DIFF
--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -684,7 +684,7 @@ class GP_Local {
 			$show_actions_column = $can_create_projects;
 			?>
 			<p>
-				<?php esc_html_e( 'These are the plugins and themes that you have installed locally. With GlotPress you can change the translations of these.', 'glotpress' ); ?>
+				<?php esc_html_e( 'These are the plugins and themes that you have installed locally. With GlotPress you can change their translations.', 'glotpress' ); ?>
 			</p>
 
 			<?php foreach ( $projects as $type => $items ) : ?>

--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -106,7 +106,7 @@ class GP_Local {
 				esc_html__( 'Local GlotPress', 'glotpress' ),
 				esc_html__( 'Local GlotPress', 'glotpress' ),
 				'edit_posts',
-				'glotpress-local-glotpress',
+				'local-glotpress',
 				array( $this, 'show_local_projects' ),
 			);
 			add_submenu_page(
@@ -282,6 +282,13 @@ class GP_Local {
 			<h1>
 				<?php esc_html_e( 'Settings', 'glotpress' ); ?>
 			</h1>
+			<?php
+			if ( 'en_US' === get_user_locale() ) {
+				$this->show_english_notice();
+			} elseif ( self::is_active() ) {
+				$this->check_for_existing_language_projects();
+			}
+			?>
 			<form method="post">
 				<?php wp_nonce_field( 'gp_save_settings', 'gp_save_settings_nonce' ); ?>
 				<table class="form-table">
@@ -378,7 +385,7 @@ class GP_Local {
 				return trailingslashit( $directory ) . 'continents-cities-' . $locale->wp_locale . '.po';
 		}
 
-		if ( in_array( dirname($project_path), array( 'wp-plugins', 'wp-themes'), true ) ) {
+		if ( in_array( dirname( $project_path ), array( 'wp-plugins', 'wp-themes' ), true ) ) {
 			return trailingslashit( $directory ) . substr( $project_path, 3 ) . '-' . $locale->wp_locale . '.po';
 		}
 
@@ -487,6 +494,59 @@ class GP_Local {
 	}
 
 	/**
+	 * Display a notice if there are no language projects for the current language.
+	 */
+	private function check_for_existing_language_projects() {
+		if ( ! $this->has_language_projects() ) {
+			?>
+			<div class="notice notice-info">
+				<p>
+				<?php
+					echo wp_kses(
+						sprintf(
+							/* Translators: %s is the Local GlotPress settings URL. */
+							__( 'There are no projects or active translation sets for your language. Please <a href="%s">go to the Local GlotPress settings</a> to activate translation sets for your language.', 'glotpress' ),
+							admin_url( 'admin.php?page=local-glotpress' ),
+						),
+						array( 'a' => array( 'href' => array() ) )
+					);
+				?>
+				</p>
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * Check whether there are language projects.
+	 *
+	 * @return     bool  True if language projects, False otherwise.
+	 */
+	private function has_language_projects() {
+		$locale_code = get_user_locale();
+		$locale_slug = $this->get_locale_slug( $locale_code );
+
+		$gp_locale = $this->get_gp_locale( $locale_code );
+
+		foreach ( $this->get_potential_projects() as $type => $items ) {
+			foreach ( $items as $item ) {
+				if ( empty( $item['TextDomain'] ) ) {
+					continue;
+				}
+				$path    = str_replace( 'wp/wp/', 'wp/', $type . '/' . $item['TextDomain'] );
+				$project = GP::$project->by_path( apply_filters( 'gp_local_project_path', $path ) );
+				if ( $project ) {
+					$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $locale_slug, $gp_locale->slug );
+					if ( $translation_set ) {
+						return $translation_set;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Shows a notice when English is the UI language.
 	 */
 	private function show_english_notice() {
@@ -510,22 +570,12 @@ class GP_Local {
 	}
 
 	/**
-	 * Shows a page with a list with the core, the plugins and themes installed locally.
+	 * Gets the potential local projects.
 	 *
-	 * @return void
+	 * @return     array  The potential projects.
 	 */
-	public function show_local_projects() {
-		$locale_code = get_user_locale();
-		$locale_slug = 'default';
-		$gp_locale   = GP_Locales::by_field( 'wp_locale', $locale_code );
-		if ( ! $gp_locale ) {
-			$gp_locale               = new GP_Locale();
-			$gp_locale->english_name = 'Unknown (' . $locale_code . ')';
-			$gp_locale->native_name  = $gp_locale->english_name;
-			$gp_locale->wp_locale    = $locale_code;
-		}
-
-		$projects = array(
+	private function get_potential_projects() {
+		return array(
 			'wp'         => array_map(
 				function( $path ) {
 					global $wp_version;
@@ -552,6 +602,50 @@ class GP_Local {
 				apply_filters( 'local_glotpress_local_themes', wp_get_themes() )
 			),
 		);
+	}
+
+	/**
+	 * Gets the locale slug.
+	 *
+	 * @param      string $locale_code  The (user) locale code.
+	 *
+	 * @return     string  The locale slug.
+	 */
+	private function get_locale_slug( $locale_code ) {
+		// TODO: fix for locales that use a different slug on translate.wordpress.org.
+		return 'default';
+	}
+
+	/**
+	 * Gets the gp locale.
+	 *
+	 * @param      string $locale_code  The locale code.
+	 *
+	 * @return     GP_Locale  The gp locale.
+	 */
+	private function get_gp_locale( $locale_code ) {
+		$gp_locale = GP_Locales::by_field( 'wp_locale', $locale_code );
+		if ( ! $gp_locale ) {
+			$gp_locale               = new GP_Locale();
+			$gp_locale->english_name = 'Unknown (' . $locale_code . ')';
+			$gp_locale->native_name  = $gp_locale->english_name;
+			$gp_locale->wp_locale    = $locale_code;
+		}
+		return $gp_locale;
+	}
+
+	/**
+	 * Shows a page with a list with the core, the plugins and themes installed locally.
+	 *
+	 * @return void
+	 */
+	public function show_local_projects() {
+		$locale_code = get_user_locale();
+		$locale_slug = $this->get_locale_slug( $locale_code );
+
+		$gp_locale = $this->get_gp_locale( $locale_code );
+
+		$projects = $this->get_potential_projects();
 
 		?>
 		<div class="wrap">
@@ -635,7 +729,7 @@ class GP_Local {
 								$title = __( 'Project and language are available.', 'glotpress' );
 							} else {
 								$icon  = '⚠️';
-								$title = __( 'Language is not available.', 'glotpress' );
+								$title = __( 'Project exists but language is not available.', 'glotpress' );
 							}
 						}
 						?>

--- a/gp-includes/local.php
+++ b/gp-includes/local.php
@@ -497,15 +497,19 @@ class GP_Local {
 	 * Display a notice if there are no language projects for the current language.
 	 */
 	private function check_for_existing_language_projects() {
-		if ( ! $this->has_language_projects() ) {
+		$locale_code = get_user_locale();
+		$gp_locale   = $this->get_gp_locale( $locale_code );
+
+		if ( ! $this->has_language_projects( $locale_code ) ) {
 			?>
 			<div class="notice notice-info">
 				<p>
 				<?php
 					echo wp_kses(
 						sprintf(
-							/* Translators: %s is the Local GlotPress settings URL. */
-							__( 'There are no projects or active translation sets for your language. Please <a href="%s">go to the Local GlotPress settings</a> to activate translation sets for your language.', 'glotpress' ),
+							/* Translators: %1$s is a language. %2$s is the Local GlotPress settings URL. */
+							__( 'No projects for %1$s exist right now. Please <a href="%2$s">go to the Local GlotPress settings</a> to activate them for your language.', 'glotpress' ),
+							$gp_locale->native_name,
 							admin_url( 'admin.php?page=local-glotpress' ),
 						),
 						array( 'a' => array( 'href' => array() ) )
@@ -520,13 +524,13 @@ class GP_Local {
 	/**
 	 * Check whether there are language projects.
 	 *
+	 * @param      string $locale_code  The locale code.
+	 *
 	 * @return     bool  True if language projects, False otherwise.
 	 */
-	private function has_language_projects() {
-		$locale_code = get_user_locale();
+	private function has_language_projects( $locale_code ) {
 		$locale_slug = $this->get_locale_slug( $locale_code );
-
-		$gp_locale = $this->get_gp_locale( $locale_code );
+		$gp_locale   = $this->get_gp_locale( $locale_code );
 
 		foreach ( $this->get_potential_projects() as $type => $items ) {
 			foreach ( $items as $item ) {


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
Make it more apparent why inline translation won't work right now.

## Why?
It can be irritating to activate Inline Translation and nothing happens.

## How?
Shows warnings when there are no local projects or translation sets in the current language.

## Testing Instructions
### English
1. Switch to a English and check the GlotPress Settings as well as the Local GlotPress page.

### Other language
1. Switch to a language that doesn't have any translations yet and check the GlotPress Settings as well as the Local GlotPress page.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2023-04-06 at 09 48 56](https://user-images.githubusercontent.com/203408/230319442-8357c283-77dd-4749-80bd-9445ee63c3ff.png)

![Screenshot 2023-04-06 at 11 27 51](https://user-images.githubusercontent.com/203408/230335260-0cc65dc3-b636-46d5-9f0f-64c354aed703.png)

![Screenshot 2023-04-06 at 10 26 13](https://user-images.githubusercontent.com/203408/230319618-3cb769cd-7590-4458-a3bb-0af54ba46e06.png)
