### PR TITLE
Update the 404 template and add a new generic error template

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1703,3 +1703,9 @@ a.tour-button.button-primary:hover {
 .webui-popover a {
 	color: #fff;
 }
+
+.error-template {
+	text-align: center;
+	margin: 0 auto;
+	padding: 7rem 0;
+}

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -34,14 +34,17 @@ class GP_Route {
 	/**
 	 * Shows a template and exit.
 	 *
-	 * @param string $message  The message to display.
-	 * @param int    $status   The HTTP status code.
-	 * @param string $title    The title of the page.
-	 * @param string $template The template to use.
+	 * @param string      $message  The message to display.
+	 * @param int         $status   The HTTP status code.
+	 * @param string|null $title    The title of the page.
+	 * @param string      $template The template to use.
 	 *
 	 * @return void
 	 */
-	public function die_with_error( string $message, int $status = 500, string $title = '', string $template = 'error' ) {
+	public function die_with_error( string $message, int $status = 500, ?string $title = null, string $template = 'error' ) {
+		if ( null === $title ) {
+			$title = esc_html__( 'Error', 'glotpress' );
+		}
 		$this->status_header( $status );
 		if ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest' ) {
 			$this->exit_( $message );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -41,7 +41,7 @@ class GP_Route {
 	 *
 	 * @return void
 	 */
-	public function die_with_error(string $message, int $status = 500, string $title = '', string $template = 'error' ) {
+	public function die_with_error( string $message, int $status = 500, string $title = '', string $template = 'error' ) {
 		$this->status_header( $status );
 		if ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest' ) {
 			$this->exit_( $message );

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -31,33 +31,30 @@ class GP_Route {
 		add_action( 'gp_before_request', array( $this, 'check_uri_trailing_slash' ) );
 	}
 
-	public function die_with_error( $message, $status = 500 ) {
-		$this->status_header( $status );
-		$this->exit_( $message );
-	}
-
 	/**
 	 * Shows a template and exit.
 	 *
-	 * @since 4.1.0
-	 *
-	 * @param string $title    The title of the page.
 	 * @param string $message  The message to display.
-	 * @param string $template The template to use.
 	 * @param int    $status   The HTTP status code.
+	 * @param string $title    The title of the page.
+	 * @param string $template The template to use.
 	 *
 	 * @return void
 	 */
-	public function die_with_template( string $title = '', string $message = '', string $template = 'error', int $status = 500 ) {
+	public function die_with_error(string $message, int $status = 500, string $title = '', string $template = 'error' ) {
 		$this->status_header( $status );
-		$this->tmpl(
-			$template,
-			array(
-				'title'   => $title,
-				'message' => $message,
-			)
-		);
-		$this->exit_();
+		if ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest' ) {
+			$this->exit_( $message );
+		} else {
+			$this->tmpl(
+				$template,
+				array(
+					'title'   => $title,
+					'message' => $message,
+				)
+			);
+			$this->exit_();
+		}
 	}
 
 	public function before_request() {

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -36,6 +36,30 @@ class GP_Route {
 		$this->exit_( $message );
 	}
 
+	/**
+	 * Shows a template and exit.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $title    The title of the page.
+	 * @param string $message  The message to display.
+	 * @param string $template The template to use.
+	 * @param int    $status   The HTTP status code.
+	 *
+	 * @return void
+	 */
+	public function die_with_template( string $title = '', string $message = '', string $template = 'error', int $status = 500 ) {
+		$this->status_header( $status );
+		$this->tmpl(
+			$template,
+			array(
+				'title'   => $title,
+				'message' => $message,
+			)
+		);
+		$this->exit_();
+	}
+
 	public function before_request() {
 		/**
 		 * Fires before a route method is called.

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -467,7 +467,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( __( 'Project wasn&#8217;found', 'glotpress' ) );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, __esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		$changes = $project->set_difference_from( $other_project );
@@ -518,7 +518,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( __( 'Project wasn&#8217;found', 'glotpress' ) );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, __esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		header( 'Content-Type: application/json' );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -733,7 +733,7 @@ class GP_Route_Translation extends GP_Route_Main {
 		$translation = GP::$translation->get( gp_post( 'translation_id' ) );
 
 		if ( ! $translation ) {
-			return $this->die_with_error( 'Translation doesn&#8217;t exist!' );
+			return $this->die_with_error( esc_html__( 'Translation doesn&#8217;t exist!', 'glotpress' ), 404, esc_html__( 'Not Found', 'glotpress' ), '404' );
 		}
 
 		$this->can_approve_translation_or_forbidden( $translation );
@@ -776,7 +776,7 @@ class GP_Route_Translation extends GP_Route_Main {
 	 */
 	private function discard_warning_edit_function( $project, $locale, $translation_set, $translation ) {
 		if ( ! isset( $translation->warnings[ gp_post( 'index' ) ][ gp_post( 'key' ) ] ) ) {
-			return $this->die_with_error( 'The warning doesn&#8217;exist!' );
+			return $this->die_with_error( esc_html__( 'The warning doesn&#8217;exist!', 'glotpress' ), 404, esc_html__( 'Not Found', 'glotpress' ), '404' );
 		}
 
 		$warning = array(

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -776,7 +776,7 @@ class GP_Route_Translation extends GP_Route_Main {
 	 */
 	private function discard_warning_edit_function( $project, $locale, $translation_set, $translation ) {
 		if ( ! isset( $translation->warnings[ gp_post( 'index' ) ][ gp_post( 'key' ) ] ) ) {
-			return $this->die_with_error( esc_html__( 'The warning doesn&#8217;exist!', 'glotpress' ), 404, esc_html__( 'Not Found', 'glotpress' ), '404' );
+			return $this->die_with_error( esc_html__( 'The warning doesn&#8217;t exist!', 'glotpress' ), 404, esc_html__( 'Not Found', 'glotpress' ), '404' );
 		}
 
 		$warning = array(

--- a/gp-templates/404.php
+++ b/gp-templates/404.php
@@ -1,7 +1,10 @@
 <?php
 gp_title( __( 'Not Found &lt; GlotPress', 'glotpress' ) );
 gp_tmpl_header();
-
-_e( 'Not Found', 'glotpress' );
-
+?>
+<div class="error-template">
+	<h2><?php esc_html_e( 'Not Found', 'glotpress' ); ?></h2>
+	<?php esc_html_e( 'The requested URL was not found on this server.', 'glotpress' ); ?>
+</div>
+<?php
 gp_tmpl_footer();

--- a/gp-templates/error.php
+++ b/gp-templates/error.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Template for errors.
+ */
+
+/** @var string $title */
+/** @var string $message */
+
+/* Translators: %s: title */
+gp_title( esc_html( sprintf( __( '%s &lt; GlotPress', 'glotpress' ), $title ) ) );
+gp_tmpl_header();
+?>
+	<div class="error-template">
+		<h2><?php echo esc_html( $title ); ?></h2>
+		<?php echo esc_html( $message ); ?>
+	</div>
+<?php
+gp_tmpl_footer();

--- a/gp-templates/error.php
+++ b/gp-templates/error.php
@@ -7,7 +7,7 @@
 /** @var string $message */
 
 /* Translators: %s: title */
-gp_title( esc_html( sprintf( __( '%s &lt; GlotPress', 'glotpress' ), $title ) ) );
+gp_title( esc_html( sprintf( __( '%s &lt; GlotPress', 'glotpress' ), $title ? $title : esc_html__( 'Error', 'glotpress' ) ) ) );
 gp_tmpl_header();
 ?>
 	<div class="error-template">

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -105,7 +105,7 @@ $i = 0;
 		$sort_values_only    = array_filter( $sort );
 		$filters_and_sort    = array_merge( $filters_values_only, $sort_values_only );
 		// Remove any non-string or non-numeric values from the array.
-		$filters_and_sort    = array_filter( $filters_and_sort, 'is_scalar' );
+		$filters_and_sort = array_filter( $filters_and_sort, 'is_scalar' );
 
 		/**
 		 * Check to see if a term or user login has been added to the filter or one of the other filter options, if so,

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -105,7 +105,7 @@ $i = 0;
 		$sort_values_only    = array_filter( $sort );
 		$filters_and_sort    = array_merge( $filters_values_only, $sort_values_only );
 		// Remove any non-string or non-numeric values from the array.
-		$filters_and_sort = array_filter( $filters_and_sort, 'is_scalar' );
+		$filters_and_sort    = array_filter( $filters_and_sort, 'is_scalar' );
 
 		/**
 		 * Check to see if a term or user login has been added to the filter or one of the other filter options, if so,


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

As I explained in https://github.com/GlotPress/GlotPress/issues/1841, we should improve the error messages. Currently:
- The [die_with_error](https://github.com/GlotPress/GlotPress/blob/10644fd9bebd966c1327ff7fea3879556be7833b/gp-includes/route.php#L34) method shows an empty page with the error text.
- The [die_with_404](https://github.com/GlotPress/GlotPress/blob/10644fd9bebd966c1327ff7fea3879556be7833b/gp-includes/route.php#L324) method shows a template that can be improved.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/3156cfd7-96d6-482f-9cfa-6a3f594cebac)


Fixes https://github.com/GlotPress/GlotPress/issues/1841. 
See https://github.com/WordPress/wporg-gp-translation-events/issues/251. 
Fixes  https://github.com/WordPress/wporg-gp-translation-events/issues/251.
<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

In the [issue](https://github.com/GlotPress/GlotPress/issues/1841), I proposed to add a template to the [die_with_error](https://github.com/GlotPress/GlotPress/blob/10644fd9bebd966c1327ff7fea3879556be7833b/gp-includes/route.php#L34) method and improve the 404 template.

This PR:
- Updates the `404` template.
- Updates the `die_with_error` method to load a new generic template: `error.php`:
  - If the request is an AJAX request, it maintains the old functionality.
  - If the request is not an AJAX request, it returns a new template: `error.php` by default.

**Old 404 template**

![image](https://github.com/GlotPress/GlotPress/assets/1667814/3156cfd7-96d6-482f-9cfa-6a3f594cebac)

**New 404 template**

![image](https://github.com/GlotPress/GlotPress/assets/1667814/d2332878-2704-4bec-b134-846bf2fad5b5)

**Error with the old approach**

![image](https://github.com/GlotPress/GlotPress/assets/1667814/1df76166-e6a3-4242-a24e-c838576dffcb)

**Error with the new template**

![image](https://github.com/GlotPress/GlotPress/assets/1667814/4ed84467-b5b4-4e4c-b260-7351f77f12ba)

<!--
Please, describe how this PR improves the situation.
-->

## Testing Instructions

To test this PR:
- To test the updates in the 404 template, you need to access to a non-existent URL: https://glotpress.test/glotpress/non-existent-url
- To test the new template, you can change the `die_with_error` method with the new parameters: 

I tested it [here](https://github.com/WordPress/wporg-gp-translation-events/blob/b72cb73c60bc9ccb28ce50a3dd4098cfd37380c8/includes/routes/event/details.php#L97-L103), with the [wporg-gp-translation-events](https://github.com/WordPress/wporg-gp-translation-events) plugin, that depends on GlotPress and uses the `die_with_error` method.

I updated this code:

```
		try {
			$event_stats = $this->stats_calculator->for_event( $event->id() );
		} catch ( Exception $e ) {
			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
			error_log( $e );
			$this->die_with_error( esc_html__( 'Failed to calculate event stats', 'gp-translation-events' ) );
		}
```

With this:

```
		try {
			$event_stats = $this->stats_calculator->for_event( $event->id() );
			throw new Exception('This is a test');
		} catch ( Exception $e ) {
			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
			error_log( $e );
			$this->die_with_error(
				esc_html__( 'Failed to calculate event stats', 'gp-translation-events' ),
				500,
				esc_html__( 'Error', 'gp-translation-events' ),
				'error'
			);
		}
```

So I forced to fire a new exception, and then I show the new template.

<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open an original string in a project.
2. Add the translation.
3. etc. 
-->

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->