### PR TITLE
Update the slug for the Valencia (Catalan) language

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -472,7 +472,7 @@ class GP_Locales {
 		$ca_valencia->lang_code_iso_639_1 = 'ca';
 		$ca_valencia->lang_code_iso_639_2 = 'cat';
 		$ca_valencia->wp_locale = 'ca_valencia';
-		$ca_valencia->slug = 'ca-valencia';
+		$ca_valencia->slug = 'ca-val';
 		$ca_valencia->google_code = 'ca';
 		$ca_valencia->facebook_locale = 'ca_ES';
 


### PR DESCRIPTION
<!-- Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR updates the slug for the Valencia (Catalan) language, because it was [too long for the table field](https://github.com/GlotPress/GlotPress/blob/907afbd3e3c29bc4d7ee79536f6c7d2f75a44ac1/gp-includes/schema.php#L93). See https://make.wordpress.org/polyglots/2023/03/12/new-locale-valencia/#comment-297072
