### PR TITLE
Reorder glossary row editor items

### DIFF
--- a/gp-templates/glossary-entry-row.php
+++ b/gp-templates/glossary-entry-row.php
@@ -42,10 +42,10 @@
 					}
 				?>
 				</select></dd>
-				<dt><label for="glossary_entry_comments_<?php echo esc_attr( $entry->id ); ?><?php echo esc_attr( $entry->id ); ?>"><?php _ex( 'Comments', 'glossary entry', 'glotpress' ); ?></label></dt>
-				<dd><textarea type="text" name="glossary_entry[<?php echo esc_attr( $entry->id ); ?>][comment]" id="glossary_entry_comments_<?php echo esc_attr( $entry->id ); ?>"><?php echo esc_textarea( $entry->comment ); ?></textarea></dd>
 				<dt><label for="glossary_entry_translation_<?php echo esc_attr( $entry->id ); ?>"><?php _ex( 'Translation', 'glossary entry', 'glotpress' ); ?></label></dt>
 				<dd><input type="text" name="glossary_entry[<?php echo esc_attr( $entry->id ); ?>][translation]" id="glossary_entry_translation_<?php echo esc_attr( $entry->id ); ?>" value="<?php echo esc_attr( $entry->translation ); ?>"></dd>
+				<dt><label for="glossary_entry_comments_<?php echo esc_attr( $entry->id ); ?><?php echo esc_attr( $entry->id ); ?>"><?php _ex( 'Comments', 'glossary entry', 'glotpress' ); ?></label></dt>
+				<dd><textarea type="text" name="glossary_entry[<?php echo esc_attr( $entry->id ); ?>][comment]" id="glossary_entry_comments_<?php echo esc_attr( $entry->id ); ?>"><?php echo esc_textarea( $entry->comment ); ?></textarea></dd>
 			</dl>
 
 			<input type="hidden" name="glossary_entry[<?php echo esc_attr( $entry->id ); ?>][glossary_id]" value="<?php echo esc_attr( $entry->glossary_id ); ?>">


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
Use the same fields order in both ***New entry*** and ***Edit entry*** glossary forms.

Fixes #1621 

## Why?
For consistency and better usability.

## How?
Just reordered the row edit fields in the code.

## Screenshots or screencast <!-- if applicable -->
![imagem](https://user-images.githubusercontent.com/7371591/236214894-fec41958-6a27-4f34-8dda-e263eca55cde.png)
