### PR TITLE
Add a Grunt action to set GP_SCRIPT_DEBUG to false when we deploy to wporg

### DIFF
--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm run updateGPScriptDebugConst
+          npm run prepare-release
           git config user.email "build@glotpress.blog"
           git config user.name "GlotPress Build"
           git add .

--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          npm run updateGPScriptDebugConst
           git config user.email "build@glotpress.blog"
           git config user.name "GlotPress Build"
           git add .

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ module.exports = function( grunt ) {
 			},
 		},
 		replace: {
-			updateGPScriptDebugConst: {
+			prepare-release: {
 				src: ['glotpress.php'],
 				overwrite: true,
 				replacements: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,18 @@ module.exports = function( grunt ) {
 				tasks: [ 'cssmin' ],
 			},
 		},
+		replace: {
+			updateGPScriptDebug: {
+				src: ['glotpress.php'],
+				overwrite: true,
+				replacements: [
+					{
+						from: /define\( 'GP_SCRIPT_DEBUG', true \);/g,
+						to: "define( 'GP_SCRIPT_DEBUG', false );" // Replacement text
+					}
+				]
+			}
+		}
 	} );
 
 	grunt.registerTask( 'default', [ 'uglify', 'cssmin' ] );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ module.exports = function( grunt ) {
 			},
 		},
 		replace: {
-			updateGPScriptDebug: {
+			updateGPScriptDebugConst: {
 				src: ['glotpress.php'],
 				overwrite: true,
 				replacements: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ module.exports = function( grunt ) {
 			},
 		},
 		replace: {
-			prepare-release: {
+			'prepare-release': {
 				src: ['glotpress.php'],
 				overwrite: true,
 				replacements: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "grunt-contrib-cssmin": "^5.0.0",
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-contrib-watch": "^1.1.0",
+        "grunt-text-replace": "^0.4.0",
         "load-grunt-tasks": "^5.1.0"
       }
     },
@@ -10318,6 +10319,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/grunt-text-replace": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
+      "integrity": "sha512-A4dFGpOaD/TQpeOlDK/zP962X1qG7KcOqPiSXOWOIeAKMzzpoDJYZ8Sz56iazI5+kTqeTa+IaEEl5c4sk+QN+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/grunt/node_modules/minimatch": {
@@ -27758,6 +27768,12 @@
           }
         }
       }
+    },
+    "grunt-text-replace": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
+      "integrity": "sha512-A4dFGpOaD/TQpeOlDK/zP962X1qG7KcOqPiSXOWOIeAKMzzpoDJYZ8Sz56iazI5+kTqeTa+IaEEl5c4sk+QN+Q==",
+      "dev": true
     },
     "gzip-size": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "grunt",
     "watch": "grunt watch",
-    "updateGPScriptDebugConst": "grunt replace:updateGPScriptDebug",
+    "updateGPScriptDebugConst": "grunt replace:updateGPScriptDebugConst",
     "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
     "env:stop": "wp-env stop",
     "lint:js": "wp-scripts lint-js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "grunt",
     "watch": "grunt watch",
-    "updateGPScriptDebugConst": "grunt replace:updateGPScriptDebugConst",
+    "prepare-release": "grunt replace:prepare-release",
     "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
     "env:stop": "wp-env stop",
     "lint:js": "wp-scripts lint-js",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "grunt-contrib-cssmin": "^5.0.0",
     "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "^1.1.0",
+    "grunt-text-replace": "^0.4.0",
     "load-grunt-tasks": "^5.1.0"
   },
   "scripts": {
     "build": "grunt",
     "watch": "grunt watch",
+    "updateGPScriptDebugConst": "grunt replace:updateGPScriptDebug",
     "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
     "env:stop": "wp-env stop",
     "lint:js": "wp-scripts lint-js",


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

When we deploy a new version to wporg, we need to minify the CSS and the JavaScript tiles. 

- In https://github.com/GlotPress/GlotPress/pull/1614 we added a `GP_SCRIPT_DEBUG` constant to load the unminified CSS and JavaScript files by default, setting this `GP_SCRIPT_DEBUG` constant to `true` in the **glotpress.php** file.
- In https://github.com/GlotPress/GlotPress/pull/1654 and in https://github.com/GlotPress/GlotPress/pull/1655 we added some actions to minify this files when we deploy to wporg.

But we need to change the `GP_SCRIPT_DEBUG` constant to `false` before we deploy to wporg, so the wporg release will use the minified files (except the end user will use the `SCRIPT_DEBUG` set to `true`). This PR address this problem.

Fixes https://github.com/GlotPress/GlotPress/issues/1587.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds:
- A **Grunt action** to change the `define( 'GP_SCRIPT_DEBUG', true );` to `define( 'GP_SCRIPT_DEBUG', false );` in the glotpress.php file. **Gruntfile.js** file.
- A **npm action** to run the Grunt action. **package.json** file.
- This npm action into the **wporg workflow**. **.github/workflows/deploy-wporg-plugin.yml** file.

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

To test this PR:
- You can execute the Grunt action with the `grunt replace:updateGPScriptDebugConst` command.
- You can execute the npm action with the `npm run updateGPScriptDebugConst` command.

In both situations, you can check that the `GP_SCRIPT_DEBUG` value in the `glotpress.php` file has changed from true to false.
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->
