### PR TITLE
Warnings: Supply Original Metadata to Warnings

### DIFF
--- a/gp-includes/cli/translation-set.php
+++ b/gp-includes/cli/translation-set.php
@@ -161,7 +161,18 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 		$project = GP::$project->get( $translation_set->project_id );
 		$locale  = GP_Locales::by_slug( $translation_set->locale );
 		foreach ( GP::$translation->for_translation( $project, $translation_set, 'no-limit' ) as $entry ) {
-			$warnings = GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale, $entry );
+			$warnings = GP::$translation_warnings->check(
+				$entry->singular,
+				$entry->plural,
+				$entry->translations,
+				$locale,
+				array(
+					'project_id' => $translation_set->project_id,
+					'context' => $entry->context,
+					'comment' => $entry->comment,
+					'references' => $entry->references,
+				)
+			);
 			if ( $warnings == $entry->warnings ) {
 				continue;
 			}

--- a/gp-includes/cli/translation-set.php
+++ b/gp-includes/cli/translation-set.php
@@ -161,7 +161,7 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 		$project = GP::$project->get( $translation_set->project_id );
 		$locale  = GP_Locales::by_slug( $translation_set->locale );
 		foreach ( GP::$translation->for_translation( $project, $translation_set, 'no-limit' ) as $entry ) {
-			$warnings = GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale );
+			$warnings = GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale, $entry );
 			if ( $warnings == $entry->warnings ) {
 				continue;
 			}

--- a/gp-includes/cli/translation-set.php
+++ b/gp-includes/cli/translation-set.php
@@ -168,8 +168,8 @@ class GP_CLI_Translation_Set extends WP_CLI_Command {
 				$locale,
 				array(
 					'project_id' => $translation_set->project_id,
-					'context' => $entry->context,
-					'comment' => $entry->comment,
+					'context'    => $entry->context,
+					'comment'    => $entry->comment,
 					'references' => $entry->references,
 				)
 			);

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -299,8 +299,8 @@ class GP_Route_Translation extends GP_Route_Main {
 				$locale,
 				array(
 					'project_id' => $project->id,
-					'context' => $original->context,
-					'comment' => $original->comment,
+					'context'    => $original->context,
+					'comment'    => $original->comment,
 					'references' => $original->references,
 				)
 			);

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -292,7 +292,18 @@ class GP_Route_Translation extends GP_Route_Main {
 			}
 
 			$original         = GP::$original->get( $original_id );
-			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale, $original );
+			$data['warnings'] = GP::$translation_warnings->check(
+				$original->singular,
+				$original->plural,
+				$translations,
+				$locale,
+				array(
+					'project_id' => $project->id,
+					'context' => $original->context,
+					'comment' => $original->comment,
+					'references' => $original->references,
+				)
+			);
 
 			$existing_translations = GP::$translation->for_translation(
 				$project,

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -292,7 +292,7 @@ class GP_Route_Translation extends GP_Route_Main {
 			}
 
 			$original         = GP::$original->get( $original_id );
-			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );
+			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale, $original );
 
 			$existing_translations = GP::$translation->for_translation(
 				$project,

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -301,18 +301,26 @@ class GP_Translation_Set extends GP_Thing {
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, null );
 
+			$meta = array(
+				'project_id' => $this->project_id,
+			);
+			if ( isset ( $entry->context ) ) {
+				$meta['context'] = $entry->context;
+			}
+			if ( isset ( $entry->comment ) ) {
+				$meta['comment'] = $entry->comment;
+			}
+			if ( isset ( $entry->references ) ) {
+				$meta['references'] = $entry->references;
+			}
+
 			$entry->warnings = maybe_unserialize(
 				GP::$translation_warnings->check(
 					$entry->singular,
 					$entry->plural,
 					$entry->translations,
 					$locale,
-					array(
-						'project_id' => $this->project_id,
-						'context' => $entry->context,
-						'comment' => $entry->comment,
-						'references' => $entry->references,
-					)
+					$meta
 				)
 			);
 			if ( ! empty( $entry->warnings ) && 'current' === $entry->status ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -304,13 +304,13 @@ class GP_Translation_Set extends GP_Thing {
 			$meta = array(
 				'project_id' => $this->project_id,
 			);
-			if ( isset ( $entry->context ) ) {
+			if ( isset( $entry->context ) ) {
 				$meta['context'] = $entry->context;
 			}
-			if ( isset ( $entry->comment ) ) {
+			if ( isset( $entry->comment ) ) {
 				$meta['comment'] = $entry->comment;
 			}
-			if ( isset ( $entry->references ) ) {
+			if ( isset( $entry->references ) ) {
 				$meta['references'] = $entry->references;
 			}
 

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -301,7 +301,7 @@ class GP_Translation_Set extends GP_Thing {
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, null );
 
-			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale ) );
+			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale, $entry ) );
 			if ( ! empty( $entry->warnings ) && 'current' === $entry->status ) {
 				$entry->status = 'waiting';
 			}

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -301,7 +301,20 @@ class GP_Translation_Set extends GP_Thing {
 			 */
 			$entry->status = apply_filters( 'gp_translation_set_import_status', $is_fuzzy ? 'fuzzy' : $desired_status, $entry, null );
 
-			$entry->warnings = maybe_unserialize( GP::$translation_warnings->check( $entry->singular, $entry->plural, $entry->translations, $locale, $entry ) );
+			$entry->warnings = maybe_unserialize(
+				GP::$translation_warnings->check(
+					$entry->singular,
+					$entry->plural,
+					$entry->translations,
+					$locale,
+					array(
+						'project_id' => $this->project_id,
+						'context' => $entry->context,
+						'comment' => $entry->comment,
+						'references' => $entry->references,
+					)
+				)
+			);
 			if ( ! empty( $entry->warnings ) && 'current' === $entry->status ) {
 				$entry->status = 'waiting';
 			}

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -67,15 +67,15 @@ class GP_Translation_Warnings {
 	 * @since 1.0.0
 	 * @access public
 	 *
-	 * @param string           $singular       The singular form of an original string.
-	 * @param string           $plural         The plural form of an original string.
-	 * @param string[]         $translations   An array of translations for an original.
-	 * @param GP_Locale        $locale         The locale of the translations.
-	 * @param GP_Original|null $original       The whole original object, or null in unit tests or where it's not necessary.
+	 * @param string    $singular       The singular form of an original string.
+	 * @param string    $plural         The plural form of an original string.
+	 * @param string[]  $translations   An array of translations for an original.
+	 * @param GP_Locale $locale         The locale of the translations.
+	 * @param array     $meta           Original metadata if available.
 	 * @return array|null Null if no issues have been found, otherwise an array
 	 *                    with warnings.
 	 */
-	public function check( $singular, $plural, $translations, $locale, $original = null ) {
+	public function check( $singular, $plural, $translations, $locale, $meta = array() ) {
 		$problems = array();
 		foreach ( $translations as $translation_index => $translation ) {
 			if ( ! $translation ) {
@@ -99,13 +99,13 @@ class GP_Translation_Warnings {
 
 			foreach ( $this->callbacks as $callback_id => $callback ) {
 				if ( ! $skip['singular'] ) {
-					$singular_test = $callback( $singular, $translation, $locale, $original );
+					$singular_test = $callback( $singular, $translation, $locale, $meta );
 					if ( true !== $singular_test ) {
 						$problems[ $translation_index ][ $callback_id ] = $singular_test;
 					}
 				}
 				if ( null !== $plural && ! $skip['plural'] ) {
-					$plural_test = $callback( $plural, $translation, $locale, $original );
+					$plural_test = $callback( $plural, $translation, $locale, $meta );
 					if ( true !== $plural_test ) {
 						$problems[ $translation_index ][ $callback_id ] = $plural_test;
 					}

--- a/gp-includes/warnings.php
+++ b/gp-includes/warnings.php
@@ -67,14 +67,15 @@ class GP_Translation_Warnings {
 	 * @since 1.0.0
 	 * @access public
 	 *
-	 * @param string    $singular     The singular form of an original string.
-	 * @param string    $plural       The plural form of an original string.
-	 * @param string[]  $translations An array of translations for an original.
-	 * @param GP_Locale $locale       The locale of the translations.
+	 * @param string           $singular       The singular form of an original string.
+	 * @param string           $plural         The plural form of an original string.
+	 * @param string[]         $translations   An array of translations for an original.
+	 * @param GP_Locale        $locale         The locale of the translations.
+	 * @param GP_Original|null $original       The whole original object, or null in unit tests or where it's not necessary.
 	 * @return array|null Null if no issues have been found, otherwise an array
 	 *                    with warnings.
 	 */
-	public function check( $singular, $plural, $translations, $locale ) {
+	public function check( $singular, $plural, $translations, $locale, $original = null ) {
 		$problems = array();
 		foreach ( $translations as $translation_index => $translation ) {
 			if ( ! $translation ) {
@@ -98,13 +99,13 @@ class GP_Translation_Warnings {
 
 			foreach ( $this->callbacks as $callback_id => $callback ) {
 				if ( ! $skip['singular'] ) {
-					$singular_test = $callback( $singular, $translation, $locale );
+					$singular_test = $callback( $singular, $translation, $locale, $original );
 					if ( true !== $singular_test ) {
 						$problems[ $translation_index ][ $callback_id ] = $singular_test;
 					}
 				}
 				if ( null !== $plural && ! $skip['plural'] ) {
-					$plural_test = $callback( $plural, $translation, $locale );
+					$plural_test = $callback( $plural, $translation, $locale, $original );
 					if ( true !== $plural_test ) {
 						$problems[ $translation_index ][ $callback_id ] = $plural_test;
 					}


### PR DESCRIPTION
## What?
Supplies the warning check function with original metadata.

## Why?
If we expose more information to the warning check (i.e. project id, context, comment and references), we can do more context specific checks such as https://github.com/WordPress/wordpress.org/pull/150.

## How?
Adds another parameter to the `GP::$translation_warnings::check()` function.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a original string in a project. -->
<!-- 2. Add the translation. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->