### PR TITLE
Add a slash at the end of a requested URI

### DIFF
--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -186,7 +186,7 @@ class GP_Router {
 			$_SERVER['REQUEST_URI'] .= '/';
 		}
 		// If the request URL doesn't match our base URL, don't bother trying to match
-		if ( $url_path && ! gp_startswith( wp_unslash( $_SERVER['REQUEST_URI'] ), $url_path ) ) {
+		if ( $url_path && ! gp_startswith( wp_unslash( trailingslashit( $_SERVER['REQUEST_URI'] ) ), $url_path ) ) {
 			return;
 		}
 

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -181,10 +181,6 @@ class GP_Router {
 
 		$url_path = gp_url_path( gp_url_public_root() );
 
-		// Check if the last character of the text is not a slash, and add it if needed
-		if ( substr( $_SERVER['REQUEST_URI'], -1 ) !== '/' ) {
-			$_SERVER['REQUEST_URI'] .= '/';
-		}
 		// If the request URL doesn't match our base URL, don't bother trying to match
 		if ( $url_path && ! gp_startswith( wp_unslash( trailingslashit( $_SERVER['REQUEST_URI'] ) ), $url_path ) ) {
 			return;

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -181,6 +181,10 @@ class GP_Router {
 
 		$url_path = gp_url_path( gp_url_public_root() );
 
+		// Check if the last character of the text is not a slash, and add it if needed
+		if ( substr( $_SERVER['REQUEST_URI'], -1 ) !== '/' ) {
+			$_SERVER['REQUEST_URI'] .= '/';
+		}
 		// If the request URL doesn't match our base URL, don't bother trying to match
 		if ( $url_path && ! gp_startswith( wp_unslash( $_SERVER['REQUEST_URI'] ), $url_path ) ) {
 			return;


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

When you access the https://glotpress.test/glotpress URI (without a slash at the end of the URI), you get a 404. Instead, if you add the slash at the end of the URI https://glotpress.test/glotpress/, you are redirected to https://glotpress.test/glotpress/projects/

Keep in mind, I am using https://glotpress.test/ as my main WordPress address. Please, change all the URI used in this description to the main URI used in your local installation.

Fixes https://github.com/GlotPress/GlotPress/issues/896.
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds a slash at the end of the requested URI if it doesn't have it.

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

Test both URI in your local installation (with and without the final slash) before and after applying this PR:
1. https://glotpress.test/glotpress
2. https://glotpress.test/glotpress/

Before applying the PR, you will get a 404 with the first URI. After applying the PR, you will be redirected to the GlotPress main page.
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->
