### PR TITLE
Add trailing slash to current_url to fix matching URLs without trailing slash

### DIFF
--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -374,7 +374,7 @@ class GP_Route {
 
 		// If the current URL has no trailing slash, redirect to URL with trailing slash.
 		if ( $current_uri_with_trailing_slash !== $current_uri_no_trailing_slash ) {
-			wp_safe_redirect( $current_uri_with_trailing_slash );
+			$this->redirect( $current_uri_with_trailing_slash );
 		}
 	}
 }

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -367,13 +367,13 @@ class GP_Route {
 	 */
 	public function check_uri_trailing_slash() {
 		// Current URL.
-		$current_uri_no_trailing_slash = str_replace( home_url(), '', gp_url_current() );
+		$current_uri = str_replace( home_url(), '', gp_url_current() );
 
 		// Current URL with forced trailing slash.
 		$current_uri_with_trailing_slash = str_replace( home_url(), '', trailingslashit( gp_url_current() ) );
 
 		// If the current URL has no trailing slash, redirect to URL with trailing slash.
-		if ( $current_uri_with_trailing_slash !== $current_uri_no_trailing_slash ) {
+		if ( $current_uri !== $current_uri_with_trailing_slash ) {
 			$this->redirect( $current_uri_with_trailing_slash );
 		}
 	}

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -27,6 +27,8 @@ class GP_Route {
 
 	public function __construct() {
 
+		// Make sure that the current URL has a trailing slash.
+		add_action( 'gp_before_request', array( $this, 'check_uri_trailing_slash' ) );
 	}
 
 	public function die_with_error( $message, $status = 500 ) {
@@ -356,5 +358,23 @@ class GP_Route {
 			return;
 		}
 		return status_header( $status );
+	}
+
+	/**
+	 * Check if the current URL has trailing slash. If not, redirect to trailed slash URL.
+	 *
+	 * @since 4.0.0
+	 */
+	public function check_uri_trailing_slash() {
+		// Current URL.
+		$current_uri_no_trailing_slash = str_replace( home_url(), '', gp_url_current() );
+
+		// Current URL with forced trailing slash.
+		$current_uri_with_trailing_slash = str_replace( home_url(), '', trailingslashit( gp_url_current() ) );
+
+		// If the current URL has no trailing slash, redirect to URL with trailing slash.
+		if ( $current_uri_with_trailing_slash !== $current_uri_no_trailing_slash ) {
+			wp_safe_redirect( $current_uri_with_trailing_slash );
+		}
 	}
 }

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -98,7 +98,7 @@ function gp_nav_menu( $location = 'main' ) {
 	$items = gp_nav_menu_items( $location );
 
 	// Get the current URI.
-	$current_uri = str_replace( home_url(), '', gp_url_current() );
+	$current_uri = str_replace( home_url(), '', trailingslashit( gp_url_current() ) );
 
 	foreach ( $items as $link => $title ) {
 		// Check if the link matches the current URI base, if true, add 'current' class.

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -98,7 +98,7 @@ function gp_nav_menu( $location = 'main' ) {
 	$items = gp_nav_menu_items( $location );
 
 	// Get the current URI.
-	$current_uri = str_replace( home_url(), '', trailingslashit( gp_url_current() ) );
+	$current_uri = str_replace( home_url(), '', gp_url_current() );
 
 	foreach ( $items as $link => $title ) {
 		// Check if the link matches the current URI base, if true, add 'current' class.


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Navigating to a page like `site.com/glotpress/projects` without the trailing slash won't identify the current page in the top menu.

## Solution

Add trailing slash when trying to match menu items to show the current one.

Fixes #1784