### PR TITLE
Update a CSS comment that causes a build error

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1675,7 +1675,7 @@ a.tour-button.button-primary:hover {
 }
 
 .webui-popover .webui-popover-title {
-	border-radius: 4px 4px 0 0; // Make webui-popover outside and inner borders radius concentric.
+	border-radius: 4px 4px 0 0; /* Make webui-popover outside and inner borders radius concentric. */
 	background: #fff;
 	font-weight: bold;
 	color: var( --gp-color-tour );


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

When I execute an assets build:

`npm run build`

I get an error:

```
Running "cssmin:core" (cssmin) task
>> Invalid property name '// Make webui-popover outside and inner borders radius concentric.
>>      background' at assets/css/style.css:1678:29. Ignoring.
>> 2 files created. 42.1 kB → 35.2 kB
```
because the '//' is not a correct CSS comment.
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR changes the comment in the CSS file, so the build runs fine.

```
npm run build

> glotpress@0.0.0 build
> grunt

Running "uglify:core" (uglify) task
>> 7 files created 80.2 kB → 39.3 kB

Running "cssmin:core" (cssmin) task
>> 2 files created. 42.1 kB → 35.2 kB

Done.
```


<!--
Please, describe how this PR improves the situation.
-->