### PR TITLE
Enable plural forms for Persian languages

### DIFF
--- a/locales/locales.php
+++ b/locales/locales.php
@@ -1020,8 +1020,6 @@ class GP_Locales {
 		$fa->lang_code_iso_639_2 = 'fas';
 		$fa->wp_locale = 'fa_IR';
 		$fa->slug = 'fa';
-		$fa->nplurals = 2;
-		$fa->plural_expression = 'n > 1';
 		$fa->text_direction = 'rtl';
 		$fa->google_code = 'fa';
 		$fa->facebook_locale = 'fa_IR';
@@ -1035,8 +1033,6 @@ class GP_Locales {
 		$fa_af->country_code = 'af';
 		$fa_af->wp_locale = 'fa_AF';
 		$fa_af->slug = 'fa-af';
-		$fa_af->nplurals = 2;
-		$fa_af->plural_expression = 'n > 1';
 		$fa_af->text_direction = 'rtl';
 		$fa_af->google_code = 'fa';
 		$fa_af->alphabet = 'persian';


### PR DESCRIPTION
Hi,
We need to have plural and singular forms in our language So I deleted the settings to have default values

Regards
