### PR TITLE
Resolve a bug with the glossary variations

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -213,14 +213,14 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 		}
 
 		// Build the regular expression.
-		$terms_search = '(%(?:[1-9]\$)?[bcdefgosuxEFGX%l@])|(\b';
+		$terms_search = '(%(?:[1-9]\$)?[bcdefgosuxEFGX%l@])|\b(';
 		foreach ( $regex_group as $suffix => $terms ) {
 			$terms_search .= '(?:' . implode( '|', $terms ) . ')' . $suffix . '|';
 		}
 
 		// Remove the trailing |.
 		$terms_search  = substr( $terms_search, 0, -1 );
-		$terms_search .= '\b)';
+		$terms_search .= ')\b';
 	}
 	// Split the singular string on glossary terms boundaries.
 	$singular_split = preg_split( '/' . $terms_search . '/i', $translation->singular, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -493,7 +493,6 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		}
 	}
 
-
 	/**
 	 * @dataProvider provide_test_map_glossary_entries_to_translation_originals
 	 */

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -285,6 +285,126 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$this->assertEquals( $orig->singular_glossary_markup, $singular_expected_result );
 		$this->assertEquals( $orig->plural_glossary_markup, $plural_expected_result );	}
 
+	/*
+	 * Matches the glossary variations. Added two unnecessary glossary entries.
+	 */
+	function test_map_glossary_entries_with_variations() {
+		$singular_string          = 'Converting, converts, converted and convert.';
+		$plural_string            = 'Plural. ' . $singular_string;
+		$singular_expected_result = '<span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">Converting</span>, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">converts</span>, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">converted</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">convert</span>.';
+		$plural_expected_result   = 'Plural. ' . $singular_expected_result;
+
+		$entry = new Translation_Entry( array( 'singular' => $singular_string, 'plural' => $plural_string ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'toy',
+			'part_of_speech' => 'noun',
+			'translation' => 'xoguete',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'convert',
+			'part_of_speech' => 'verb',
+			'translation' => 'converter',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'guy',
+			'part_of_speech' => 'noun',
+			'translation' => 'rapaz',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $singular_expected_result );
+		$this->assertEquals( $orig->plural_glossary_markup, $plural_expected_result );
+	}
+
+	/*
+	 * Matches the glossary variations and placeholders.
+	 */
+	function test_map_glossary_entries_with_variations_and_placeholders() {
+		$singular_string          = 'Delay and delays, key and keys, toy and toys, guy and guys, %see%s %1$guys%2$s %ssee%s %1$gguys%2$s, converting and convert.';
+		$plural_string            = 'Plural. ' . $singular_string;
+		$singular_expected_result = '<span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;retraso&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">Delay</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;retraso&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">delays</span>, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;chave&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">key</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;chave&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">keys</span>, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;xoguete&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">toy</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;xoguete&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">toys</span>, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;rapaz&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">guy</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;rapaz&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">guys</span>, %see%s %1$guys%2$s %s<span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;ver&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">see</span>%s %1$g<span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;rapaz&quot;,&quot;pos&quot;:&quot;noun&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">guys</span>%2$s, <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">converting</span> and <span class="glossary-word" data-translations="[{&quot;translation&quot;:&quot;converter&quot;,&quot;pos&quot;:&quot;verb&quot;,&quot;comment&quot;:null,&quot;locale_entry&quot;:&quot;&quot;}]">convert</span>.';
+		$plural_expected_result   = 'Plural. ' . $singular_expected_result;
+
+		$entry = new Translation_Entry( array( 'singular' => $singular_string, 'plural' => $plural_string ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entry = array(
+			'term' => 'delay',
+			'part_of_speech' => 'noun',
+			'translation' => 'retraso',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'key',
+			'part_of_speech' => 'noun',
+			'translation' => 'chave',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'toy',
+			'part_of_speech' => 'noun',
+			'translation' => 'xoguete',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'guy',
+			'part_of_speech' => 'noun',
+			'translation' => 'rapaz',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'see',
+			'part_of_speech' => 'verb',
+			'translation' => 'ver',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$glossary_entry = array(
+			'term' => 'convert',
+			'part_of_speech' => 'verb',
+			'translation' => 'converter',
+			'glossary_id' => $glossary->id,
+		);
+
+		GP::$glossary_entry->create_and_select( $glossary_entry );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $singular_expected_result );
+		$this->assertEquals( $orig->plural_glossary_markup, $plural_expected_result );	}
+
 	/**
 	 * Expects highlighting leading and ending spaces in single line strings, and double/multiple spaces in the middle.
 	 */

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -460,38 +460,39 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 
 	function provide_test_map_glossary_entries_to_translation_originals() {
 		foreach ( array(
-					  'party' => array(
-						  'Welcome to the party.',
-						  'My parties.',
-						  'I know, partys is the wrong plural ending but we need it because of nouns like boys.',
-					  ),
-					  'color' => array(
-						  'One color.',
-						  'Two colors.',
-					  ),
-					  'half' => array(
-						  'Half a loaf is better than none.',
-						  'Two halves are even better.',
-					  ),
-					  'man' => array(
-						  'The word man is the root of the word mankind.',
-						  'There are men but there is no menkind.',
-					  ),
-					  'issue' => array(
-						  'If you find a bug, file an issue.',
-						  'If you find two bugs, please file two issues.',
-					  ),
-					  'report' => array(
-						  'I reported a bug.',
-						  'Now there is a bug report.',
-						  'We call it bug reporting.',
-					  ),
-				  ) as $expected_result => $test_strings ) {
+			'party' => array(
+				'Welcome to the party.',
+				'My parties.',
+				'I know, partys is the wrong plural ending but we need it because of nouns like boys.',
+			),
+			'color' => array(
+				'One color.',
+				'Two colors.',
+			),
+			'half' => array(
+				'Half a loaf is better than none.',
+				'Two halves are even better.',
+			),
+			'man' => array(
+				'The word man is the root of the word mankind.',
+				'There are men but there is no menkind.',
+			),
+			'issue' => array(
+				'If you find a bug, file an issue.',
+				'If you find two bugs, please file two issues.',
+			),
+			'report' => array(
+				'I reported a bug.',
+				'Now there is a bug report.',
+				'We call it bug reporting.',
+			),
+		) as $expected_result => $test_strings ) {
 			foreach ( $test_strings as $test_string ) {
 				yield array( $test_string, $expected_result );
 			}
 		}
 	}
+
 
 	/**
 	 * @dataProvider provide_test_map_glossary_entries_to_translation_originals

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -286,7 +286,7 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$this->assertEquals( $orig->plural_glossary_markup, $plural_expected_result );	}
 
 	/*
-	 * Matches the glossary variations. Added two unnecessary glossary entries.
+	 * Matches the glossary variations.
 	 */
 	function test_map_glossary_entries_with_variations() {
 		$singular_string          = 'Converting, converts, converted and convert.';
@@ -299,32 +299,54 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
 
-		$glossary_entry = array(
-			'term' => 'toy',
-			'part_of_speech' => 'noun',
-			'translation' => 'xoguete',
-			'glossary_id' => $glossary->id,
+		$glossary_entries = array(
+			array(
+				'term' => 'delay',
+				'part_of_speech' => 'noun',
+				'translation' => 'retraso',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'key',
+				'part_of_speech' => 'noun',
+				'translation' => 'chave',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'toy',
+				'part_of_speech' => 'noun',
+				'translation' => 'xoguete',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'guy',
+				'part_of_speech' => 'noun',
+				'translation' => 'rapaz',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'see',
+				'part_of_speech' => 'verb',
+				'translation' => 'ver',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'convert',
+				'part_of_speech' => 'verb',
+				'translation' => 'converter',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'chef',
+				'part_of_speech' => 'noum',
+				'translation' => 'cociñeiro',
+				'glossary_id' => $glossary->id,
+			),
 		);
 
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'convert',
-			'part_of_speech' => 'verb',
-			'translation' => 'converter',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'guy',
-			'part_of_speech' => 'noun',
-			'translation' => 'rapaz',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
+		foreach ( $glossary_entries as $glossary_entry ) {
+			GP::$glossary_entry->create_and_select( $glossary_entry );
+		}
 
 		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
 
@@ -346,59 +368,54 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 		$set = $this->factory->translation_set->create_with_project_and_locale();
 		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
 
-		$glossary_entry = array(
-			'term' => 'delay',
-			'part_of_speech' => 'noun',
-			'translation' => 'retraso',
-			'glossary_id' => $glossary->id,
+		$glossary_entries = array(
+			array(
+				'term' => 'delay',
+				'part_of_speech' => 'noun',
+				'translation' => 'retraso',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'key',
+				'part_of_speech' => 'noun',
+				'translation' => 'chave',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'toy',
+				'part_of_speech' => 'noun',
+				'translation' => 'xoguete',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'guy',
+				'part_of_speech' => 'noun',
+				'translation' => 'rapaz',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'see',
+				'part_of_speech' => 'verb',
+				'translation' => 'ver',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'convert',
+				'part_of_speech' => 'verb',
+				'translation' => 'converter',
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'chef',
+				'part_of_speech' => 'noum',
+				'translation' => 'cociñeiro',
+				'glossary_id' => $glossary->id,
+			),
 		);
 
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'key',
-			'part_of_speech' => 'noun',
-			'translation' => 'chave',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'toy',
-			'part_of_speech' => 'noun',
-			'translation' => 'xoguete',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'guy',
-			'part_of_speech' => 'noun',
-			'translation' => 'rapaz',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'see',
-			'part_of_speech' => 'verb',
-			'translation' => 'ver',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
-
-		$glossary_entry = array(
-			'term' => 'convert',
-			'part_of_speech' => 'verb',
-			'translation' => 'converter',
-			'glossary_id' => $glossary->id,
-		);
-
-		GP::$glossary_entry->create_and_select( $glossary_entry );
+		foreach ( $glossary_entries as $glossary_entry ) {
+			GP::$glossary_entry->create_and_select( $glossary_entry );
+		}
 
 		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
 
@@ -443,33 +460,33 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 
 	function provide_test_map_glossary_entries_to_translation_originals() {
 		foreach ( array(
-			'party' => array(
-				'Welcome to the party.',
-				'My parties.',
-				'I know, partys is the wrong plural ending but we need it because of nouns like boys.',
-			),
-			'color' => array(
-				'One color.',
-				'Two colors.',
-			),
-			'half' => array(
-				'Half a loaf is better than none.',
-				'Two halves are even better.',
-			),
-			'man' => array(
-				'The word man is the root of the word mankind.',
-				'There are men but there is no menkind.',
-			),
-			'issue' => array(
-				'If you find a bug, file an issue.',
-				'If you find two bugs, please file two issues.',
-			),
-			'report' => array(
-				'I reported a bug.',
-				'Now there is a bug report.',
-				'We call it bug reporting.',
-			),
-		) as $expected_result => $test_strings ) {
+					  'party' => array(
+						  'Welcome to the party.',
+						  'My parties.',
+						  'I know, partys is the wrong plural ending but we need it because of nouns like boys.',
+					  ),
+					  'color' => array(
+						  'One color.',
+						  'Two colors.',
+					  ),
+					  'half' => array(
+						  'Half a loaf is better than none.',
+						  'Two halves are even better.',
+					  ),
+					  'man' => array(
+						  'The word man is the root of the word mankind.',
+						  'There are men but there is no menkind.',
+					  ),
+					  'issue' => array(
+						  'If you find a bug, file an issue.',
+						  'If you find two bugs, please file two issues.',
+					  ),
+					  'report' => array(
+						  'I reported a bug.',
+						  'Now there is a bug report.',
+						  'We call it bug reporting.',
+					  ),
+				  ) as $expected_result => $test_strings ) {
 			foreach ( $test_strings as $test_string ) {
 				yield array( $test_string, $expected_result );
 			}


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In https://github.com/GlotPress/GlotPress/pull/1696 I introduced a bug with the glossary variations, not detecting them. You can see it in the next screenshot.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/40ea7ac6-5706-4ce4-a255-e2b6ed0efb6e)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR updates the regular expression that splits the original string with the glossary terms and with the placeholders.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/00a14c7f-5550-4e46-aed5-cb97fd354194)

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

I have added two new tests to avoid this error another time:
- test_map_glossary_entries_with_variations.
- test_map_glossary_entries_with_variations_and_placeholders.

The load time using [this method](https://github.com/GlotPress/GlotPress/pull/1696#issuecomment-1737029365) is very similar:
- Before PR. Mean load time: 733.000 milliseconds
- After PR. Mean load time: 723.000 millisecond
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->
