### PR TITLE
Add a 'gp_before_translation_table' hook

### DIFF
--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -429,6 +429,16 @@ $i = 0;
 </div>
 
 <?php $class_rtl = 'rtl' === $locale->text_direction ? ' translation-sets-rtl' : ''; ?>
+<?php
+/**
+ * Fires before the translation table has been displayed.
+ *
+ * @since 4.0.0
+ *
+ * @param array $def_vars Variables defined in the template.
+ */
+do_action( 'gp_before_translation_table', get_defined_vars() );
+?>
 <table id="translations" class="<?php echo esc_attr( apply_filters( 'gp_translation_table_classes', 'gp-table translations ' . $class_rtl, get_defined_vars() ) ); ?>">
 	<thead>
 	<tr>


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

We don't have a hook to update the content before the translation table, as we have after it, with the `gp_after_translation_table` hook, added in https://github.com/GlotPress/GlotPress/pull/1665.

This hook is needed [here](https://github.com/WordPress/wporg-gp-translation-events/issues/98).
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds an action to add content before the translation table is displayed.

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

To test this PR, you can use a code like this:

```
add_action( 'gp_before_translation_table',
	function () {
		echo '<div>This text should be before the table</div>';
	} );
```
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->