### PR TITLE
Local: Display REST API error messages 

### DIFF
--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -206,8 +206,7 @@ registerPopoverHandlers = function() {
 					translation = {},
 					warnings = '',
 					warningsObj = {},
-					outputWarningMessage = '',
-					errorMessage = '';
+					outputWarningMessage = '';
 
 				translation[ originalId ] = submittedTranslations;
 				glotPress.submitTranslation( translation, translationPair ).done( function( data ) {
@@ -238,8 +237,7 @@ registerPopoverHandlers = function() {
 					}
 				} ).fail( function( xhr ) {
 					if ( xhr.responseJSON ) {
-						errorMessage = xhr.responseJSON.message;
-						$form.find( '.warnings' ).html( '<p class="local-inline-warning"><b>Error: </b>' + errorMessage + '</p>' );
+						$form.find( '.warnings' ).html( '<p class="local-inline-warning"><b>Error: </b>' + xhr.responseJSON.message + '</p>' );
 					}
 				} );
 			} );

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -206,7 +206,8 @@ registerPopoverHandlers = function() {
 					translation = {},
 					warnings = '',
 					warningsObj = {},
-					outputWarningMessage = '';
+					outputWarningMessage = '',
+					errorMessage = '';
 
 				translation[ originalId ] = submittedTranslations;
 				glotPress.submitTranslation( translation, translationPair ).done( function( data ) {
@@ -234,6 +235,11 @@ registerPopoverHandlers = function() {
 
 					if ( !! document.cookie.match( /inlinejumptonext=1/ ) ) {
 						jQuery( '.translator-translatable.translator-untranslated:visible' ).webuiPopover( 'show' );
+					}
+				} ).fail( function( xhr ) {
+					if ( xhr.responseJSON ) {
+						errorMessage = xhr.responseJSON.message;
+						$form.find( '.warnings' ).html( '<p class="local-inline-warning"><b>Error: </b>' + errorMessage + '</p>' );
 					}
 				} );
 			} );

--- a/inline-translation/lib/index.js
+++ b/inline-translation/lib/index.js
@@ -237,7 +237,8 @@ registerPopoverHandlers = function() {
 					}
 				} ).fail( function( xhr ) {
 					if ( xhr.responseJSON ) {
-						$form.find( '.warnings' ).html( '<p class="local-inline-warning"><b>Error: </b>' + xhr.responseJSON.message + '</p>' );
+						$form.find( '.warnings' ).html( '<p class="local-inline-warning"><b>Error: </b><span class="message">' );
+						$form.find( '.warnings .message' ).text( xhr.responseJSON.message );
 					}
 				} );
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
This PR displays on the frontend, error messages from the REST API.

## Why?
When a user tries to submit an inline translation and the REST API returns an error, the user is not aware, the popout window stays open and nothing happens.

## How?
This PR shows the error message returned by the REST API in the popout window.

## Testing Instructions
1. With GlotPress inline translation enabled, try to submit the same translation for an original that has been translated
2. You would get a "Translation already exists" error message.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/GlotPress/GlotPress/assets/2834132/1f2ecd4b-4ead-40bc-9707-c7bbb548424e)
