### PR TITLE
Site Tour: Improve the pulse

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -112,7 +112,7 @@ jQuery( document ).ready(
 			style = styleElement.sheet;
 
 			for ( n in window.tour ) {
-				color1 = window.tour[ n ][ 0 ].color + '00';
+				color1 = window.tour[ n ][ 0 ].color;
 				color2 = window.tour[ n ][ 0 ].color + 'a0';
 
 				style.insertRule( '@keyframes animation-' + n + ' {' +
@@ -120,10 +120,10 @@ jQuery( document ).ready(
 					'box-shadow: 0 0 0 0 ' + color2 + ';' +
 					'}' +
 					'70% {' +
-					'box-shadow: 0 0 0 10px ' + color1 + ';' +
+					'box-shadow: 0 0 0 10px ' + color1 + '00' + ';' +
 					'}' +
 					'100% {' +
-					'box-shadow: 0 0 0 0 ' + color1 + ';' +
+					'box-shadow: 0 0 0 0 ' + color1 + '00' + ';' +
 					'}' +
 					'}',
 				style.cssRules.length );

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -130,7 +130,7 @@ jQuery( document ).ready(
 
 				style.insertRule( '.tour-' + n + '{' +
 					'box-shadow: 0 0 0 ' + color2 + ';' +
-					'background: ' + color1 + ';' +
+					'background: ' + color1 + '80' + ';' +
 					'-webkit-animation: animation-' + n + ' 2s infinite;' +
 					'animation: animation-' + n + ' 2s infinite; }',
 				style.cssRules.length );


### PR DESCRIPTION
## Problem
The pulse is not visible and can easily be missed.

## Solution

We remove the transparency of the inner circle of the pulse to make the pulse look more bolder and visible.

## Screenshots or screencast

### Before
![pulse-before](https://github.com/GlotPress/GlotPress/assets/2834132/038801bb-b0f6-432b-8263-c2fc9003180c)

### After
![pulse-after](https://github.com/GlotPress/GlotPress/assets/2834132/01954e78-7aa3-4b98-9e45-0424022e1382)

