### PR TITLE
Breadcrumbs: Improve consistency across all content types

### DIFF
--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -281,11 +281,7 @@ function gp_breadcrumb_project( $project, $extra_items = array() ) {
 	}
 
 	// Add extra items.
-	if ( ! empty( $extra_items ) ) {
-		foreach ( $extra_items as $item ) {
-			$breadcrumb[] = $item;
-		}
-	}
+	$breadcrumb = array_merge($breadcrumb, $extra_items);
 
 	return gp_breadcrumb( $breadcrumb );
 }

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -274,11 +274,10 @@ function gp_breadcrumb_project( $project, $extra_items = array() ) {
 	// If is a translation project, get the links. If is a virtual project with ID '0' for glossary, return base Locale for breadcrumb.
 	$breadcrumb = 0 !== $project->id ? gp_project_links_from_root( $project ) : array( gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' ) ) );
 
-	foreach ( $breadcrumb as $key => $link ) {
-		// If no extra items, the last item is the project name without link.
-		if ( array_key_last( $breadcrumb ) === $key && empty( $extra_items ) ) {
-			$breadcrumb[ $key ] = $project->name;
-		}
+	if ( empty( $extra_items ) ) {
+		end( $breadcrumb );
+		$last_key = key( $breadcrumb );
+		$breadcrumb[ $last_key ] = $project->name;
 	}
 
 	// Add extra items.

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -274,14 +274,16 @@ function gp_breadcrumb_project( $project, $extra_items = array() ) {
 	// If is a translation project, get the links. If is a virtual project with ID '0' for glossary, return base Locale for breadcrumb.
 	$breadcrumb = 0 !== $project->id ? gp_project_links_from_root( $project ) : array( gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' ) ) );
 
+	// If no extra items, the last breadcrumb item is the project name with no link.
 	if ( empty( $extra_items ) ) {
 		end( $breadcrumb );
 		$last_key = key( $breadcrumb );
+
 		$breadcrumb[ $last_key ] = $project->name;
 	}
 
 	// Add extra items.
-	$breadcrumb = array_merge($breadcrumb, $extra_items);
+	$breadcrumb = array_merge( $breadcrumb, $extra_items );
 
 	return gp_breadcrumb( $breadcrumb );
 }

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -258,8 +258,37 @@ function gp_project_links_from_root( $leaf_project ) {
 	return $links;
 }
 
-function gp_breadcrumb_project( $project ) {
-	return gp_breadcrumb( gp_project_links_from_root( $project ) );
+/**
+ * Get project breadcrumb.
+ *
+ * @since 4.0.0   New $extra_items array to append items like Translation Set, Project Glossary or the current action. The last item has no link.
+ *                If project ID is '0', set base locales link to breadcrumb.
+ *
+ * @param GP_Project $project       GlotPress Project object.
+ * @param array      $extra_items   Array of additional items to add to the breadcrumb.
+ *
+ * @return string   HTML of the breadcrumb.
+ */
+function gp_breadcrumb_project( $project, $extra_items = array() ) {
+
+	// If is a translation project, get the links. If is a virtual project with ID '0' for glossary, return base Locale for breadcrumb.
+	$breadcrumb = 0 !== $project->id ? gp_project_links_from_root( $project ) : array( gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' ) ) );
+
+	foreach ( $breadcrumb as $key => $link ) {
+		// If no extra items, the last item is the project name without link.
+		if ( array_key_last( $breadcrumb ) === $key && empty( $extra_items ) ) {
+			$breadcrumb[ $key ] = $project->name;
+		}
+	}
+
+	// Add extra items.
+	if ( ! empty( $extra_items ) ) {
+		foreach ( $extra_items as $item ) {
+			$breadcrumb[] = $item;
+		}
+	}
+
+	return gp_breadcrumb( $breadcrumb );
 }
 
 function gp_js_focus_on( $html_id ) {

--- a/gp-templates/glossary-delete.php
+++ b/gp-templates/glossary-delete.php
@@ -8,11 +8,12 @@
  */
 
 gp_title( __( 'Delete glossary &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
 		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
-		gp_link_get( gp_url_join( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), '/glossary' ), __( 'Glossary', 'glotpress' ) ),
+		// Check if is Global or Project Glossary.
+		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . 'glossary', 0 === $project->id ? __( 'Locale Glossary', 'glotpress' ) : __( 'Project Glossary', 'glotpress' ), ),
 		__( 'Delete', 'glotpress' ),
 	)
 );

--- a/gp-templates/glossary-edit.php
+++ b/gp-templates/glossary-edit.php
@@ -1,5 +1,5 @@
 <?php
-gp_title( __( 'Edit Glossary &lt; GlotPress', 'glotpress' ) );
+gp_title( __( 'Edit glossary &lt; GlotPress', 'glotpress' ) );
 gp_breadcrumb_project(
 	$project,
 	array(
@@ -12,7 +12,7 @@ gp_breadcrumb_project(
 gp_tmpl_header();
 ?>
 
-<h2><?php _e( 'Edit Glossary', 'glotpress' ); ?></h2>
+<h2><?php _e( 'Edit glossary', 'glotpress' ); ?></h2>
 
 <form action="" method="post">
 	<p>

--- a/gp-templates/glossary-edit.php
+++ b/gp-templates/glossary-edit.php
@@ -1,10 +1,11 @@
 <?php
 gp_title( __( 'Edit Glossary &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
 		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
-		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . '/glossary', __( 'Glossary', 'glotpress' ) ),
+		// Check if is Global or Project Glossary.
+		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . 'glossary', 0 === $project->id ? __( 'Locale Glossary', 'glotpress' ) : __( 'Project Glossary', 'glotpress' ), ),
 		__( 'Edit', 'glotpress' ),
 	)
 );

--- a/gp-templates/glossary-import.php
+++ b/gp-templates/glossary-import.php
@@ -1,10 +1,11 @@
 <?php
 gp_title( __( 'Import into Glossary &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
 		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
-		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . '/glossary', __( 'Glossary', 'glotpress' ) ),
+		// Check if is Global or Project Glossary.
+		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ) . 'glossary', 0 === $project->id ? __( 'Locale Glossary', 'glotpress' ) : __( 'Project Glossary', 'glotpress' ), ),
 		__( 'Import', 'glotpress' ),
 	)
 );

--- a/gp-templates/glossary-new.php
+++ b/gp-templates/glossary-new.php
@@ -1,10 +1,10 @@
 <?php
 gp_title( __( 'Create New Glossary &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
 		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
-		__( 'Create Glossary', 'glotpress' ),
+		__( 'Create New Glossary', 'glotpress' ),
 	)
 );
 gp_tmpl_header();

--- a/gp-templates/glossary-view.php
+++ b/gp-templates/glossary-view.php
@@ -1,9 +1,9 @@
 <?php
 gp_title( __( 'View Glossary &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
 		// Show Projects if is projects path, show Locales if is locales path.
-		gp_project_links_from_root( $project ) ? gp_project_links_from_root( $project ) : gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' ) ),
 		gp_link_get( gp_url_project_locale( $project->path, $locale->slug, $translation_set->slug ), $translation_set->name ),
 		0 === $project->id ? __( 'Locale Glossary', 'glotpress' ) : __( 'Project Glossary', 'glotpress' ),
 	)

--- a/gp-templates/project-branch.php
+++ b/gp-templates/project-branch.php
@@ -6,7 +6,12 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb_project( $project );
+gp_breadcrumb_project(
+	$project,
+	array(
+		__( 'Branch', 'glotpress' ),
+	)
+);
 gp_tmpl_header();
 ?>
 <h2>

--- a/gp-templates/project-delete.php
+++ b/gp-templates/project-delete.php
@@ -14,7 +14,12 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb_project( $project );
+gp_breadcrumb_project(
+	$project,
+	array(
+		__( 'Delete', 'glotpress' ),
+	)
+);
 gp_tmpl_header();
 ?>
 <h2>

--- a/gp-templates/project-edit.php
+++ b/gp-templates/project-edit.php
@@ -6,7 +6,12 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb_project( $project );
+gp_breadcrumb_project(
+	$project,
+	array(
+		__( 'Edit', 'glotpress' ),
+	)
+);
 gp_tmpl_header();
 ?>
 <h2>

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -6,7 +6,12 @@ if ( 'originals' === $kind ) {
 		esc_html( $project->name )
 	);
 	$return_link = gp_url_project( $project );
-	gp_breadcrumb_project( $project );
+	gp_breadcrumb_project(
+		$project,
+		array(
+			__( 'Import Originals', 'glotpress' ),
+		)
+	);
 } else {
 	$gp_title = sprintf(
 		/* translators: %s: Project name. */
@@ -14,10 +19,11 @@ if ( 'originals' === $kind ) {
 		esc_html( $project->name )
 	);
 	$return_link = gp_url_project_locale( $project, $locale->slug, $translation_set->slug );
-	gp_breadcrumb(
+	gp_breadcrumb_project(
+		$project,
 		array(
-			gp_project_links_from_root( $project ),
 			gp_link_get( $return_link, $translation_set->name ),
+			__( 'Import Translations', 'glotpress' ),
 		)
 	);
 }

--- a/gp-templates/project-mass-create-sets.php
+++ b/gp-templates/project-mass-create-sets.php
@@ -6,7 +6,12 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb_project( $project );
+gp_breadcrumb_project(
+	$project,
+	array(
+		__( 'Mass-create Translation Sets', 'glotpress' ),
+	)
+);
 gp_enqueue_scripts( 'gp-mass-create-sets-page' );
 wp_localize_script(
 	'gp-mass-create-sets-page',

--- a/gp-templates/project-permissions.php
+++ b/gp-templates/project-permissions.php
@@ -6,7 +6,12 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb_project( $project );
+gp_breadcrumb_project(
+	$project,
+	array(
+		__( 'Permissions', 'glotpress' ),
+	)
+);
 gp_tmpl_header();
 ?>
 <h2><?php _e( 'Permissions', 'glotpress' ); ?></h2>

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -15,10 +15,11 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
-		gp_link_get( $url, $locale->english_name . ( 'default' !== $set->slug ? ' ' . $set->name : '' ) ),
+		gp_link_get( $url, $locale->english_name . 'default' !== $set->slug ? ' ' . $set->name : '' ),
+		__( 'Delete', 'glotpress' ),
 	)
 );
 gp_tmpl_header();

--- a/gp-templates/translation-set-edit.php
+++ b/gp-templates/translation-set-edit.php
@@ -7,10 +7,11 @@ gp_title(
 		$project->name
 	)
 );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
 		gp_link_get( $url, $locale->english_name . 'default' !== $set->slug ? ' ' . $set->name : '' ),
+		__( 'Edit', 'glotpress' ),
 	)
 );
 

--- a/gp-templates/translation-set-new.php
+++ b/gp-templates/translation-set-new.php
@@ -1,6 +1,19 @@
 <?php
 gp_title( __( 'Create New Translation Set &lt; GlotPress', 'glotpress' ) );
-$project ? gp_breadcrumb_project( $project ) : gp_breadcrumb( array( __( 'New Translation Set', 'glotpress' ) ) );
+if ( $project ) {
+	gp_breadcrumb_project(
+		$project,
+		array(
+			__( 'Create New Translation Set', 'glotpress' ),
+		)
+	);
+} else {
+	gp_breadcrumb(
+		array(
+			__( 'Create New Translation Set', 'glotpress' ),
+		)
+	);
+}
 
 // jQuery is required for the 'translation-set-form' template.
 gp_enqueue_script( 'jquery' );

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -20,11 +20,10 @@ $inactive_bubble = '';
 if ( ! $project->active ) {
 	$inactive_bubble = ' <span class="inactive bubble">' . __( 'Inactive', 'glotpress' ) . '</span>';
 }
-
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
-		gp_project_links_from_root( $project ),
-		gp_link_get( $url, $translation_set->name ) . $inactive_bubble,
+		$translation_set->name . $inactive_bubble,
 	)
 );
 gp_enqueue_scripts( array( 'gp-editor', 'gp-translations-page' ) );


### PR DESCRIPTION
## Problem

As described in #1788, there are several inconsistencies in the breadcrumbs:
- Glossary edit/delete miss the base 'Locale' link
- Projects and Translation sets have links on the last item (current page)
- Projects and Translation sets don't have action item for Delete/Edit/Import/Permissions, etc.
- Glossaries and Locales show correctly the last item without link.

## Solution
- [x] Add a parameter to `gp_breadcrumb_project()` with extra optional items, with backwards compatibility. If no extra items, the last item (`project->name`) is used without link. If not empty, all the links are outputed and the extra items are appended (Translation Set, Glossary, action, etc)

## Testing Instructions
Navigate through all the possible pages:

1. Locales
2. Locales / Locale
3. Locales / Locale / Glossary
4. Locales / Locale / Glossary / (Delete|Edit|Import)
5. Projects
6. Projects / Project
7. Projects / Project / (Delete|Edit|Permissions|Import|Etc)
8. Projects / Project / Set
9. Projects / Project / Set / (Delete|Edit|Create)
10. Projects / Project / Set / Project Glossary
11. Projects / Project / Set / Project Glossary / (Delete|Edit|Create)

Etc.

## Screenshots
### Locales and Global glossaries
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/fbe360cc-59b9-4b33-a2f2-50d7c291f5f3)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/44f89fae-3c7c-4c8f-87da-ac1421492425)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/5bf3964e-d190-4cf5-81d7-4a774a26f301)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/a31f8f2a-f900-4936-9b82-f081e24d310b)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/053590d4-5732-412a-bfee-e1c38603598b)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/c0271458-1106-491a-8db9-e8e892116b17)

### Projects
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/e75d0cbf-cc46-4af9-9207-228f8cc712ae)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/935b41d6-cdf0-40d1-bdfc-44235aed2c45)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/07532dfb-ce17-48cd-a9fd-a24f08d4d8ec)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/7f59ba12-a790-4c63-bc29-f6058c211ecf)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/b3b26d02-4017-432a-9a8f-3dab6e06986f)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/235867dd-a2d6-4ffb-b67d-72361e014bb6)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/4cabbb5d-4c41-4b60-99a9-2bffd01e59fd)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/833f4118-b628-4d4c-8419-cefca99733b5)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/4ab4f411-6aea-41d0-8095-b4d20074faa5)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/54dd67d7-2efe-4f90-864e-bc5edcf37be1)

### Translation Sets and Project glossaries
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/d33e970c-b754-4c0c-8b24-38729a740843)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/2ffbcead-9363-4227-aa40-dc9b27d5280a)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/f3508843-7101-49d5-bad8-1ed66c0c655c)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/7f1ac356-cf76-4824-9f98-27c485470211)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/70b05f98-d936-42c5-b3b8-53187d1f124c)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/84330490-62cf-4250-a8ea-a12954117887)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/3ba25b45-648c-4142-9c17-ad53116a8813)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/e3f234c7-063f-4cf4-88d5-9f9cdec120e4)
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/d2fd7b1b-a546-4227-8bec-9282ed8b3874)

<hr>

Fixes #1788 