### PR TITLE
Glossary: Match single word entries of parts of speech that have no suffix rules.

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -408,6 +408,7 @@ function gp_glossary_add_suffixes( $glossary_entries ) {
 		// Filter out suffixes with empty values.
 		$suffixes = array_filter( $suffixes, fn( $value ) => ! empty( $value ) );
 
+		// Add suffixes for part_of_speech with rules.
 		if ( ! empty( $suffixes[ $type ] ) ) {
 			// Loop through rules.
 			foreach ( $suffixes[ $type ] as $rule ) {
@@ -462,6 +463,9 @@ function gp_glossary_add_suffixes( $glossary_entries ) {
 					}
 				}
 			}
+		} else {
+			// Add match for part_of_speech without any suffix rules.
+			$glossary_entries_suffixes[ $term ] = array();
 		}
 	}
 

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -1879,13 +1879,68 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	}
 
 	/**
-	 * Expects exact matching the different Parts of Speech without suffixes.
+	 * Data provider.
+	 *
+	 * @var array
 	 */
-	function test_map_glossary_entries_to_translation_originals_with_all_parts_of_speach_in_glossary() {
-		// Match only exact words, no suffixes. (eg: matches 'drive' and not 'driving').
-		$test_string = 'Oh my goodness! She loves driving and quickly drive her SUV along the curvy mountain road, while taking in the sights and admiring the scenery.';
-		$expected_result = $this->glossary_match( 'oh meu deus', 'interjection', 'Oh my goodness' ) . '! ' . $this->glossary_match( 'ela', 'pronoun', 'She' ) . ' loves driving and ' . $this->glossary_match( 'rapidamente', 'adverb', 'quickly' ) . ' ' . $this->glossary_match( 'conduzir', 'verb', 'drive' ) . ' her ' . $this->glossary_match( 'SUV', 'abbreviation', 'SUV' ) . ' ' . $this->glossary_match( 'ao longo', 'preposition', 'along' ) . ' the ' . $this->glossary_match( 'sinuoso', 'adjective', 'curvy' ) . ' mountain road, ' . $this->glossary_match( 'enquanto', 'conjunction', 'while' ) . ' ' . $this->glossary_match( 'apreciar as vistas', 'expression', 'taking in the sights' ) . ' and admiring the ' . $this->glossary_match( 'paisagem', 'noun', 'scenery' ) . '.';
+	function provide_test_map_glossary_entries_to_translation_originals_exact_match_with_all_parts_of_speach_in_glossary() {
+		return array(
+			// Full sentence with all the entries.
+			array(
+				'test_string'     => 'Oh my goodness! She loves driving and quickly drive her SUV along the curvy mountain road, while taking in the sights and admiring the scenery.',
+				'expected_result' => $this->glossary_match( 'oh meu deus', 'interjection', 'Oh my goodness' ) . '! ' . $this->glossary_match( 'ela', 'pronoun', 'She' ) . ' loves driving and ' . $this->glossary_match( 'rapidamente', 'adverb', 'quickly' ) . ' ' . $this->glossary_match( 'conduzir', 'verb', 'drive' ) . ' her ' . $this->glossary_match( 'SUV', 'abbreviation', 'SUV' ) . ' ' . $this->glossary_match( 'ao longo', 'preposition', 'along' ) . ' the ' . $this->glossary_match( 'sinuoso', 'adjective', 'curvy' ) . ' mountain road, ' . $this->glossary_match( 'enquanto', 'conjunction', 'while' ) . ' ' . $this->glossary_match( 'apreciar as vistas', 'expression', 'taking in the sights' ) . ' and admiring the ' . $this->glossary_match( 'paisagem', 'noun', 'scenery' ) . '.',
+			),
+			// Strings that are the exact match of a glossary don't depend of the gp_glossary_add_suffixes() to split an exact match to the glossary terms keys, always match.
+			array(
+				'test_string'     => 'Oh my goodness',
+				'expected_result' => $this->glossary_match( 'oh meu deus', 'interjection', 'Oh my goodness' ),
+			),
+			array(
+				'test_string'     => 'She',
+				'expected_result' => $this->glossary_match( 'ela', 'pronoun', 'She' ),
+			),
+			array(
+				'test_string'     => 'quickly',
+				'expected_result' => $this->glossary_match( 'rapidamente', 'adverb', 'quickly' ),
+			),
+			array(
+				'test_string'     => 'drive',
+				'expected_result' => $this->glossary_match( 'conduzir', 'verb', 'drive' ),
+			),
+			array(
+				'test_string'     => 'SUV',
+				'expected_result' => $this->glossary_match( 'SUV', 'abbreviation', 'SUV' ),
+			),
+			array(
+				'test_string'     => 'along',
+				'expected_result' => $this->glossary_match( 'ao longo', 'preposition', 'along' ),
+			),
 
+			array(
+				'test_string'     => 'curvy',
+				'expected_result' => $this->glossary_match( 'sinuoso', 'adjective', 'curvy' ),
+			),
+			array(
+				'test_string'     => 'while',
+				'expected_result' =>  $this->glossary_match( 'enquanto', 'conjunction', 'while' ),
+			),
+			array(
+				'test_string'     => 'taking in the sights',
+				'expected_result' =>  $this->glossary_match( 'apreciar as vistas', 'expression', 'taking in the sights' ),
+			),
+			array(
+				'test_string'     => 'scenery',
+				'expected_result' =>  $this->glossary_match( 'paisagem', 'noun', 'scenery' ),
+			),
+		);
+	}
+
+	/**
+	 * Expects exact matching the different Parts of Speech without suffix matching.
+	 *
+	 * @dataProvider provide_test_map_glossary_entries_to_translation_originals_exact_match_with_all_parts_of_speach_in_glossary
+	 */
+	function test_map_glossary_entries_to_translation_originals_exact_match_with_all_parts_of_speach_in_glossary( $test_string, $expected_result ) {
 		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
 
 		$set = $this->factory->translation_set->create_with_project_and_locale();

--- a/tests/phpunit/testcases/test_template_helper_functions.php
+++ b/tests/phpunit/testcases/test_template_helper_functions.php
@@ -1879,6 +1879,95 @@ class GP_Test_Template_Helper_Functions extends GP_UnitTestCase {
 	}
 
 	/**
+	 * Expects exact matching the different Parts of Speech without suffixes.
+	 */
+	function test_map_glossary_entries_to_translation_originals_with_all_parts_of_speach_in_glossary() {
+		// Match only exact words, no suffixes. (eg: matches 'drive' and not 'driving').
+		$test_string = 'Oh my goodness! She loves driving and quickly drive her SUV along the curvy mountain road, while taking in the sights and admiring the scenery.';
+		$expected_result = $this->glossary_match( 'oh meu deus', 'interjection', 'Oh my goodness' ) . '! ' . $this->glossary_match( 'ela', 'pronoun', 'She' ) . ' loves driving and ' . $this->glossary_match( 'rapidamente', 'adverb', 'quickly' ) . ' ' . $this->glossary_match( 'conduzir', 'verb', 'drive' ) . ' her ' . $this->glossary_match( 'SUV', 'abbreviation', 'SUV' ) . ' ' . $this->glossary_match( 'ao longo', 'preposition', 'along' ) . ' the ' . $this->glossary_match( 'sinuoso', 'adjective', 'curvy' ) . ' mountain road, ' . $this->glossary_match( 'enquanto', 'conjunction', 'while' ) . ' ' . $this->glossary_match( 'apreciar as vistas', 'expression', 'taking in the sights' ) . ' and admiring the ' . $this->glossary_match( 'paisagem', 'noun', 'scenery' ) . '.';
+
+		$entry = new Translation_Entry( array( 'singular' => $test_string, ) );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create_and_select( array( 'translation_set_id' => $set->id ) );
+
+		$glossary_entries = array(
+			array(
+				'term' => 'oh my goodness',
+				'part_of_speech' => 'interjection',
+				'translation' => 'oh meu deus', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'she',
+				'part_of_speech' => 'pronoun',
+				'translation' => 'ela', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'quickly',
+				'part_of_speech' => 'adverb',
+				'translation' => 'rapidamente', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'drive',
+				'part_of_speech' => 'verb',
+				'translation' => 'conduzir', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'SUV',
+				'part_of_speech' => 'abbreviation',
+				'translation' => 'SUV', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'along',
+				'part_of_speech' => 'preposition',
+				'translation' => 'ao longo', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'curvy',
+				'part_of_speech' => 'adjective',
+				'translation' => 'sinuoso', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'while',
+				'part_of_speech' => 'conjunction',
+				'translation' => 'enquanto', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'taking in the sights',
+				'part_of_speech' => 'expression',
+				'translation' => 'apreciar as vistas', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+			array(
+				'term' => 'scenery',
+				'part_of_speech' => 'noun',
+				'translation' => 'paisagem', // Portuguese.
+				'glossary_id' => $glossary->id,
+			),
+		);
+
+		foreach ( $glossary_entries as $glossary_entry ) {
+			GP::$glossary_entry->create_and_select( $glossary_entry );
+		}
+
+		// Remove all suffix rules to allow only exact matches.
+		add_filter( 'gp_glossary_match_suffixes', '__return_empty_array' );
+
+		$orig = map_glossary_entries_to_translation_originals( $entry, $glossary );
+
+		$this->assertEquals( $orig->singular_glossary_markup, $expected_result );
+
+	}
+
+	/**
 	 * Method to test the map_glossary_entries_to_translation_originals() function.
 	 *
 	 * @param string $test_string      The string to test.


### PR DESCRIPTION
## Problem
For any types of glossary items (part of speech), if the entry has multiple words won't try to add any suffixes, and is immediately added to the glossary list.

As explained in Meta Ticket https://meta.trac.wordpress.org/ticket/7473, if the glossary entry is a single word, currently it will only be added if there are rules for suffixes, which is wrong. Even if there isn't any rule, at least the exact word should be added.


## Solution
For single word glossary terms of a `part_of_speech` that have no suffix rules, add the exact match to the glossary list.

Fixes #1790 

Thanks @marcarmengou for reporting.