### PR TITLE
Avoid adding the invisible classes in the glossary

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -34,15 +34,6 @@ function prepare_original( $text ) {
 	// Wrap placeholders with notranslate.
 	$text = preg_replace( '/(%(\d+\$(?:\d+)?)?[bcdefgosuxEFGX])/', '<span class="notranslate">\\1</span>', $text );
 
-	// Put the glossaries back!
-	$text = preg_replace_callback(
-		'!(<span GLOSSARY=(\d+)>)!',
-		function( $m ) use ( $glossary_entries ) {
-			return $glossary_entries[ $m[2] ];
-		},
-		$text
-	);
-
 	// Highlight two or more spaces between words.
 	$text = preg_replace( '/(?!^)  +(?!$)/', '<span class="invisible-spaces">$0</span>', $text );
 	// Highlight leading and trailing spaces in single lines.
@@ -54,6 +45,15 @@ function prepare_original( $text ) {
 
 	$text = str_replace( array( "\r", "\n" ), "<span class='invisibles' title='" . esc_attr__( 'New line', 'glotpress' ) . "'>&crarr;</span>\n", $text );
 	$text = str_replace( "\t", "<span class='invisibles' title='" . esc_attr__( 'Tab character', 'glotpress' ) . "'>&rarr;</span>\t", $text );
+
+	// Put the glossaries back!
+	$text = preg_replace_callback(
+		'!(<span GLOSSARY=(\d+)>)!',
+		function( $m ) use ( $glossary_entries ) {
+			return $glossary_entries[ $m[2] ];
+		},
+		$text
+	);
 
 	return $text;
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

If the comment in an element of the glossary has two spaces, the `prepare_original` function breaks the originals in the translation table.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/89fd8123-ce5f-451b-a491-342320bb22d5)

![image](https://github.com/GlotPress/GlotPress/assets/1667814/8afe7a94-3d55-40b3-a0eb-81a9a428b4da)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR avoids adding the invisible classes in the glossary, applying the glossary as the last element in the `prepare_original` function.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/af46b4de-d5bb-49a7-9dbb-9e1562700378)

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

To test this PR: 
1. Add an element in the glossary with two spaces in the comment.
2. Test that this breaks the original string in the translation table.
3. Test that this PR doesn't break the original string in the translation table.

<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->
