### PR TITLE
Deprecation. Check if the ctype_digit parameter is null

### DIFF
--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -641,7 +641,7 @@ class GP_Thing {
 			return array_map( array( &$this, 'sql_condition_from_php_value' ), $php_value );
 		}
 		$operator = '=';
-		if ( is_integer( $php_value ) || ctype_digit( $php_value ) ) {
+		if ( is_integer( $php_value ) || ctype_digit( $php_value ?? '' ) ) {
 			$sql_value = $php_value;
 		} else {
 			$sql_value = "'" . esc_sql( $php_value ) . "'";

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -641,7 +641,7 @@ class GP_Thing {
 			return array_map( array( &$this, 'sql_condition_from_php_value' ), $php_value );
 		}
 		$operator = '=';
-		if ( is_integer( $php_value ) || ctype_digit( $php_value ?? '' ) ) {
+		if ( is_integer( $php_value ) || ( null !== $php_value && ctype_digit( $php_value ) ) ) {
 			$sql_value = $php_value;
 		} else {
 			$sql_value = "'" . esc_sql( $php_value ) . "'";


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Using PHP8.2, with a non logged user, when I access to a list of projects, I get a deprecation notice:

`PHP Deprecated:  ctype_digit(): Argument of type null will be interpreted as string in the future in /wordpress/glotpress/wp-content/plugins/GlotPress/gp-includes/thing.php on line 644`


![image](https://github.com/GlotPress/GlotPress/assets/1667814/026fb687-5af1-44a1-a8f8-12534f8b5f2e)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

Since PHP 8.1.0, passing a non-string argument to the `ctype_digit` function is deprecated. More info [here](https://www.php.net/manual/en/function.ctype-digit.php).

This PR checks if the argument passed to `ctype_digit` is not null, avoiding its execution in this situation.