### PR TITLE
Use filemtime to set the asset's version

### DIFF
--- a/gp-includes/assets-loader.php
+++ b/gp-includes/assets-loader.php
@@ -10,13 +10,13 @@
  * Registers the GlotPress styles and loads the base style sheet.
  */
 function gp_register_default_styles() {
-	$url = gp_plugin_url( 'assets/css' );
-
+	$url    = gp_plugin_url( 'assets/css' );
+	$path   = plugin_dir_path( __DIR__ ) . 'assets/css/';
 	$suffix = SCRIPT_DEBUG || GP_SCRIPT_DEBUG ? '.css' : '.min.css';
 
 	// Register our base style.
-	wp_register_style( 'gp-base', $url . '/style' . $suffix, array(), '20230725' );
-	wp_register_style( 'gp-jquery-webui-popover', $url . '/jquery.webui-popover' . $suffix, array( 'gp-base' ), '20230503' );
+	wp_register_style( 'gp-base', $url . '/style' . $suffix, array(), filemtime( $path . 'style' . $suffix ) );
+	wp_register_style( 'gp-jquery-webui-popover', $url . '/jquery.webui-popover' . $suffix, array( 'gp-base' ), filemtime( $path . 'jquery.webui-popover' . $suffix ) );
 }
 
 add_action( 'init', 'gp_register_default_styles' );
@@ -25,25 +25,25 @@ add_action( 'init', 'gp_register_default_styles' );
  * Register the GlotPress scripts.
  */
 function gp_register_default_scripts() {
-	$url = gp_plugin_url( 'assets/js' );
-
+	$url    = gp_plugin_url( 'assets/js' );
+	$path   = plugin_dir_path( __DIR__ ) . 'assets/js/';
 	$suffix = SCRIPT_DEBUG || GP_SCRIPT_DEBUG ? '.js' : '.min.js';
 
 	// Register our standard scripts.
-	wp_register_script( 'tablesorter', $url . '/vendor/jquery.tablesorter' . $suffix, array( 'jquery' ), '20210429' );
-	wp_register_script( 'gp-common', $url . '/common' . $suffix, array( 'jquery', 'wp-i18n' ), '20230808' );
-	wp_register_script( 'gp-editor', $url . '/editor' . $suffix, array( 'gp-common', 'jquery-ui-tooltip', 'wp-wordcount' ), '20230808' );
-	wp_register_script( 'gp-glossary', $url . '/glossary' . $suffix, array( 'gp-editor' ), '20230808' );
-	wp_register_script( 'gp-translations-page', $url . '/translations-page' . $suffix, array( 'gp-editor' ), '20230808' );
-	wp_register_script( 'gp-mass-create-sets-page', $url . '/mass-create-sets-page' . $suffix, array( 'gp-editor' ), '20230808' );
-	wp_register_script( 'gp-tour', $url . '/tour' . $suffix, array( 'jquery', 'gp-jquery-webui-popover' ), '20230728', false );
+	wp_register_script( 'tablesorter', $url . '/vendor/jquery.tablesorter' . $suffix, array( 'jquery' ), filemtime( $path . 'vendor/jquery.tablesorter' . $suffix ) );
+	wp_register_script( 'gp-common', $url . '/common' . $suffix, array( 'jquery', 'wp-i18n' ), filemtime( $path . 'common' . $suffix ) );
+	wp_register_script( 'gp-editor', $url . '/editor' . $suffix, array( 'gp-common', 'jquery-ui-tooltip', 'wp-wordcount' ), filemtime( $path . 'editor' . $suffix ) );
+	wp_register_script( 'gp-glossary', $url . '/glossary' . $suffix, array( 'gp-editor' ), filemtime( $path . 'glossary' . $suffix ) );
+	wp_register_script( 'gp-translations-page', $url . '/translations-page' . $suffix, array( 'gp-editor' ), filemtime( $path . 'translations-page' . $suffix ) );
+	wp_register_script( 'gp-mass-create-sets-page', $url . '/mass-create-sets-page' . $suffix, array( 'gp-editor' ), filemtime( $path . 'mass-create-sets-page' . $suffix ) );
+	wp_register_script( 'gp-tour', $url . '/tour' . $suffix, array( 'jquery', 'gp-jquery-webui-popover' ), filemtime( $path . 'tour' . $suffix ), false );
 
 	wp_set_script_translations( 'gp-common', 'glotpress' );
 	wp_set_script_translations( 'gp-editor', 'glotpress' );
 	wp_set_script_translations( 'gp-glossary', 'glotpress' );
 	wp_set_script_translations( 'gp-mass-create-sets-page', 'glotpress' );
 	wp_set_script_translations( 'gp-tour', 'glotpress' );
-	wp_register_script( 'gp-jquery-webui-popover', $url . '/jquery.webui-popover' . $suffix, array( 'jquery' ), '20210429', false );
+	wp_register_script( 'gp-jquery-webui-popover', $url . '/jquery.webui-popover' . $suffix, array( 'jquery' ), filemtime( $path . 'jquery.webui-popover' . $suffix ), false );
 	wp_localize_script( 'gp-tour', 'gp_tour', apply_filters( 'gp_tour', array() ) );
 }
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Sometimes, when a developer changes the content in an asset (CSS or JavaScript file), she forgets to update the hard-coded version in some register functions:
- [wp_register_style](https://developer.wordpress.org/reference/functions/wp_register_style/) (`$ver` parameter).
- [wp_register_script](https://developer.wordpress.org/reference/functions/wp_register_script/)  (`$ver` parameter).

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR uses the [filemtime()](https://www.php.net/manual/en/function.filemtime.php) function to this version parameter, so the version parameter will be the modification time for each asset. When a developer changes some element in a asset file, the version parameter will be update automatically.

<!--
Please, describe how this PR improves the situation.
-->

