### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.0] (March 7, 2024)
+
+(this space intentionally left blank)
+
 ## [4.0.0-rc.1] (March 4, 2024)
 
 (this space intentionally left blank)
@@ -645,7 +649,8 @@ Thanks to all the contributors so far: Aki Björklund, Daisuke Takahashi, Domini
 
 * Initial release.
 
-[Unreleased]: https://github.com/GlotPress/GlotPress/compare/3.0.0...HEAD
+[Unreleased]: https://github.com/GlotPress/GlotPress/compare/4.0.0...HEAD
+[4.0.0]: https://github.com/GlotPress/GlotPress/compare/4.0.0-rc.1...4.0.0
 [4.0.0-rc.1]: https://github.com/GlotPress/GlotPress/compare/4.0.0-beta.3...4.0.0-rc.1
 [4.0.0-beta.3]: https://github.com/GlotPress/GlotPress/compare/4.0.0-beta.2...4.0.0-beta.3
 [4.0.0-beta.2]: https://github.com/GlotPress/GlotPress/compare/4.0.0-beta.1...4.0.0-beta.2

--- a/glotpress.php
+++ b/glotpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: GlotPress
  * Plugin URI: https://wordpress.org/plugins/glotpress/
  * Description: GlotPress is a tool to help translators collaborate.
- * Version: 4.0.0-rc.1
+ * Version: 4.0.0
  * Requires at least: 4.6
  * Tested up to: 6.4
  * Requires PHP: 7.4
@@ -29,7 +29,7 @@
  * @package GlotPress
  */
 
-define( 'GP_VERSION', '4.0.0-rc.1' );
+define( 'GP_VERSION', '4.0.0' );
 define( 'GP_DB_VERSION', '980' );
 define( 'GP_CACHE_VERSION', '3.0' );
 define( 'GP_ROUTING', true );


### PR DESCRIPTION
- Updates the CHANGELOG.md.
- Updates the version.

This PR use a branch called `release-4.0.0-stable` and not the usual format name `release-4.0.0` because this branch was used before [here](https://github.com/GlotPress/GlotPress/pull/1672), and I was not able to delete it.