### PR TITLE
Avoid passing `null` to `trim()`

### DIFF
--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -682,6 +682,9 @@ class GP_Thing {
 	}
 
 	public function sql_from_order( $order_by, $order_how = '' ) {
+		if ( ! $order_by ) {
+			$order_by = '';
+		}
 		if ( is_array( $order_by ) ) {
 			$order_by  = implode( ' ', $order_by );
 			$order_how = '';

--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -211,6 +211,10 @@ class GP_Original extends GP_Thing {
 		foreach ( $translations->entries as $key => $entry ) {
 			$wpdb->queries = array();
 
+			if ( ! $entry->context ) {
+				$entry->context = '';
+			}
+
 			// Context needs to match VARCHAR(255) in the database schema.
 			if ( mb_strlen( $entry->context ) > 255 ) {
 				$entry->context                         = mb_substr( $entry->context, 0, 255 );

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -398,6 +398,10 @@ function textareas( $entry, $permissions, $index = 0 ) {
 }
 
 function display_status( $status ) {
+	if ( ! $status ) {
+		$status = '';
+	}
+
 	$status_labels = array(
 		'current'          => _x( 'current', 'Single Status', 'glotpress' ),
 		'waiting'          => _x( 'waiting', 'Single Status', 'glotpress' ),


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

<!--
Please, describe what is the status/problem before the PR.
-->

I got some PHP deprecation notices:

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/gp-includes/thing.php on line 689
```

## Solution

<!--
Please, describe how this PR improves the situation.
-->

Set variable to an empty string if null.

## To-do

<!--
Please, describe the other undone tasks or items on the to-do list for this PR,
only if it is applicable.
-->
- [ ] Task 1 (Replace with your task description)

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->