### PR TITLE
Add regex search

### DIFF
--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -334,9 +334,9 @@ class GP_Translation extends GP_Thing {
 		if ( gp_array_get( $filters, 'term' ) ) {
 			// Check wether to do a regex or regular search.
 			if ( $regex ) {
-				$like = "REGEXP $collation '" . ( esc_sql( gp_array_get( $filters, 'term' ) ) ) . "'";
+				$condition = "REGEXP $collation '" . ( esc_sql( gp_array_get( $filters, 'term' ) ) ) . "'";
 			} else {
-				$like = "LIKE $collation '%" . ( esc_sql( $wpdb->esc_like( gp_array_get( $filters, 'term' ) ) ) ) . "%'";
+				$condition = "LIKE $collation '%" . ( esc_sql( $wpdb->esc_like( gp_array_get( $filters, 'term' ) ) ) ) . "%'";
 			}
 
 			$term_scope = gp_array_get( $filters, 'term_scope', 'scope_any' );
@@ -363,8 +363,8 @@ class GP_Translation extends GP_Thing {
 			}
 
 			$mapped_scope_array = array_map(
-				function( $x ) use ( $like ) {
-					return "($x $like)";
+				function( $x ) use ( $condition ) {
+					return "($x $condition)";
 				},
 				$scope_array
 			);

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -327,11 +327,17 @@ class GP_Translation extends GP_Thing {
 			'desc' => 'DESC',
 		);
 		$sort_how  = gp_array_get( $sort_hows, gp_array_get( $sort, 'how' ), gp_array_get( $sort_hows, $default_sort['how'] ) );
+		$regex     = 'yes' === gp_array_get( $filters, 'regex' ) ? true : false;
 		$collation = 'yes' === gp_array_get( $filters, 'case_sensitive' ) ? 'BINARY' : '';
 
 		$where = array();
 		if ( gp_array_get( $filters, 'term' ) ) {
-			$like = "LIKE $collation '%" . ( esc_sql( $wpdb->esc_like( gp_array_get( $filters, 'term' ) ) ) ) . "%'";
+			// Check wether to do a regex or regular search.
+			if ( $regex ) {
+				$like = "REGEXP $collation '" . ( esc_sql( gp_array_get( $filters, 'term' ) ) ) . "'";
+			} else {
+				$like = "LIKE $collation '%" . ( esc_sql( $wpdb->esc_like( gp_array_get( $filters, 'term' ) ) ) ) . "%'";
+			}
 
 			$term_scope = gp_array_get( $filters, 'term_scope', 'scope_any' );
 

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -117,6 +117,7 @@ $i = 0;
 		$additional_filters = array_key_exists( 'term', $filters_and_sort ) ||
 								array_key_exists( 'user_login', $filters_and_sort ) ||
 								array_key_exists( 'with_comment', $filters_and_sort ) ||
+								array_key_exists( 'regex', $filters_and_sort ) ||
 								array_key_exists( 'case_sensitive', $filters_and_sort ) ||
 								array_key_exists( 'with_plural', $filters_and_sort ) ||
 								array_key_exists( 'with_context', $filters_and_sort );
@@ -259,7 +260,8 @@ $i = 0;
 				<fieldset>
 					<legend class="screen-reader-text"><?php _e( 'Search:', 'glotpress' ); ?></legend>
 					<label for="filters[term]" class="filter-title"><?php _e( 'Search Term:', 'glotpress' ); ?></label><br />
-					<input type="text" value="<?php echo gp_esc_attr_with_entities( gp_array_get( $filters, 'term' ) ); ?>" name="filters[term]" id="filters[term]" /><br />
+					<input type="text" value="<?php echo gp_esc_attr_with_entities( gp_array_get( $filters, 'term' ) ); ?>" name="filters[term]" id="filters[term]" />
+					<input type="checkbox" name="filters[regex]" value="yes" id="filters[regex][yes]" <?php gp_checked( 'yes' === gp_array_get( $filters, 'regex' ) ); ?>>&nbsp;<label for='filters[regex][yes]'><?php _e( 'Regex', 'glotpress' ); ?></label><br />
 					<input type="checkbox" name="filters[case_sensitive]" value="yes" id="filters[case_sensitive][yes]" <?php gp_checked( 'yes' === gp_array_get( $filters, 'case_sensitive' ) ); ?>>&nbsp;<label for='filters[case_sensitive][yes]'><?php _e( 'Case-sensitive search', 'glotpress' ); ?></label>
 				</fieldset>
 


### PR DESCRIPTION
## Problem

As described in #1816, *there are cases when an usual search just isn't good enough*.

## Solution

Add a checkbox to turn the search in a Regex search

- [x] Add a checkbox field near the term input to turn the search in a Regex
- [x] If the checkbox is selected, make a regex search to the db

## Testing Instructions
1. Open translation table with many translation strings, like a copy of WordPress core.
2. Try searching with the Regex option, with examples like the below, with and without case sensitive:
  - `^(Activ|Disabl|Enab)` - Will find any string starting with `Activ...`, `Disabl...` or `Enabl...`
  - `^(activ\w*\s.*)` - Will find any string starting with `Activ...` folowed by any other words, like `Activate %s`

## Screenshots or screencast

### Regex Search for `^(Activ|Disabl|Enab)`
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/8f5db138-fd18-4f0c-9df2-605bdb67832a)


### Regex Search for `^(activ\w*\s.*)`
![imagem](https://github.com/GlotPress/GlotPress/assets/7371591/d6755748-0efd-4811-990e-05ebe27cb8b4)

Fixes #1816 
