### PR TITLE
Do not fail the CI if the codecov action fails

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -90,4 +90,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: coverage-clover-${{ github.sha }}.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

The CI system is failing in the last PRs.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/a53df5b5-3446-480d-a124-3cf2953a17c1)

The reason is a 429 error from codecov.io while the CI system sends the coverage results.

![image](https://github.com/GlotPress/GlotPress/assets/1667814/4230181e-0469-4295-9374-b0c8fb77177a)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR changes the `fail_ci_if_error` value from `true` to `false`. As you can see in the official documentation from the [Codecov GitHub Action](https://github.com/codecov/codecov-action?tab=readme-ov-file#arguments), this argument specifies whether CI build should fail if Codecov runs into an error during upload.

<!--
Please, describe how this PR improves the situation.
-->

