### PR TITLE
Site Tour: Add popover offset property

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -29,12 +29,14 @@ jQuery( document ).ready(
 		jQuery( document ).on( 'click', '.pulse', function() {
 			var wrapper = jQuery( this ).closest( '.pulse-wrapper' );
 			var tourName = wrapper.data( 'tourname' );
-			var nextItem = 1 + wrapper.data( 'tourindex' );
+			var currentTourIndex = wrapper.data( 'tourindex' );
+			var nextItem = 1 + currentTourIndex;
 			var tourEndsHere = typeof window.tour[ tourName ][ nextItem ] === 'undefined';
-			var showPreviousBtn = wrapper.data( 'tourindex' ) > 1;
+			var showPreviousBtn = currentTourIndex > 1;
 			var popoverContent = wrapper.data( 'popover-content' );
 			var item;
-
+			var istopOffsetDefined = typeof window.tour[ tourName ][ currentTourIndex ].topOffset !== 'undefined' && Number.isInteger( window.tour[ tourName ][ currentTourIndex ].topOffset );
+			var popoverTopOffset = istopOffsetDefined ? window.tour[ tourName ][ currentTourIndex ].topOffset : 0;
 			if ( ! tourEndsHere ) {
 				// Check if the selector for the next item does not exists
 				if ( jQuery( window.tour[ tourName ][ nextItem ].selector + ':visible' ).length < 1 ) {
@@ -46,6 +48,7 @@ jQuery( document ).ready(
 					}
 				}
 			}
+
 			item = window.tour[ tourName ][ nextItem ];
 
 			jQuery( '.pulse-wrapper' ).removeClass( 'pulse-border' );
@@ -65,7 +68,7 @@ jQuery( document ).ready(
 			if ( ! tourEndsHere ) {
 				popoverContent += '<br/><small><a href="" class="dismiss-tour">' + wp.i18n.__( 'Dismiss this tour', 'glotpress' );
 			}
-			WebuiPopovers.show( this, { title: window.tour[ tourName ][ 0 ].title, content: popoverContent, width: 300, dismissible: true } );
+			WebuiPopovers.show( this, { title: window.tour[ tourName ][ 0 ].title, content: popoverContent, width: 300, dismissible: true, offsetTop: popoverTopOffset } );
 			jQuery( '.tour-' + tourName ).remove();
 
 			if ( tourEndsHere ) {

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -37,6 +37,8 @@ jQuery( document ).ready(
 			var item;
 			var istopOffsetDefined = typeof window.tour[ tourName ][ currentTourIndex ].topOffset !== 'undefined' && Number.isInteger( window.tour[ tourName ][ currentTourIndex ].topOffset );
 			var popoverTopOffset = istopOffsetDefined ? window.tour[ tourName ][ currentTourIndex ].topOffset : 0;
+			var isPlacementDefined = typeof window.tour[ tourName ][ currentTourIndex ].placement !== 'undefined';
+			var popoverPlacement = isPlacementDefined ? window.tour[ tourName ][ currentTourIndex ].placement : 'bottom-right';
 			if ( ! tourEndsHere ) {
 				// Check if the selector for the next item does not exists
 				if ( jQuery( window.tour[ tourName ][ nextItem ].selector + ':visible' ).length < 1 ) {
@@ -68,7 +70,7 @@ jQuery( document ).ready(
 			if ( ! tourEndsHere ) {
 				popoverContent += '<br/><small><a href="" class="dismiss-tour">' + wp.i18n.__( 'Dismiss this tour', 'glotpress' );
 			}
-			WebuiPopovers.show( this, { title: window.tour[ tourName ][ 0 ].title, content: popoverContent, width: 300, dismissible: true, offsetTop: popoverTopOffset } );
+			WebuiPopovers.show( this, { title: window.tour[ tourName ][ 0 ].title, content: popoverContent, width: 300, dismissible: true, offsetTop: popoverTopOffset, placement: popoverPlacement } );
 			jQuery( '.tour-' + tourName ).remove();
 
 			if ( tourEndsHere ) {


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem
The popover sometime displays over the tour item thereby  partially or fully hiding the tour item from the user.

See below;
<img width="769" alt="image" src="https://github.com/GlotPress/GlotPress/assets/2834132/b4e9b3b5-34fd-4366-bf43-c2b25245e3ff">


## Solution
Allow setting of the offsetTop value for the popover, this can be a +ve or a -ve integer.

## Testing Instructions
Add the filter below;
```
add_filter(
				'gp_tour',
				function() {
					return array(
						'ui-intro' => [
							[
								'title' => 'UI Introduction Tour',
								'color' => '#3939c7',
							],
							[
								'selector'         => '.strings .original',
								'html'             => 'This is the original string, pay attention to underlined words: they are in the glossary of your locale and if the context fits you must use the translation suggested by the glossary',
								'popover-position' => 'left',
								'topOffset' => 35,
								'placement' => 'top',

							],
							[
								'selector' => '.strings .textareas',
								'html'     => 'This is the area where you can suggest your translation. Good grammar helps! Also, always pay attention to context and the Glossary entries that may apply.',
								'topOffset' => -80,
							],
							[
								'selector' => '.actions .is-primary',
								'html'     => 'This is the buttons area where you can find the very helpful “Help” button!',
							],
							
						],
					);
				},
				10
			);
```
For the `placement` key, value can be any of the following auto, top, right, bottom, left, top-right, top-left, bottom-right, bottom-left, auto-top, auto-right, auto-bottom, auto-left, horizontal, vertical