### PR TITLE
Change file extension for PHP format

### DIFF
--- a/gp-includes/formats/format-php.php
+++ b/gp-includes/formats/format-php.php
@@ -20,7 +20,7 @@ class GP_Format_PHP extends GP_Format {
 	 *
 	 * @var string
 	 */
-	public $name = 'PHP (.mo.php)';
+	public $name = 'PHP (.l10n.php)';
 
 	/**
 	 * File extension of the file format, used to autodetect formats and when creating the output file names.
@@ -29,7 +29,7 @@ class GP_Format_PHP extends GP_Format {
 	 *
 	 * @var string
 	 */
-	public $extension = 'mo.php';
+	public $extension = 'l10n.php';
 
 	/**
 	 * Generates a string the contains the $entries to export in the PHP file format.

--- a/tests/phpunit/testcases/tests_formats/test_format_php.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_php.php
@@ -29,11 +29,11 @@ class GP_Test_Format_PHP extends GP_UnitTestCase {
 	}
 
 	public function test_format_name() {
-		$this->assertSame( 'PHP (.mo.php)', GP::$formats[ $this->format ]->name );
+		$this->assertSame( 'PHP (.l10n.php)', GP::$formats[ $this->format ]->name );
 	}
 
 	public function test_format_extension() {
-		$this->assertSame( 'mo.php', GP::$formats[ $this->format ]->extension );
+		$this->assertSame( 'l10n.php', GP::$formats[ $this->format ]->extension );
 	}
 
 	public function test_print_exported_file() {


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

<!--
Please, describe what is the status/problem before the PR.
-->

In https://github.com/WordPress/wordpress-develop/pull/5306 we ended up changing the desired file extension from `.mo.php` to `.l10n.php`. All related projects (meta, WP-CLI) will be updated accordingly as well.

## Solution

<!--
Please, describe how this PR improves the situation.
-->

## To-do

<!--
Please, describe the other undone tasks or items on the to-do list for this PR,
only if it is applicable.
-->
- [ ] Task 1 (Replace with your task description)

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->