### PR TITLE
Don't set context to empty string by default

### DIFF
--- a/gp-includes/things/original.php
+++ b/gp-includes/things/original.php
@@ -211,12 +211,8 @@ class GP_Original extends GP_Thing {
 		foreach ( $translations->entries as $key => $entry ) {
 			$wpdb->queries = array();
 
-			if ( ! $entry->context ) {
-				$entry->context = '';
-			}
-
 			// Context needs to match VARCHAR(255) in the database schema.
-			if ( mb_strlen( $entry->context ) > 255 ) {
+			if ( is_string( $entry->context ) && mb_strlen( $entry->context ) > 255 ) {
 				$entry->context                         = mb_substr( $entry->context, 0, 255 );
 				$translations->entries[ $entry->key() ] = $entry;
 			}


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

This PR solves the bug introduced [here](https://github.com/GlotPress/GlotPress/pull/1698/files#r1362529266), as this bug sets the context property to empty string if the value is NULL.

Fixes https://github.com/GlotPress/GlotPress/issues/1724.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

The solution is to remove one check that sets the property `context` to empty string if its value is NULL, and to check if the context property is a string before using with the `mb_strlen` function as its paremeter, to avoid introducing the previous bug (warning) another time.

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

I have made 2 manual tests with the same steps:
- Create a subproject.
- Import the originals for this new subproject.
- Create a translation set for this new subproject (a new locale).
- Import the translations for this new subproject and translation set. 

1. Before this bugfix, after creating the originals, the originals without context are stored as empty strings in the database. When I import the translations for the subproject and the translation set, this import process fails to import most of the strings. 
2. With this bugfix, the imported originals without context are stored as NULL in the database. When I import the translations for the subproject and the translation set, this import process works fine.

<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
3. Add the translation.
4. etc. 
-->
