### PR TITLE
Declare variables to avoid dynamic creation error in PHP 8

### DIFF
--- a/gp-includes/things/validator-permission.php
+++ b/gp-includes/things/validator-permission.php
@@ -23,6 +23,8 @@ class GP_Validator_Permission extends GP_Permission {
 	public $project_id;
 	public $locale_slug;
 	public $set_slug;
+	public $user;
+	public $project;
 
 	/**
 	 * Sets restriction rules for fields.


### PR DESCRIPTION
Declare the `$user` and `$project` variables to avoid the dynamic variable creation errors in PHP 8 when viewing the project permissions page.

Fixes https://github.com/GlotPress/GlotPress/issues/1860

<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

Dynamic creation of variable in Project and sub-project permissions page.

## Solution

Declare the variables
