### PR TITLE
Combine the suffixes for shorter regular expression.

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -217,7 +217,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 		foreach ( $regex_group as $suffix => $terms ) {
 			$terms_search .= '(?:' . implode( '|', $terms ) . ')' . $suffix . '|';
 		}
-		
+
 		// Remove the trailing |.
 		$terms_search  = substr( $terms_search, 0, -1 );
 		$terms_search .= ')\b';

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -178,15 +178,15 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 			$glossary_entries_reference[ $term ][] = $id;
 		}
 
-		$terms_search = '\b(';
+		$regex_group = array();
 		foreach ( $glossary_entries_suffixes as $term => $suffixes ) {
-			$terms_search .= preg_quote( $term, '/' );
+			$regex_suffix = $suffixes ? '(?:' . implode( '|', $suffixes ) . ')?' : '';
 
-			if ( ! empty( $suffixes ) ) {
-				$terms_search .= '(?:' . implode( '|', $suffixes ) . ')?';
+			if ( ! isset( $regex_group[ $regex_suffix ] ) ) {
+				$regex_group[ $regex_suffix ] = array();
 			}
 
-			$terms_search .= '|';
+			$regex_group[ $regex_suffix ][] = preg_quote( $term, '/' );
 
 			$referenced_term = $term;
 			if ( ! isset( $glossary_entries_reference[ $referenced_term ] ) ) {
@@ -212,6 +212,12 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 			}
 		}
 
+		// Build the regular expression.
+		$terms_search = '\b(';
+		foreach ( $regex_group as $suffix => $terms ) {
+			$terms_search .= '(?:' . implode( '|', $terms ) . ')' . $suffix . '|';
+		}
+		
 		// Remove the trailing |.
 		$terms_search  = substr( $terms_search, 0, -1 );
 		$terms_search .= ')\b';

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -189,4 +189,95 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$this->assertEquals( $orig, $expected_result );
 	}
 
+	function provide_test_map_glossary_entries_to_translation_originals() {
+		foreach ( array(
+			'party' => array(
+				'Welcome to the party.',
+				'My parties.',
+				'I know, partys is the wrong plural ending but we need it because of nouns like boys.',
+			),
+			'color' => array(
+				'One color.',
+				'Two colors.',
+			),
+			'half' => array(
+				'Half a loaf is better than none.',
+				'Two halves are even better.',
+			),
+			'man' => array(
+				'The word man is the root of the word mankind.',
+				'There are men but there is no menkind.',
+			),
+			'issue' => array(
+				'If you find a bug, file an issue.',
+				'If you find two bugs, please file two issues.',
+			),
+			'report' => array(
+				'I reported a bug.',
+				'Now there is a bug report.',
+				'We call it bug reporting.',
+			),
+		) as $expected_result => $test_strings ) {
+			foreach ( $test_strings as $test_string ) {
+				yield array( $test_string, $expected_result );
+			}
+		}
+	}
+
+	/**
+	 * @dataProvider provide_test_map_glossary_entries_to_translation_originals
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_suffixes( $test_string, $expected_result ) {
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entries = array(
+			array(
+				'term' => 'party',
+				'part_of_speech' => 'noun',
+				'translation' => 'party',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'color',
+				'part_of_speech' => 'noun',
+				'translation' => 'color',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'half',
+				'part_of_speech' => 'noun',
+				'translation' => 'half',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'man',
+				'part_of_speech' => 'noun',
+				'translation' => 'man',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'issue',
+				'part_of_speech' => 'noun',
+				'translation' => 'issue',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'report',
+				'part_of_speech' => 'noun',
+				'translation' => 'report',
+				'glossary_id' => $glossary->id,
+			),
+		);
+
+		foreach ( $glossary_entries as $glossary_entry ) {
+			GP::$glossary_entry->create_and_select( $glossary_entry );
+		}
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertMatchesRegularExpression( '#<span class="glossary-word" data-translations="\[{&quot;translation&quot;:&quot;' . $expected_result . '&quot;,[^"]+">[^<]+</span>#', $orig->singular_glossary_markup );
+	}
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Per #1647 large glossaries cause the expression to fail to execute when the glossary item count is high.
This is due to regular expressions having a limit to the overall length.

## Solution

This solution is not the most ideal, ideally this should not be using a regular expression at all.

This solution simply combines the regex such that the suffix matches are only included once, rather than individually on every single term.

For Translate.WordPress.org glossaries, it reduces the regex length...
 - en_AU: 6,709 down to 2,765 chars.
 - tw_ZH: 33,362 down to 16,083 chars.
 - de_DE: 8,846 down to 4,225 chars.

Roughly a 50-60% decrease in length.

Initially there were no logical changes I could see, but now that I'm PR'ing it, I can see that there's a "small" change - the terms are no longer sorted by length, as they're only sorted within their "suffix group".

| Test Case | Regex |
| --- | --- |
| Before | `\b(favorited(?:s\|es\|ed\|ing)?\|favorites(?:s\|es\|ed\|ing)?\|zip code\|url(?:s\|es\|ed\|ing)?)\b` |
| After | `\b((?:favorited\|favorites\|url)(?:s\|es\|ed\|ing)?)\|(?:zip code))\b` |

(Yes, those suffixes are wildly inaccurate, but that's not the purpose of this issue/pr)

## To-do

- [x] See if there's unit tests, and/or if anyone else wants to add them.
- [ ] See if anyone wants to write a proper solution not using regex.

## Testing Instructions
1. Apply patch
2. View Translations
3. Ensure glossary items are matched

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->