### PR TITLE
Fix including the minified assets in the WP.org deploy

### DIFF
--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -3,6 +3,7 @@ name: Deploy plugin to WordPress.org
 on:
   release:
     types: [published]
+  pull_request:
 
 permissions:
   contents: read
@@ -28,11 +29,13 @@ jobs:
         run: |
           npm install
           npm run build
-          mkdir build
-          cp -r assets gp-includes gp-templates locales CHANGELOG.md glotpress.php gp-settings.php license.txt readme.txt build
+          git add .
+          git commit -m "Build"
 
       - name: WordPress.org plugin update
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          dry-run: true
         env:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: WordPress.org plugin update
         uses: 10up/action-wordpress-plugin-deploy@stable
-        with:
-          dry-run: true
         env:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -24,15 +24,17 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install NPM Dependencies
-        run: npm ci
-
-      - name: Build minified JavaScript and CSS
-        run: npm run build
+      - name: Build
+        run: |
+          npm install
+          npm run build
+          mkdir build
+          cp -r assets gp-includes gp-templates locales CHANGELOG.md glotpress.php gp-settings.php license.txt readme.txt build
 
       - name: WordPress.org plugin update
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}
+          BUILD_DIR: build
           SLUG: glotpress

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -24,9 +24,9 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Build
+      - name: Build minified JavaScript and CSS and commit it just for the release
         run: |
-          npm install
+          npm ci
           npm run build
           git config user.email "build@glotpress.blog"
           git config user.name "GlotPress Build"

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -41,5 +41,4 @@ jobs:
         env:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}
-          BUILD_DIR: build
           SLUG: glotpress

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -30,7 +30,7 @@ jobs:
           npm install
           npm run build
           git config user.email "build@glotpress.blog"
-          git config user.name "Glotpress Build"
+          git config user.name "GlotPress Build"
           git add .
           git commit -m "Build"
 

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           npm install
           npm run build
+          git config user.email "build@glotpress.blog"
+          git config user.name "Glotpress Build"
           git add .
           git commit -m "Build"
 

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -3,7 +3,6 @@ name: Deploy plugin to WordPress.org
 on:
   release:
     types: [published]
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

The approach in  #1654 doesn't include the built minified assets even though the example readme in https://github.com/10up/action-wordpress-plugin-deploy suggests otherwise.

It turns out that the action uses `git archive` if you don't have a `.distignore`. If we build the files into the git monitored directory, then those newly built files are ignored by `git archive` since it creates the archive from its index files.

Relates to #1587.

## Solution

`git commit` the newly built files.

## Tasks
- [x] Fix the issue upstream: https://github.com/10up/action-wordpress-plugin-deploy/pull/130