### PR TITLE
1681: correction of plurals parameters for Saraiki

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -2262,8 +2262,6 @@ class GP_Locales {
 		$skr->country_code = 'pk';
 		$skr->wp_locale = 'skr';
 		$skr->slug = 'skr';
-		$skr->nplurals = 2;
-		$skr->plural_expression = 'n > 1';
 		$skr->text_direction = 'rtl';
 		$skr->alphabet = 'saraiki';
 


### PR DESCRIPTION
Fixes #1681

## Problem
The plural settings of the Locale Saraiki are wrong.


## Solution
Remove the custom plural settings to correctly use the fallback settings.

## To-do
- [x] Remove the nplural settings
