### PR TITLE
Fix redirecting URL with query args

### DIFF
--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -374,7 +374,7 @@ class GP_Route {
 		$current_path = $current_uri['path'];
 
 		// If the current path has no trailing slash, redirect to path with trailing slash.
-		if ( $current_path !== trailingslashit( $current_path ) ) {
+		if ( trailingslashit( $current_path ) !== $current_path ) {
 
 			// Add trailing slash to redirect URL.
 			$redirect_url = trailingslashit( $current_path );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -366,15 +366,23 @@ class GP_Route {
 	 * @since 4.0.0
 	 */
 	public function check_uri_trailing_slash() {
+
 		// Current URL.
-		$current_uri = str_replace( home_url(), '', gp_url_current() );
+		$current_uri = wp_parse_url( gp_url_current() );
 
-		// Current URL with forced trailing slash.
-		$current_uri_with_trailing_slash = str_replace( home_url(), '', trailingslashit( gp_url_current() ) );
+		$current_path = $current_uri['path'];
 
-		// If the current URL has no trailing slash, redirect to URL with trailing slash.
-		if ( $current_uri !== $current_uri_with_trailing_slash ) {
-			$this->redirect( $current_uri_with_trailing_slash );
+		// If the current path has no trailing slash, redirect to path with trailing slash.
+		if ( $current_path !== trailingslashit( $current_path ) ) {
+
+			$redirect_url = trailingslashit( $current_path );
+
+			// Include any existing query.
+			if ( isset( $current_uri['query'] ) ) {
+				$redirect_url .= '?' . $current_uri['query'];
+			}
+
+			$this->redirect( $redirect_url );
 		}
 	}
 }

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -370,11 +370,13 @@ class GP_Route {
 		// Current URL.
 		$current_uri = wp_parse_url( gp_url_current() );
 
+		// URL path.
 		$current_path = $current_uri['path'];
 
 		// If the current path has no trailing slash, redirect to path with trailing slash.
 		if ( $current_path !== trailingslashit( $current_path ) ) {
 
+			// Add trailing slash to redirect URL.
 			$redirect_url = trailingslashit( $current_path );
 
 			// Include any existing query.
@@ -382,6 +384,7 @@ class GP_Route {
 				$redirect_url .= '?' . $current_uri['query'];
 			}
 
+			// Redirect to URL with trailing slash.
 			$this->redirect( $redirect_url );
 		}
 	}


### PR DESCRIPTION
## Problem
Currently the routes are being added a trailing slash without care for query args.
Example:
Current URL `/glotpress/projects/wordpress/pt/default?page=2`
Redirects to `/glotpress/projects/wordpress/pt/default?page=2/`

## Solution

Only apply the `trailingslashit()` to the URL path and not to the complete URL.

Example:
Current URL `/glotpress/projects/wordpress/pt/default?page=2`
Redirects to `/glotpress/projects/wordpress/pt/default/?page=2`
