### PR TITLE
Add templates for bug and feature report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,56 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+Please fill out ALL required sections. Bug reports with missing information will
+be closed.
+
+Before submitting a bug report:
+
+- Check if the bug has already been fixed by updating WordPress, GlotPress and/or the plugin.
+- Check if the bug is caused by a plugin by deactivating all plugins except GlotPress and this plugin.
+- Check if the bug is caused by a theme by activating a default theme, e.g. Twenty Twenty Two.
+- Check if the bug has already been reported by searching https://github.com/WordPress/gp-translation-helpers/issues.
+
+If this is a security issue, please report it in HackerOne instead:
+https://hackerone.com/wordpress
+-->
+
+## Description
+<!-- Please write a brief description of the bug. -->
+
+## Step-by-step reproduction instructions
+<!--
+Please list the steps needed to reproduce the bug. For example:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+-->
+
+## Expected behavior
+<!-- Please describe what you expected to happen. -->
+
+## Actual behavior
+<!-- Please describe what actually happened. -->
+
+## Screenshots or screen recording (optional)
+<!--
+If possible, please upload a screenshot or screen recording which demonstrates
+the bug. 
+-->
+
+## WordPress information
+- WordPress version: <!-- e.g. "6.0.0". Find this in Tools → Site Health → Info → WordPress -->
+- GlotPress version: <!-- e.g. "3.0.0" or "Not installed" -->
+- Plugin version: <!-- e.g. "0.0.2" or "Not installed" -->
+- Are all plugins except GlotPress and this plugin deactivated? <!-- "Yes" or "No" -->
+- Are you using a default theme (e.g. Twenty Twenty-Two)? <!-- "Yes" or "No" -->
+
+## Device information
+- Operating system: <!-- e.g. "macOS 12.4", "Windows 11", "Android 11.0" or "iOS 14.0" -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,10 @@ be closed.
 
 Before submitting a bug report:
 
-- Check if the bug has already been fixed by updating WordPress, GlotPress and/or the plugin.
-- Check if the bug is caused by a plugin by deactivating all plugins except GlotPress and this plugin.
-- Check if the bug is caused by a theme by activating a default theme, e.g. Twenty Twenty Two.
-- Check if the bug has already been reported by searching https://github.com/WordPress/gp-translation-helpers/issues.
+- Check if the bug has already been fixed by updating WordPress and/or GlotPress.
+- Check if the bug is caused by a plugin by deactivating all plugins except GlotPress.
+- Check if the bug is caused by a theme by activating a default theme, e.g. Twenty Twenty-Three.
+- Check if the bug has already been reported by searching https://github.com/glotpress/glotpress/issues.
 
 If this is a security issue, please report it in HackerOne instead:
 https://hackerone.com/wordpress
@@ -41,16 +41,16 @@ Please list the steps needed to reproduce the bug. For example:
 
 ## Screenshots or screen recording (optional)
 <!--
-If possible, please upload a screenshot or screen recording which demonstrates
+If possible, please, upload a screenshot or screen recording which demonstrates
 the bug.
 -->
 
 ## WordPress information
 - WordPress version: <!-- e.g. "6.0.0". Find this in Tools → Site Health → Info → WordPress -->
 - GlotPress version: <!-- e.g. "3.0.0" or "Not installed" -->
-- Plugin version: <!-- e.g. "0.0.2" or "Not installed" -->
-- Are all plugins except GlotPress and this plugin deactivated? <!-- "Yes" or "No" -->
-- Are you using a default theme (e.g. Twenty Twenty-Two)? <!-- "Yes" or "No" -->
+- Are all plugins except GlotPress deactivated? <!-- "Yes" or "No" -->
+- Are you using a default theme (e.g. Twenty Twenty-Three)? <!-- "Yes" or "No" -->
 
 ## Device information
 - Operating system: <!-- e.g. "macOS 12.4", "Windows 11", "Android 11.0" or "iOS 14.0" -->
+- Browser: <!-- e.g. "Chrome 94.0.4606.81", "Firefox 93.0" or "Safari 15.0" -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Report a bug to help us improve
-title: ''
-labels: bug
-assignees: ''
+title: ""
+labels: "[Type] Bug"
+assignees: ""
 
 ---
 
@@ -42,7 +42,7 @@ Please list the steps needed to reproduce the bug. For example:
 ## Screenshots or screen recording (optional)
 <!--
 If possible, please upload a screenshot or screen recording which demonstrates
-the bug. 
+the bug.
 -->
 
 ## WordPress information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose an idea for a feature or an enhancement
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## What problem does this address?
+<!--
+Please describe if this feature or enhancement is related to a current problem
+or pain point. For example, "I'm always frustrated when ..." or "It is currently
+difficult to ...".
+-->
+
+## What is your proposed solution?
+<!--
+Please outline the feature or enhancement that you want and how it addresses any
+problem identified above.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,6 +9,10 @@ assignees: ""
 
 ## What problem does this address?
 <!--
+
+Before submitting a new enhancement request, please, check if the feature has
+already been requested by searching at https://github.com/glotpress/glotpress/issues
+
 Please describe if this feature or enhancement is related to a current problem
 or pain point. For example, "I'm always frustrated when ..." or "It is currently
 difficult to ...".

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,3 +23,9 @@ difficult to ...".
 Please outline the feature or enhancement that you want and how it addresses any
 problem identified above.
 -->
+
+## Mockups/screenshots
+<!--
+If applicable, add mockups or screenshots to help explain your feature or
+enhancement.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature request
 about: Propose an idea for a feature or an enhancement
-title: ''
-labels: enhancement
-assignees: ''
+title: ""
+labels: "[Type] Enhancement"
+assignees: ""
 
 ---
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

When a user creates a new issue, sometimes the information she puts is bad or without good information.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds the templates we currently have in the [gp-translation-helpers](https://github.com/GlotPress/gp-translation-helpers) plugin.

When you want to [create an issue](https://github.com/GlotPress/gp-translation-helpers/issues/new/choose), you need to select between:
- Bug report.
- Feature request.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/88ef34b4-4022-4816-8416-06e47611e4c8)

### [Bug report](https://github.com/GlotPress/gp-translation-helpers/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=)

![image](https://github.com/GlotPress/GlotPress/assets/1667814/5a6ebdcb-bcfc-4479-a02f-8ebd7560b726)

### [Feature request](https://github.com/GlotPress/gp-translation-helpers/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=)

![image](https://github.com/GlotPress/GlotPress/assets/1667814/3a642838-2f3a-4d58-8036-7dc710f47357)

<!--
Please, describe how this PR improves the situation.
-->

