### PR TITLE
When creating a new project, check if the project slug exists and is not null

### DIFF
--- a/gp-templates/project-form.php
+++ b/gp-templates/project-form.php
@@ -5,7 +5,7 @@
 	<!-- TODO: make slug edit WordPress style -->
 	<dt><label for="project[slug]"><?php _e( 'Slug', 'glotpress' ); ?></label></dt>
 	<dd>
-		<input type="text" name="project[slug]" value="<?php echo esc_attr( urldecode( $project->slug ) ); ?>" id="project[slug]">
+		<input type="text" name="project[slug]" value="<?php echo esc_attr( urldecode( $project->slug ?? '' ) ); ?>" id="project[slug]">
 		<small><?php _e( 'If you leave the slug empty, it will be derived from the name.', 'glotpress' ); ?></small>
 	</dd>
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Using PHP8.2, I get a deprecation warning when I create a new project with an empty slug. 

`PHP Deprecated:  urldecode(): Passing null to parameter #1 ($string) of type string is deprecated in /wordpress/glotpress/wp-content/plugins/GlotPress/gp-templates/project-form.php on line 8`

![image](https://github.com/GlotPress/GlotPress/assets/1667814/5f11c752-2a0d-4481-a9fe-574ce9e1d94b)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

We need to check if the project slug exists and is not null.

<!--
Please, describe how this PR improves the situation.
-->

