### PR TITLE
Document how to use wp-env to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ GlotPress includes automated test code, but coverage is not complete at this tim
 
 ### Unit tests
 
-You can run [PHPUnit](https://phpunit.de/) on Unix or Windows, however at this time instructions and scripts are only provided for Unix.  GlotPress tests are based on the WordPress test suite which is currently only compatible with PHPUnit up to 7.x. Please use the latest PHPUnit version from the 7.x branch.
+You can run [PHPUnit](https://phpunit.de/) on Unix or Windows, however at this time instructions and scripts are only provided for Unix. GlotPress tests are based on the WordPress test suite.
 
 The unit test files are in the `tests/` directory. To run the unit tests on a Unix machine, open a command shell, change to your development directory for GlotPress and run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,11 @@ To write unit tests, find the relevant file that has similar tests already in th
 You can also run tests in `wp-env`. Once you have [set up `wp-env`](#alternative-wp-env), you can run the whole test suite with:
 
 ```shell
+# If wp-env isn't running, you need to start it first.
 npm run env:start
-npm run env:tests
+
+# Run the whole test suite.
+npm run env:phpunit
 ```
 
 ## Helpful tips for writing issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ GlotPress includes automated test code, but coverage is not complete at this tim
 
 ### Unit tests
 
-You can run [PHPUnit](https://phpunit.de/) on Unix or Windows, however at this time instructions and scripts are only provided for Unix. GlotPress tests are based on the WordPress test suite.
+You can run [PHPUnit](https://phpunit.de/) on Unix or Windows, however at this time instructions and scripts are only provided for Unix. GlotPress tests are based on the WordPress test suite, which is currently compatible with PHPUnit up to 9.x. Please use the latest PHPUnit version from the 9.x branch.
 
 The unit test files are in the `tests/` directory. To run the unit tests on a Unix machine, open a command shell, change to your development directory for GlotPress and run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,20 @@ npm run env:start
 npm run env:phpunit
 ```
 
+If you need to pass arguments to PHPUnit, you can do so too:
+
+> Note that the `--` is required, otherwise arguments will not be correctly passed to PHPUnit.
+
+```shell
+npm run env:phpunit -- --version
+```
+
+As an example, to only run the `test_multiple_imports_singular` test, you would use:
+
+```shell
+npm run env:phpunit -- --filter test_multiple_imports_singular
+```
+
 ## Helpful tips for writing issues
 
 When submitting an issue on GitHub there are several things you should include to ensure we can verify the problem and have enough information to resolve it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,15 @@ $ ./tests/phpunit/bin/run-unittests.sh -d testdb_name [ -u dbuser ] [ -p dbpassw
 
 To write unit tests, find the relevant file that has similar tests already in them (they are named accordingly), and add the tests there. If there isn't a file that has tests for the functionality you've written, create a new file, and name it `test_<functionality>.php`. PHPUnit will pick up the file automatically. Refer to the [PHPUnit documentation](https://phpunit.de/documentation.html) and existing files for how to write new tests.
 
+### Alternative: run tests with wp-env
+
+You can also run tests in `wp-env`. Once you have [set up `wp-env`](#alternative-wp-env), you can run the whole test suite with:
+
+```shell
+npm run env:start
+npm run env:tests
+```
+
 ## Helpful tips for writing issues
 
 When submitting an issue on GitHub there are several things you should include to ensure we can verify the problem and have enough information to resolve it.

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "prepare-release": "grunt replace:prepare-release",
     "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
     "env:stop": "wp-env stop",
-    "env:tests": "npm run env:tests-cmd composer install && npm run env:tests-cmd composer test",
-    "env:tests-cmd": "wp-env run tests-cli --env-cwd=wp-content/plugins/GlotPress",
+    "env:tests": "npm run env:tests-cmd composer test",
+    "env:tests-cmd": "npm run env:tests-cmd composer install && wp-env run tests-cli --env-cwd=wp-content/plugins/GlotPress",
     "lint:js": "wp-scripts lint-js",
     "lint:js-fix": "wp-scripts lint-js --fix"
   }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "prepare-release": "grunt replace:prepare-release",
     "env:start": "wp-env start && wp-env run cli wp option update permalink_structure '/%postname%/'",
     "env:stop": "wp-env stop",
-    "env:tests": "npm run env:tests-cmd composer test",
-    "env:tests-cmd": "npm run env:tests-cmd composer install && wp-env run tests-cli --env-cwd=wp-content/plugins/GlotPress",
+    "env:phpunit": "wp-env run tests-cli --env-cwd=wp-content/plugins/GlotPress composer install && wp-env run tests-cli --env-cwd=wp-content/plugins/GlotPress php ./vendor/bin/phpunit",
     "lint:js": "wp-scripts lint-js",
     "lint:js-fix": "wp-scripts lint-js --fix"
   }


### PR DESCRIPTION
## Problem

In #1760, we introduced two `npm run` commands to run tests in `wp-env`: `env:test` and `env:tests-cmd`. Those commands are confusing and lack documentation.

## Solution

This PR replaces both commands with a single `env:phpunit` command. Additionally, this PR adds documentation on how to run tests in `wp-env`, in `CONTRIBUTING.md`.

[Rendered docs](https://github.com/GlotPress/GlotPress/blob/f94597ef784e4bb6d7078899046ef0d1b5603030/CONTRIBUTING.md#alternative-run-tests-with-wp-env)

## Testing Instructions

Follow the [instructions to run tests in `wp-env`](https://github.com/GlotPress/GlotPress/blob/f94597ef784e4bb6d7078899046ef0d1b5603030/CONTRIBUTING.md#alternative-run-tests-with-wp-env) and make sure tests pass.
