### PR TITLE
Glossary: Fix fatal array in PHP8 for invalid post data

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -108,14 +108,14 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 	public function glossary_entries_post( $project_path, $locale_slug, $translation_set_slug ) {
 		$ge_post = gp_post( 'glossary_entry' );
 		if ( ! is_array( $ge_post ) || ! isset( $ge_post[0]['glossary_entry_id'] ) ) {
-			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 200 );
+			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 404 );
 		}
 
 		$ge             = array_shift( $ge_post );
 		$glossary_entry = GP::$glossary_entry->get( absint( $ge['glossary_entry_id'] ) );
 
 		if ( ! $glossary_entry ) {
-			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 200 );
+			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 404 );
 		}
 
 		if ( ! $this->verify_nonce( 'edit-glossary-entry_' . $glossary_entry->id ) ) {

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -106,7 +106,11 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 	}
 
 	public function glossary_entries_post( $project_path, $locale_slug, $translation_set_slug ) {
-		$ge_post        = gp_post( 'glossary_entry' );
+		$ge_post = gp_post( 'glossary_entry' );
+		if ( ! is_array( $ge_post ) || ! isset( $ge_post[0]['glossary_entry_id'] ) ) {
+			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 200 );
+		}
+
 		$ge             = array_shift( $ge_post );
 		$glossary_entry = GP::$glossary_entry->get( absint( $ge['glossary_entry_id'] ) );
 

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -107,13 +107,16 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 
 	public function glossary_entries_post( $project_path, $locale_slug, $translation_set_slug ) {
 		$ge_post = gp_post( 'glossary_entry' );
-		if ( ! is_array( $ge_post ) || ! isset( $ge_post[0]['glossary_entry_id'] ) ) {
+		if ( ! is_array( $ge_post ) ) {
 			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 404 );
 		}
 
-		$ge             = array_shift( $ge_post );
-		$glossary_entry = GP::$glossary_entry->get( absint( $ge['glossary_entry_id'] ) );
+		$ge = array_shift( $ge_post );
+		if ( ! isset( $ge['glossary_entry_id'] ) ) {
+			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 404 );
+		}
 
+		$glossary_entry = GP::$glossary_entry->get( absint( $ge['glossary_entry_id'] ) );
 		if ( ! $glossary_entry ) {
 			return $this->die_with_error( __( 'The glossary entry cannot be found', 'glotpress' ), 404 );
 		}


### PR DESCRIPTION
Fixes #1749.

## Before
```
$ curl https://php81.example.org/locale/en-au/default/glossary/ --data 'glossary_entry=foobar&bogus=data' -i
HTTP/1.1 500 Internal Server Error

$ curl https://php74.example.org/locale/en-au/default/glossary/ --data 'glossary_entry=foobar&bogus=data'
HTTP/1.1 200 OK
...
The glossary entry cannot be found
```

## After

```
$ curl https://php81.example.org/locale/en-au/default/glossary/ --data 'glossary_entry=foobar&bogus=data' -i
HTTP/1.1 404 Not Found

$ curl https://php74.example.org/locale/en-au/default/glossary/ --data 'glossary_entry=foobar&bogus=data'
HTTP/1.1 404 Not Found
...
The glossary entry cannot be found
```
