### PR TITLE
Deprecation. Check if the preg_split parameter is null

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -576,7 +576,7 @@ class GP_Translation extends GP_Thing {
 			for ( $i = 0; $i < $locale->nplurals; $i++ ) {
 				$row->translations[] = $row->{'translation_' . $i};
 			}
-			$row->references         = preg_split( '/\s+/', $row->references ?? '', -1, PREG_SPLIT_NO_EMPTY );
+			$row->references         = $row->references !== null ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
 			$row->extracted_comments = $row->comment;
 			$row->warnings           = $row->warnings ? maybe_unserialize( $row->warnings ) : null;
 			unset( $row->comment );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -576,7 +576,7 @@ class GP_Translation extends GP_Thing {
 			for ( $i = 0; $i < $locale->nplurals; $i++ ) {
 				$row->translations[] = $row->{'translation_' . $i};
 			}
-			$row->references         = null !== $row->references ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
+			$row->references         = $row->references ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
 			$row->extracted_comments = $row->comment;
 			$row->warnings           = $row->warnings ? maybe_unserialize( $row->warnings ) : null;
 			unset( $row->comment );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -576,7 +576,7 @@ class GP_Translation extends GP_Thing {
 			for ( $i = 0; $i < $locale->nplurals; $i++ ) {
 				$row->translations[] = $row->{'translation_' . $i};
 			}
-			$row->references         = preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY );
+			$row->references         = preg_split( '/\s+/', $row->references ?? '', -1, PREG_SPLIT_NO_EMPTY );
 			$row->extracted_comments = $row->comment;
 			$row->warnings           = $row->warnings ? maybe_unserialize( $row->warnings ) : null;
 			unset( $row->comment );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -576,7 +576,7 @@ class GP_Translation extends GP_Thing {
 			for ( $i = 0; $i < $locale->nplurals; $i++ ) {
 				$row->translations[] = $row->{'translation_' . $i};
 			}
-			$row->references         = $row->references !== null ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
+			$row->references         = null !== $row->references  ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
 			$row->extracted_comments = $row->comment;
 			$row->warnings           = $row->warnings ? maybe_unserialize( $row->warnings ) : null;
 			unset( $row->comment );

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -576,7 +576,7 @@ class GP_Translation extends GP_Thing {
 			for ( $i = 0; $i < $locale->nplurals; $i++ ) {
 				$row->translations[] = $row->{'translation_' . $i};
 			}
-			$row->references         = null !== $row->references  ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
+			$row->references         = null !== $row->references ? preg_split( '/\s+/', $row->references, -1, PREG_SPLIT_NO_EMPTY ) : array();
 			$row->extracted_comments = $row->comment;
 			$row->warnings           = $row->warnings ? maybe_unserialize( $row->warnings ) : null;
 			unset( $row->comment );


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Using PHP8.2, when I access to a list of translations in the main table, I get a deprecation notice:

`PHP Deprecated:  preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated in /wordpress/glotpress/wp-content/plugins/GlotPress/gp-includes/things/translation.php on line 579`

![image](https://github.com/GlotPress/GlotPress/assets/1667814/c5ee08ca-c059-41e4-bd3b-fdc672faa316)


<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

Skip the `preg_split` execution if the second parameter is null.

<!--
Please, describe how this PR improves the situation.
-->

