### PR TITLE
Fix button margins

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -333,7 +333,7 @@ button,
 	box-shadow: none;
 	background: var( --gp-color-btn-bg );
 	min-height: 32px;
-	margin: 0 0 8px 0;
+	margin: 0;
 	cursor: pointer;
 	outline: 0;
 	white-space: nowrap;


### PR DESCRIPTION
Buttons margins appear to have broken after #1451 and are now misaligned. This adjusts them back to the pre-1451 state.

Fixes #1676.

Before:
<img width="335" alt="Screenshot 2023-08-18 at 09 21 52" src="https://github.com/GlotPress/GlotPress/assets/4642604/e91988b6-61aa-47ab-83a3-d342dff1949a">

After:
<img width="388" alt="Screenshot 2023-08-18 at 09 22 17" src="https://github.com/GlotPress/GlotPress/assets/4642604/86198c2e-083a-425c-8c0c-7fae05b3d11c">
