### PR TITLE
Fix issue with GlotPress routes not being available after initial setup with wp-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "grunt",
     "watch": "grunt watch",
     "prepare-release": "grunt replace:prepare-release",
-    "env:start": "wp-env start && wp-env run cli --env-cwd=wp-content/plugins/GlotPress wp rewrite structure '/%postname%/' --hard",
+    "env:start": "wp-env start && wp-env run cli wp rewrite structure '/%postname%/' && wp-env run cli --env-cwd=wp-content/plugins/GlotPress wp rewrite flush --hard",
     "env:stop": "wp-env stop",
     "lint:js": "wp-scripts lint-js",
     "lint:js-fix": "wp-scripts lint-js --fix"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "grunt",
     "watch": "grunt watch",
     "prepare-release": "grunt replace:prepare-release",
-    "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
+    "env:start": "wp-env start && wp-env run cli --env-cwd=wp-content/plugins/GlotPress wp rewrite structure '/%postname%/' --hard",
     "env:stop": "wp-env stop",
     "lint:js": "wp-scripts lint-js",
     "lint:js-fix": "wp-scripts lint-js --fix"

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+apache_modules:
+  - mod_rewrite


### PR DESCRIPTION
## Problem
Before this, PR visiting http://localhost:8888/glotpress after following [wp-env setup instructions](https://github.com/GlotPress/GlotPress/blob/f9eb8ae297673ecde84d95a00cca05ff0338de3e/CONTRIBUTING.md#alternative-wp-env) would result in a 404.

## Solution
The cause of the 404 was that the `.htaccess` file had not been generated. Here we're generating the `.htaccess` file through the `wp rewrite` command, with the `--hard` flag: 

> [--hard]
>    Perform a hard flush – update .htaccess rules as well as rewrite rules in database.
>
> From https://developer.wordpress.org/cli/commands/rewrite/structure/

However, for the `wp rewrite` command to be able to generate/modify `.htaccess`, the `mod_rewrite` module needs to be enabled in wp-cli's config, so we're adding a new `wp-cli.yml` file to set that option. This is required because the `apache_modules` setting cannot be passed as a flag to the CLI, it must be passed through a config file.

## Testing Instructions
1. Follow [wp-env setup instructions](https://github.com/GlotPress/GlotPress/blob/f9eb8ae297673ecde84d95a00cca05ff0338de3e/CONTRIBUTING.md#alternative-wp-env)
2. Visit http://localhost:8888/glotpress
3. It should render the page instead of a 404

## Screenshots
### Before
<img width="377" alt="Screenshot 2024-01-09 at 13 22 11" src="https://github.com/GlotPress/GlotPress/assets/550401/cd932b25-3be7-47fd-8a9b-5ddbedd9d929">

### After
<img width="398" alt="Screenshot 2024-01-09 at 13 22 42" src="https://github.com/GlotPress/GlotPress/assets/550401/eea18c6e-3feb-4fad-b33a-2d33d2d0e87e">

