### PR TITLE
Build the minified assets before WP.org deploy

### DIFF
--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -18,6 +18,18 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Build minified JavaScript and CSS
+        run: npm run build
+
       - name: WordPress.org plugin update
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ module.exports = function( grunt ) {
 					'assets/js/**/*.js',
 
 					// Exceptions.
+					'!assets/js/vendor/*',
 					'!**/*.min.js'
 				],
 


### PR DESCRIPTION
## Problem

The deploy to WP.org pushes the files as is in the repo. If the minified assets aren't up to date, that's how they'll be deployed.

## Solution

Rebuild the minified JavaScript and CSS assets immediately before the WP.org repo deploy.

Includes:
- [x] JavaScript files in `/assets/js/` folder, excluding the `/assets/js/vendor/` subfolder
- [x] CSS files in `/assets/css/` folder


Related to https://github.com/GlotPress/GlotPress/issues/1587
