### PR TITLE
Make the glossary regex more deterministic

### DIFF
--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -548,7 +548,9 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 				}
 			}
 		}
-
+		// Make the regex more deterministic.
+		ksort( $regex_group );
+		
 		// Build the regular expression.
 		$placeholders_search = '%(?:(?:\d+\$)?(?:\d+)?)?[bcdefglosuxEFGX%@]';
 		$terms_search        = '(?:(\b|' . $placeholders_search . ')(';

--- a/gp-templates/helper-functions.php
+++ b/gp-templates/helper-functions.php
@@ -550,7 +550,7 @@ function map_glossary_entries_to_translation_originals( $translation, $glossary 
 		}
 		// Make the regex more deterministic.
 		ksort( $regex_group );
-		
+
 		// Build the regular expression.
 		$placeholders_search = '%(?:(?:\d+\$)?(?:\d+)?)?[bcdefglosuxEFGX%@]';
 		$terms_search        = '(?:(\b|' . $placeholders_search . ')(';


### PR DESCRIPTION
## Problem

@amieiro noticed that with the Spanish glossary, a term didn't match that existed in the Glossary. On the other hand, Portuguese, which had the same rivalling terms got it right:
![Spanish translations with the wrong glossary match for Add-On](https://github.com/GlotPress/GlotPress/assets/203408/92c957d8-d9c8-459a-8565-2eb6e8051a14)

![Portuguese translations with the right glossary match for Add-On](https://github.com/GlotPress/GlotPress/assets/203408/7dec069b-81be-4b19-bb0b-c1bcefd6026a)

The problem arises from the fact that we now group the regex by suffixes. For each English term the suffix is determined and the term sorted into that bin and the regex is built from those bins.

Add-on and Add fall in different bins (the first just with an "s" suffix, the second with possible suffixes "s", "ed", or "ing") but in Spanish the second bin is created first because in the sequence of glossary terms, the word "troubleshooting" that starts the bin is processed before "customization" which crates the "s" bin. In Portuguese its reversed, more or less by chance, because "customization" is processed before "downgrading":

![addon-spanish](https://github.com/GlotPress/GlotPress/assets/203408/97af6ff3-0590-4f3f-a6ba-72d60adb8777)
![addon-portuguese](https://github.com/GlotPress/GlotPress/assets/203408/d631b084-2716-4e74-a62d-5906b69a8aa5)

## Solution

The proposed solution of making the regex more deterministic so that there are not differences between languages. In this case it fixes the problem but there could be other occurrences where a `krsort` would make it work. We need to 

## Testing Instructions
Create a language with a glossary that contains the words "troubleshooting", "customization", "add", and "add-on" and an original that contains the word "Add-on". Before this PR it will only match the "add".
