### PR TITLE
Wrong number was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0-rc.2] (April 1, 2022)
 
 **Bugfixes**
-* Glossary: Provide fallback if term splitting has failed. ([#1378])
+* Glossary: preg_split() can fail, causing no original to be displayed ([#1377])
 
 ## [3.0.0-rc.1] (March 31, 2022)
 


### PR DESCRIPTION
For [3.0.0-rc.2] (April 1, 2022), the bugfix link was to a PR... Which doesn't show in this list. If you change it to the actual issue number, it's fixed.

<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Very minor fix in the changelog.md file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? What new functionality is it adding? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it annoyed me a bit that there wasn't a clickable link.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

There shouldn't be any testing ... It works or doesn't.

## Screenshots or screencast <!-- if applicable -->