### PR TITLE
Local: Add locale glossary to inline translation

### DIFF
--- a/assets/css/inline-translation.css
+++ b/assets/css/inline-translation.css
@@ -413,3 +413,61 @@ iframe.translator-untranslatable {
 	margin-bottom: .2em;
 	cursor: pointer;
 }
+
+.webui-popover .glossary-word {
+    display: inline-block;
+    text-decoration: underline;
+    text-decoration-style: dashed;
+    text-decoration-thickness: max(1px,0.063rem);
+    text-underline-offset: 0.1em;
+    text-underline-position: under;
+    cursor: help;
+}
+
+.ui-tooltip {
+	background-color: #eee;
+	margin: 2px;
+	padding: 6px;
+	text-align: left;
+	max-width: 250px;
+	z-index: 999999999 !important;
+	border-radius: 10px;
+}
+
+.ui-tooltip ul {
+	list-style-type: none;
+	margin: 2px;
+	padding-left: 10px;
+}
+
+.ui-tooltip ul li {
+	padding: 0;
+	margin: 0;
+}
+
+.ui-tooltip .pos {
+	display:inline-block;
+	font-style: italic;
+	padding-right: 10px;
+}
+
+.ui-tooltip .translation {
+	font-weight: bold;
+}
+
+.ui-tooltip .comment {
+	display: block;
+	font-size: small;
+}
+
+.ui-tooltip:after {
+	display: block;
+	content: "";
+	border-color: #eee transparent;
+	border-style: solid;
+	border-width: 0 10px 10px;
+	width: 0;
+	position: absolute;
+	top: -8px;
+	left: 1em;
+}

--- a/assets/js/inline-translation-loader.js
+++ b/assets/js/inline-translation-loader.js
@@ -88,6 +88,26 @@
 			$( '#inline-jump-next-switch' ).prop( 'checked', true );
 		}
 
+		jQuery( document.body ).tooltip( {
+			items: '.glossary-word',
+			content: function() {
+				var content = $( '<ul>' );
+				$.each( $( this ).data( 'translations' ), function( i, e ) {
+					var def = $( '<li>' );
+					if ( e.locale_entry ) {
+						def.append( $( '<span>', { text: e.locale_entry } ).addClass( 'locale-entry bubble' ) );
+					}
+					def.append( $( '<span>', { text: e.pos } ).addClass( 'pos' ) );
+					def.append( $( '<span>', { text: e.translation } ).addClass( 'translation' ) );
+					def.append( $( '<span>', { text: e.comment } ).addClass( 'comment' ) );
+					content.append( def );
+				} );
+				return content;
+			},
+			hide: false,
+			show: false,
+		} );
+
 		// only show the button when the translator has been loaded
 		runWhenTranslatorIsLoaded( function() {
 			$( '#translator-launcher' ).show();

--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -131,7 +131,7 @@ class GP_Inline_Translation {
 	public function enqueue_scripts() {
 		wp_enqueue_style( 'inline-translation-loader', gp_plugin_url( 'assets/css/inline-translation-loader.css', __FILE__ ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		wp_enqueue_style( 'inline-translation', gp_plugin_url( 'assets/css/inline-translation.css', __FILE__ ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_enqueue_script( 'inline-translation', gp_plugin_url( 'assets/js/inline-translation.min.js' ), array( 'jquery' ), false, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+		wp_enqueue_script( 'inline-translation', gp_plugin_url( 'assets/js/inline-translation.min.js' ), array( 'jquery', 'jquery-ui-tooltip' ), false, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
 		wp_enqueue_script( 'inline-translation-loader', gp_plugin_url( 'assets/js/inline-translation-loader.js', __FILE__ ), array( 'inline-translation' ), false, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
 	}
 

--- a/gp-includes/inline-translation.php
+++ b/gp-includes/inline-translation.php
@@ -68,6 +68,7 @@ class GP_Inline_Translation {
 		if ( ! self::$instance ) {
 			self::$instance = new self();
 		}
+		require_once GP_PATH . 'gp-templates/helper-functions.php';
 
 		return self::$instance;
 	}
@@ -448,17 +449,22 @@ class GP_Inline_Translation {
 			return false;
 		}
 
-		$query_result                     = new stdClass();
-		$query_result->original_id        = $original_record->id;
-		$query_result->original           = $original;
-		$query_result->domain             = $text_domain;
-		$query_result->singular           = $original_record->singular;
-		$query_result->plural             = $original_record->plural;
-		$query_result->context            = $original_record->context;
-		$query_result->project            = $project->path;
-		$query_result->translation_set_id = $translation_sets[ $project->id ]->id;
-		$query_result->original_comment   = $original_record->comment;
-		$query_result->hash               = $text_domain . '|' . $context . '|' . $entry->singular;
+		$locale_glossary_translation_set = GP::$translation_set->by_project_id_slug_and_locale( 0, $translation_sets[ $project->id ]->slug, $translation_sets[ $project->id ]->locale );
+		$locale_glossary                 = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
+		$singular_glossary_markup        = map_glossary_entries_to_translation_originals( $entry, $locale_glossary )->singular_glossary_markup;
+
+		$query_result                           = new stdClass();
+		$query_result->original_id              = $original_record->id;
+		$query_result->original                 = $original;
+		$query_result->singular_glossary_markup = $singular_glossary_markup;
+		$query_result->domain                   = $text_domain;
+		$query_result->singular                 = $original_record->singular;
+		$query_result->plural                   = $original_record->plural;
+		$query_result->context                  = $original_record->context;
+		$query_result->project                  = $project->path;
+		$query_result->translation_set_id       = $translation_sets[ $project->id ]->id;
+		$query_result->original_comment         = $original_record->comment;
+		$query_result->hash                     = $text_domain . '|' . $context . '|' . $entry->singular;
 
 		$query_result->translations = GP::$translation->find_many( "original_id = '{$query_result->original_id}' AND translation_set_id = '{$query_result->translation_set_id}' AND ( status = 'waiting' OR status = 'fuzzy' OR status = 'current' )" );
 

--- a/gp-includes/rest-api.php
+++ b/gp-includes/rest-api.php
@@ -521,6 +521,26 @@ class GP_Rest_API {
 			);
 		}
 
+		$url = 'https://translate.wordpress.org/locale/' . $locale->slug . '/default/glossary/-export/';
+		$file_name = $locale->slug . '-glossary.csv';
+		$file_path = 	$languages_dir . '/glossary/' . $file_name;
+
+		if ( file_put_contents( $file_path, file_get_contents( $url ) ) ) {
+			$messages[]         = sprintf(
+				// translators: %s is the locale slug.
+				__( 'Imported %s locale glossary.', 'glotpress' ),
+				$locale->slug
+			);
+		} else {
+			$messages[]         = sprintf(
+				// translators: %s locale slug.
+				__( 'Failed to import %s locale glossary.', 'glotpress' ),
+				$locale->slug
+			);
+		}
+
+
+
 		return array(
 			'project'            => $project->id,
 			'translation_set'    => $translation_set->id,

--- a/gp-includes/rest-api.php
+++ b/gp-includes/rest-api.php
@@ -521,26 +521,6 @@ class GP_Rest_API {
 			);
 		}
 
-		$url = 'https://translate.wordpress.org/locale/' . $locale->slug . '/default/glossary/-export/';
-		$file_name = $locale->slug . '-glossary.csv';
-		$file_path = 	$languages_dir . '/glossary/' . $file_name;
-
-		if ( file_put_contents( $file_path, file_get_contents( $url ) ) ) {
-			$messages[]         = sprintf(
-				// translators: %s is the locale slug.
-				__( 'Imported %s locale glossary.', 'glotpress' ),
-				$locale->slug
-			);
-		} else {
-			$messages[]         = sprintf(
-				// translators: %s locale slug.
-				__( 'Failed to import %s locale glossary.', 'glotpress' ),
-				$locale->slug
-			);
-		}
-
-
-
 		return array(
 			'project'            => $project->id,
 			'translation_set'    => $translation_set->id,

--- a/inline-translation/css/custom.css
+++ b/inline-translation/css/custom.css
@@ -167,3 +167,13 @@ iframe.translator-untranslatable {
 	margin-bottom: .2em;
 	cursor: pointer;
 }
+
+.webui-popover .glossary-word {
+    display: inline-block;
+    text-decoration: underline;
+    text-decoration-style: dashed;
+    text-decoration-thickness: max(1px,0.063rem);
+    text-underline-offset: 0.1em;
+    text-underline-position: under;
+    cursor: help;
+}

--- a/inline-translation/css/custom.css
+++ b/inline-translation/css/custom.css
@@ -177,3 +177,51 @@ iframe.translator-untranslatable {
     text-underline-position: under;
     cursor: help;
 }
+
+.ui-tooltip {
+	background-color: #eee;
+	margin: 2px;
+	padding: 6px;
+	text-align: left;
+	max-width: 250px;
+	z-index: 999999999 !important;
+	border-radius: 10px;
+}
+
+.ui-tooltip ul {
+	list-style-type: none;
+	margin: 2px;
+	padding-left: 10px;
+}
+
+.ui-tooltip ul li {
+	padding: 0;
+	margin: 0;
+}
+
+.ui-tooltip .pos {
+	display:inline-block;
+	font-style: italic;
+	padding-right: 10px;
+}
+
+.ui-tooltip .translation {
+	font-weight: bold;
+}
+
+.ui-tooltip .comment {
+	display: block;
+	font-size: small;
+}
+
+.ui-tooltip:after {
+	display: block;
+	content: "";
+	border-color: #eee transparent;
+	border-style: solid;
+	border-width: 0 10px 10px;
+	width: 0;
+	position: absolute;
+	top: -8px;
+	left: 1em;
+}

--- a/inline-translation/lib/original.js
+++ b/inline-translation/lib/original.js
@@ -7,7 +7,8 @@ function Original( original ) {
 	var singular,
 		plural = null,
 		comment = null,
-		originalId = null;
+		originalId = null,
+		glossaryMarkup = null;
 
 	if ( 'string' === typeof original ) {
 		singular = original;
@@ -88,6 +89,7 @@ function Original( original ) {
 				if ( typeof data.original_comment === 'string' ) {
 					comment = data.original_comment.replace( /^translators: /, '' );
 				}
+				glossaryMarkup = data.singular_glossary_markup;
 			} );
 		},
 		getId: function() {
@@ -95,6 +97,9 @@ function Original( original ) {
 		},
 		getComment: function() {
 			return comment;
+		},
+		getGlossaryMarkup: function() {
+			return glossaryMarkup;
 		},
 	};
 }

--- a/inline-translation/lib/popover.js
+++ b/inline-translation/lib/popover.js
@@ -156,7 +156,7 @@ function getInputForm( translationPair ) {
 		pairs = form.find( 'div.pairs' ),
 		item, i;
 
-	original.html( getOriginalHtml( translationPair ) );
+	original.html( translationPair.getOriginal().getGlossaryMarkup() );
 	exposeOtherOriginals( form, translationPair );
 
 	if ( translationPair.getContext() ) {


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
This PR highlights glossary items in an original.

## Why?
To help ensure that translations are of great quality and in line with standards for the locale. Translators are able to quickly view the glossary details of highlighted glossary words by just hovering the mouse on the words.

## How?
This PR highlights glossary words in an original string. It also adds a tooltips that displays more information about the glossary words when hovered on. See screenshots below.

## Testing Instructions
1. Download the locale glossary for the locale you are translating in, from translate.wordpress.org. 
Here is an example to download the glossary for the German(de) locale - https://translate.wordpress.org/locale//default/glossary/-export/
Replace `de` in the url above with your locale slug(e.g `es`, `it` ) to download the glossary file.
2. Import this downloaded glossary file in #1 above into GlotPress, see steps below;
- Step 1: Go to your translations page in GlotPress and click on `Locale Glossary`
![Screenshot 2023-04-27 at 16 50 59](https://user-images.githubusercontent.com/2834132/234917731-ea5403e4-357d-4c5b-a14e-1ae40e9a3935.png)
- Step 2: Click on `Import`
![Screenshot 2023-04-27 at 16 51 11](https://user-images.githubusercontent.com/2834132/234917887-a2669a32-b278-46c8-967c-9f9b55ae7e33.png)
- Step 3: Select the downloaded glossary file from your computer and click on `Import`
![Screenshot 2023-04-27 at 16 51 24](https://user-images.githubusercontent.com/2834132/234918236-a962ab32-70da-4cc3-a7b1-2730d551f185.png)

## Screenshots
![glossary](https://user-images.githubusercontent.com/2834132/234920439-00abd52f-7869-429a-b6d3-36d38f4b5ab3.gif)
