### PR TITLE
Convert NULL translation values to empty string

### DIFF
--- a/gp-includes/formats/format-pomo.php
+++ b/gp-includes/formats/format-pomo.php
@@ -33,7 +33,7 @@ class GP_Format_PO extends GP_Format {
 			// Convert NULL to empty string to prevent PHP 8 passing NULL errors.
 			$entry->translations = array_map(
 				function ( $translation ) {
-					return $translation ?: '';
+					return $translation ? $translation : '';
 				},
 				$entry->translations
 			);

--- a/gp-includes/formats/format-pomo.php
+++ b/gp-includes/formats/format-pomo.php
@@ -30,6 +30,13 @@ class GP_Format_PO extends GP_Format {
 		$filters['status'] = 'current';
 
 		foreach ( $entries as $entry ) {
+			// Convert NULL to empty string to prevent PHP 8 passing NULL errors.
+			$entry->translations = array_map(
+				function ( $translation ) {
+					return $translation ?: '';
+				},
+				$entry->translations
+			);
 			$po->add_entry( $entry );
 		}
 


### PR DESCRIPTION
Convert NULL values to empty strings for passing to string manipulation functions in core.

Fixes https://github.com/GlotPress/GlotPress/issues/1858

<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Partial translations may pass NULL to string functions in WP Core.

## Solution

Convert translations saved as NULL to empty strings.


## Testing Instructions
GlotPress 4.0.1, WP 6.6.1 installation with partial translations.
