### PR TITLE
Fix wordpress.org plugin deploy if the minified files are already built

### DIFF
--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -31,7 +31,7 @@ jobs:
           git config user.email "build@glotpress.blog"
           git config user.name "GlotPress Build"
           git add .
-          git commit -m "Build"
+          git commit -m "Build" || true
 
       - name: WordPress.org plugin update
         uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
This shouldn't have stopped the deploy:

![Screenshot 2023-07-25 at 15 35 06](https://github.com/GlotPress/GlotPress/assets/203408/5b574dd6-848b-47c2-870c-424aaf5b26d5)
