### PR TITLE
Add some properties in the translation-set to avoid deprecation notices

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -105,11 +105,46 @@ class GP_Translation_Set extends GP_Thing {
 	public $warnings_count;
 
 	/**
+	 * Number of rejected translations.
+	 *
+	 * @var int
+	 */
+	public $rejected_count;
+
+	/**
+	 * Number of old translations.
+	 *
+	 * @var int
+	 */
+	public $old_count;
+
+	/**
 	 * Number of all originals.
 	 *
 	 * @var int
 	 */
 	public $all_count;
+
+	/**
+	 * The percent translated.
+	 *
+	 * @var int
+	 */
+	public $percent_translated;
+
+	/**
+	 * The English name of the locale.
+	 *
+	 * @var string
+	 */
+	public $name_with_locale;
+
+	/**
+	 * The WP locale.
+	 *
+	 * @var string
+	 */
+	public $wp_locale;
 
 	/**
 	 * Sets restriction rules for fields.


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Using PHP8.2, I get some deprecation warnings when I access to the different locales in a project, because it tries to create dynamic properties:
- $name_with_locale
- $rejected_count
- $old_count
- $percent_translated
- $wp_locale

![image](https://github.com/GlotPress/GlotPress/assets/1667814/1f467c11-18fc-4dc0-9b3d-31b1b24e8672)

```
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$name_with_locale is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/routes/project.php on line 36
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$rejected_count is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/things/translation-set.php on line 638
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$old_count is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/things/translation-set.php on line 638
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$percent_translated is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/routes/project.php on line 42
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$wp_locale is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/routes/project.php on line 44
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$rejected_count is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/things/translation-set.php on line 638
PHP Deprecated:  Creation of dynamic property GP_Translation_Set::$old_count is deprecated in /wordpress/glotpress2/wp-content/plugins/GlotPress/gp-includes/things/translation-set.php on line 638
```


<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

To avoid these warnings, I have added these properties to the `GP_Translation_Set` class.

<!--
Please, describe how this PR improves the situation.
-->

