### PR TITLE
Site Tour: Fix CORS error in accessing tour stylesheet

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -99,14 +99,13 @@ jQuery( document ).ready(
 		window.loadTour = function() {
 			var color1 = '';
 			var color2 = '';
-			var styleElement = {};
+			var styleElement = document.createElement( 'style' );
 			var n;
 			var style;
+			document.head.appendChild( styleElement );
 			for ( n in window.tour ) {
 				color1 = window.tour[ n ][ 0 ].color + '00';
 				color2 = window.tour[ n ][ 0 ].color + 'a0';
-				styleElement = document.createElement( 'style' );
-				document.head.appendChild( styleElement );
 				style = styleElement.sheet;
 
 				style.insertRule( '@keyframes animation-' + n + ' {' +

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -99,13 +99,17 @@ jQuery( document ).ready(
 		window.loadTour = function() {
 			var color1 = '';
 			var color2 = '';
-			var sheet = {};
+			var styleElement = {};
 			var n;
+			var style;
 			for ( n in window.tour ) {
 				color1 = window.tour[ n ][ 0 ].color + '00';
 				color2 = window.tour[ n ][ 0 ].color + 'a0';
-				sheet = document.styleSheets[ 0 ];
-				sheet.insertRule( '@keyframes animation-' + n + ' {' +
+				styleElement = document.createElement( 'style' );
+				document.head.appendChild( styleElement );
+				style = styleElement.sheet;
+
+				style.insertRule( '@keyframes animation-' + n + ' {' +
 					'0% {' +
 					'box-shadow: 0 0 0 0 ' + color2 + ';' +
 					'}' +
@@ -116,14 +120,14 @@ jQuery( document ).ready(
 					'box-shadow: 0 0 0 0 ' + color1 + ';' +
 					'}' +
 					'}',
-				sheet.cssRules.length );
+				style.cssRules.length );
 
-				sheet.insertRule( '.tour-' + n + '{' +
+				style.insertRule( '.tour-' + n + '{' +
 					'box-shadow: 0 0 0 ' + color2 + ';' +
 					'background: ' + color1 + ';' +
 					'-webkit-animation: animation-' + n + ' 2s infinite;' +
 					'animation: animation-' + n + ' 2s infinite; }',
-				sheet.cssRules.length );
+				style.cssRules.length );
 				addPulse( jQuery( window.tour[ n ][ 1 ].selector ), window.tour[ n ][ 1 ], n, 1 );
 			}
 		};

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -102,11 +102,13 @@ jQuery( document ).ready(
 			var styleElement = document.createElement( 'style' );
 			var n;
 			var style;
+
 			document.head.appendChild( styleElement );
+			style = styleElement.sheet;
+
 			for ( n in window.tour ) {
 				color1 = window.tour[ n ][ 0 ].color + '00';
 				color2 = window.tour[ n ][ 0 ].color + 'a0';
-				style = styleElement.sheet;
 
 				style.insertRule( '@keyframes animation-' + n + ' {' +
 					'0% {' +


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem
The error ```Uncaught DOMException: Failed to read the ‘cssRules’ property from ‘CSSStyleSheet' ``` is thrown when the tour stylesheet is being accessed.
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution
Instead of adding these styles to the first stylesheet which happens to be on another domain, we have decided to create a style tag and add all the css rules in it.
<!--
Please, describe how this PR improves the situation.
-->

