### PR TITLE
Add the breadcrumbs for the "New project" actions

### DIFF
--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -253,9 +253,8 @@ function gp_project_links_from_root( $leaf_project ) {
 	$path_from_root = array_reverse( $leaf_project->path_to_root() );
 	$links[]        = empty( $path_from_root ) ? __( 'Projects', 'glotpress' ) : gp_link_get( gp_url( '/projects' ), __( 'Projects', 'glotpress' ) );
 	foreach ( $path_from_root as $project ) {
-		$link = gp_link_project_get( $project, esc_html( $project->name ) );
-		if ( '' !== strip_tags( $link ) ) {
-			$links[] = $link;
+		if ( ! is_null( $project->id ) ) {
+			$links[] = gp_link_project_get( $project, esc_html( $project->name ) );
 		}
 	}
 	return $links;

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -253,7 +253,10 @@ function gp_project_links_from_root( $leaf_project ) {
 	$path_from_root = array_reverse( $leaf_project->path_to_root() );
 	$links[]        = empty( $path_from_root ) ? __( 'Projects', 'glotpress' ) : gp_link_get( gp_url( '/projects' ), __( 'Projects', 'glotpress' ) );
 	foreach ( $path_from_root as $project ) {
-		$links[] = gp_link_project_get( $project, esc_html( $project->name ) );
+		$link = gp_link_project_get( $project, esc_html( $project->name ) );
+		if ( '' !== strip_tags( $link ) ) {
+			$links[] = $link;
+		}
 	}
 	return $links;
 }
@@ -284,7 +287,6 @@ function gp_breadcrumb_project( $project, $extra_items = array() ) {
 
 	// Add extra items.
 	$breadcrumb = array_merge( $breadcrumb, $extra_items );
-
 	return gp_breadcrumb( $breadcrumb );
 }
 

--- a/gp-templates/project-new.php
+++ b/gp-templates/project-new.php
@@ -1,6 +1,7 @@
 <?php
 gp_title( __( 'Create New Project &lt; GlotPress', 'glotpress' ) );
-gp_breadcrumb(
+gp_breadcrumb_project(
+	$project,
 	array(
 		__( 'Create New Project', 'glotpress' ),
 	)


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In https://github.com/GlotPress/GlotPress/pull/1789 we improved the consistency across all content types of breadcrumbs, but we forgot one situation: the "New project" creation, both at the top level and as a subproject.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/72bf232d-7b14-45bf-8863-0611399b99db)
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds the link to the current project in the breadcrumbs.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/b89f8386-bc23-4555-bc44-5fd6b25574a0)

![image](https://github.com/GlotPress/GlotPress/assets/1667814/bae944fa-c86b-4499-abe9-909b07e66cca)

Fixes https://github.com/GlotPress/GlotPress/issues/1799. 
<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

Try to:
- Create a new project in the GlotPress root path.
- Create a new subproject in a GlotPress project. 

In both situations, you should see the correct links to the current project.

<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->