### PR TITLE
wporg-deploy-assets: Set the slug

### DIFF
--- a/.github/workflows/deploy-wporg-assets.yml
+++ b/.github/workflows/deploy-wporg-assets.yml
@@ -23,3 +23,4 @@ jobs:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}
           IGNORE_OTHER_FILES: true
+          SLUG: glotpress


### PR DESCRIPTION
## Problem
When deploying the assets, [it fails because Subversion is case sensitive](https://github.com/GlotPress/GlotPress/actions/runs/7538307681/job/20518620346): 

```
ℹ︎ SLUG is GlotPress
ℹ︎ ASSETS_DIR is .wordpress-org
ℹ︎ README_NAME is readme.txt
ℹ︎ IGNORE_OTHER_FILES is true
➤ Checking out .org repository...
svn: E170000: URL 'https://plugins.svn.wordpress.org/GlotPress' doesn't exist
```

## Solution
Set the slug to `glotpress`