### PR TITLE
Add action hooks and filters to Projects and Project templates

### DIFF
--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -74,105 +74,195 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 	<table class="gp-table translation-sets">
 		<thead>
 			<tr>
-				<th class="gp-column-locale"><?php _e( 'Locale', 'glotpress' ); ?></th>
-				<th class="gp-column-percent"><?php _ex( '%', 'locale translation percent header', 'glotpress' ); ?></th>
-				<th class="gp-column-translated"><?php _e( 'Translated', 'glotpress' ); ?></th>
-				<th class="gp-column-fuzzy"><?php _e( 'Fuzzy', 'glotpress' ); ?></th>
-				<th class="gp-column-untranslated"><?php _e( 'Untranslated', 'glotpress' ); ?></th>
-				<th class="gp-column-waiting"><?php _e( 'Waiting', 'glotpress' ); ?></th>
-				<?php if ( has_action( 'gp_project_template_translation_set_extra' ) ) : ?>
-					<th class="gp-column-extra"><?php _e( 'Extra', 'glotpress' ); ?></th>
-				<?php endif; ?>
+				<?php
+
+				$translation_sets_columns = array(
+					'gp-column-locale'       => __( 'Locale', 'glotpress' ),
+					'gp-column-percent'      => _x( '%', 'locale translation percent header', 'glotpress' ),
+					'gp-column-translated'   => __( 'Translated', 'glotpress' ),
+					'gp-column-fuzzy'        => __( 'Fuzzy', 'glotpress' ),
+					'gp-column-untranslated' => __( 'Untranslated', 'glotpress' ),
+					'gp-column-waiting'      => __( 'Waiting', 'glotpress' ),
+				);
+				if ( has_action( 'gp_project_template_translation_set_extra' ) ) {
+					$translation_sets_columns['gp-column-extra'] = __( 'Extra', 'glotpress' );
+				}
+
+				/**
+				 * Fires after the last header column of a translation set.
+				 *
+				 * @since 4.0.2
+				 *
+				 * @param GP_Translation_Set $set     The translation set.
+				 * @param GP_Project         $project The current project.
+				 */
+				$translation_sets_columns = apply_filters( 'gp_project_template_translation_set_manage_columns', $translation_sets_columns, $project );
+
+				foreach ( $translation_sets_columns as $class => $label ) {
+					?>
+					<th class="<?php echo esc_attr( $class ); ?>"><?php echo esc_html( $label ); ?></th>
+					<?php
+				}
+
+				?>
 			</tr>
 		</thead>
 		<tbody>
-		<?php
-		foreach ( $translation_sets as $set ) :
-		?>
-			<tr>
-				<td>
-					<strong><?php gp_link( gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) ), $set->name_with_locale() ); ?></strong>
+			<?php
+			foreach ( $translation_sets as $set ) {
+
+				?>
+				<tr>
 					<?php
-					if ( $set->current_count && $set->current_count >= $set->all_count * 0.9 ) :
-							$percent = floor( $set->current_count / $set->all_count * 100 );
+
+					foreach ( $translation_sets_columns as $column_name => $column ) {
+
+						switch ( $column_name ) {
+
+							case 'gp-column-locale':
+								?>
+								<td>
+									<strong><?php gp_link( gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) ), $set->name_with_locale() ); ?></strong>
+									<?php
+									if ( $set->current_count && $set->current_count >= $set->all_count * 0.9 ) :
+											$percent = floor( $set->current_count / $set->all_count * 100 );
+									?>
+										<span class="bubble morethan90"><?php echo number_format_i18n( $percent ); ?>%</span>
+									<?php endif; ?>
+								</td>
+								<?php
+								break;
+
+							case 'gp-column-percent':
+								?>
+								<td class="stats percent"><?php echo number_format_i18n( $set->percent_translated ); ?>%</td>
+								<?php
+								break;
+
+							case 'gp-column-translated':
+								?>
+								<td class="stats translated" title="translated">
+									<?php
+									gp_link(
+										gp_url_project(
+											$project,
+											gp_url_join( $set->locale, $set->slug ),
+											array(
+												'filters[status]' => 'current',
+											)
+										),
+										number_format_i18n( $set->current_count )
+									);
+									?>
+								</td>
+								<?php
+								break;
+
+							case 'gp-column-fuzzy':
+								?>
+								<td class="stats fuzzy" title="fuzzy">
+									<?php
+									gp_link(
+										gp_url_project(
+											$project,
+											gp_url_join( $set->locale, $set->slug ),
+											array(
+												'filters[status]' => 'fuzzy',
+											)
+										),
+										number_format_i18n( $set->fuzzy_count )
+									);
+									?>
+								</td>
+								<?php
+								break;
+
+							case 'gp-column-untranslated':
+								?>
+								<td class="stats untranslated" title="untranslated">
+									<?php
+									gp_link(
+										gp_url_project(
+											$project,
+											gp_url_join( $set->locale, $set->slug ),
+											array(
+												'filters[status]' => 'untranslated',
+											)
+										),
+										number_format_i18n( $set->untranslated_count )
+									);
+									?>
+								</td>
+								<?php
+								break;
+
+							case 'gp-column-waiting':
+								?>
+								<td class="stats waiting">
+									<?php
+									gp_link(
+										gp_url_project(
+											$project,
+											gp_url_join( $set->locale, $set->slug ),
+											array(
+												'filters[status]' => 'waiting',
+											)
+										),
+										number_format_i18n( $set->waiting_count )
+									);
+									?>
+								</td>
+								<?php
+								break;
+
+							case 'gp-column-extra':
+								?>
+								<td class="extra">
+									<?php
+									/**
+									 * Fires in an extra information column of a translation set.
+									 *
+									 * @since 1.0.0
+									 *
+									 * @param GP_Translation_Set $set     The translation set.
+									 * @param GP_Project         $project The current project.
+									 */
+									do_action( 'gp_project_template_translation_set_extra', $set, $project );
+									?>
+								</td>
+								<?php
+								break;
+
+							default:
+								?>
+								<td class="<?php echo esc_attr( $column_name ); ?>">
+									<?php
+
+									/**
+									 * Fires inside each custom column of the Translation Sets list table.
+									 *
+									 * @since 4.0.2
+									 *
+									 * @param string             $column_name   Name of the column.
+									 * @param GP_Translation_Set $set           The translation set.
+									 * @param GP_Project         $project       The current project.
+									 */
+									do_action( 'gp_project_template_translation_set_custom_column', $column_name, $set, $project );
+
+									?>
+								</td>
+								<?php
+								break;
+
+						}
+					}
+
 					?>
-						<span class="bubble morethan90"><?php echo number_format_i18n( $percent ); ?>%</span>
-					<?php endif; ?>
-				</td>
-				<td class="stats percent"><?php echo number_format_i18n( $set->percent_translated ); ?>%</td>
-				<td class="stats translated" title="translated">
-					<?php
-					gp_link(
-						gp_url_project(
-							$project,
-							gp_url_join( $set->locale, $set->slug ),
-							array(
-								'filters[status]' => 'current',
-							)
-						),
-						number_format_i18n( $set->current_count )
-					);
-					?>
-				</td>
-				<td class="stats fuzzy" title="fuzzy">
-					<?php
-					gp_link(
-						gp_url_project(
-							$project,
-							gp_url_join( $set->locale, $set->slug ),
-							array(
-								'filters[status]' => 'fuzzy',
-							)
-						),
-						number_format_i18n( $set->fuzzy_count )
-					);
-					?>
-				</td>
-				<td class="stats untranslated" title="untranslated">
-					<?php
-					gp_link(
-						gp_url_project(
-							$project,
-							gp_url_join( $set->locale, $set->slug ),
-							array(
-								'filters[status]' => 'untranslated',
-							)
-						),
-						number_format_i18n( $set->untranslated_count )
-					);
-					?>
-				</td>
-				<td class="stats waiting">
-					<?php
-					gp_link(
-						gp_url_project(
-							$project,
-							gp_url_join( $set->locale, $set->slug ),
-							array(
-								'filters[status]' => 'waiting',
-							)
-						),
-						number_format_i18n( $set->waiting_count )
-					);
-					?>
-				</td>
-				<?php if ( has_action( 'gp_project_template_translation_set_extra' ) ) : ?>
-					<td class="extra">
-						<?php
-						/**
-						 * Fires in an extra information column of a translation set.
-						 *
-						 * @since 1.0.0
-						 *
-						 * @param GP_Translation_Set $set     The translation set.
-						 * @param GP_Project         $project The current project.
-						 */
-						do_action( 'gp_project_template_translation_set_extra', $set, $project );
-						?>
-					</td>
-				<?php endif; ?>
-			</tr>
-		<?php endforeach; ?>
+				</tr>
+			<?php
+
+			}
+			?>
 		</tbody>
 	</table>
 </div>

--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -280,12 +280,32 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 			$sub_project_class = $sub_project->active ? 'project-active' : 'project-inactive';
 			?>
 			<dt class="<?php echo esc_attr( $sub_project_class ); ?>">
-				<?php gp_link_project( $sub_project, esc_html( $sub_project->name ) ); ?>
-				<?php gp_link_project_edit( $sub_project, null, array( 'class' => 'button is-small' ) ); ?>
-				<?php gp_link_project_delete( $sub_project, null, array( 'class' => 'button is-small' ) ); ?>
 				<?php
-				if ( ! $sub_project->active ) {
-					echo "<span class='inactive bubble'>" . __( 'Inactive', 'glotpress' ) . '</span>';
+
+				/**
+				 * Filter a project row items, like title, action buttons and active bubble.
+				 *
+				 * @since 4.0.2
+				 *
+				 * @param array $project_row_items   The array of project items to render on the projects list.
+				 * @param GP_Project $project        GP_Project object.
+				 */
+				$project_row_items = apply_filters(
+					'gp_project_row_items',
+					array(
+						'link-name'     => gp_link_project_get( $sub_project, esc_html( $sub_project->name ) ),
+						'button-edit'   => gp_link_project_edit_get( $sub_project, null, array( 'class' => 'button is-small' ) ),
+						'button-delete' => gp_link_project_delete_get( $sub_project, null, array( 'class' => 'button is-small' ) ),
+						'bubble-status' => $sub_project->active ? null : "<span class='inactive bubble'>" . __( 'Inactive', 'glotpress' ) . '</span>',
+					),
+					$sub_project
+				);
+
+				// Render project row items.
+				foreach ( $project_row_items as $project_row_item ) {
+					if ( ! is_null( $project_row_item ) ) {
+						echo wp_kses_post( $project_row_item );
+					}
 				}
 				?>
 			</dt>

--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -124,11 +124,13 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 								<td>
 									<strong><?php gp_link( gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) ), $set->name_with_locale() ); ?></strong>
 									<?php
-									if ( $set->current_count && $set->current_count >= $set->all_count * 0.9 ) :
-											$percent = floor( $set->current_count / $set->all_count * 100 );
-									?>
+									if ( $set->current_count && $set->current_count >= $set->all_count * 0.9 ) {
+										$percent = floor( $set->current_count / $set->all_count * 100 );
+										?>
 										<span class="bubble morethan90"><?php echo number_format_i18n( $percent ); ?>%</span>
-									<?php endif; ?>
+										<?php
+									}
+									?>
 								</td>
 								<?php
 								break;

--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -285,7 +285,7 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 				<?php
 
 				/**
-				 * Filter a project row items, like title, action buttons and active bubble.
+				 * Filter a subproject row items, like title, action buttons and active bubble in the project template.
 				 *
 				 * @since 4.0.2
 				 *
@@ -293,7 +293,7 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 				 * @param GP_Project $project        GP_Project object.
 				 */
 				$project_row_items = apply_filters(
-					'gp_project_row_items',
+					'gp_project_template_subproject_items',
 					array(
 						'link-name'     => gp_link_project_get( $sub_project, esc_html( $sub_project->name ) ),
 						'button-edit'   => gp_link_project_edit_get( $sub_project, null, array( 'class' => 'button is-small' ) ),

--- a/gp-templates/projects.php
+++ b/gp-templates/projects.php
@@ -12,12 +12,32 @@ gp_tmpl_header();
 				$project_class = $project->active ? 'project-active' : 'project-inactive';
 				?>
 				<dt class="<?php echo esc_attr( $project_class ); ?>">
-					<?php gp_link_project( $project, esc_html( $project->name ) ); ?>
-					<?php gp_link_project_edit( $project, null, array( 'class' => 'button is-small' ) ); ?>
-					<?php gp_link_project_delete( $project, null, array( 'class' => 'button is-small' ) ); ?>
 					<?php
-					if ( ! $project->active ) {
-						echo "<span class='inactive bubble'>" . __( 'Inactive', 'glotpress' ) . '</span>';
+
+					/**
+					 * Filter a project row items, like title, action buttons and active bubble.
+					 *
+					 * @since 4.0.2
+					 *
+					 * @param array $project_row_items   The array of project items to render on the projects list.
+					 * @param GP_Project $project        GP_Project object.
+					 */
+					$project_row_items = apply_filters(
+						'gp_project_row_items',
+						array(
+							'link-name'     => gp_link_project_get( $project, esc_html( $project->name ) ),
+							'button-edit'   => gp_link_project_edit_get( $project, null, array( 'class' => 'button is-small' ) ),
+							'button-delete' => gp_link_project_delete_get( $project, null, array( 'class' => 'button is-small' ) ),
+							'bubble-status' => $project->active ? null : "<span class='inactive bubble'>" . __( 'Inactive', 'glotpress' ) . '</span>',
+						),
+						$project
+					);
+
+					// Render project row items.
+					foreach ( $project_row_items as $project_row_item ) {
+						if ( ! is_null( $project_row_item ) ) {
+							echo wp_kses_post( $project_row_item );
+						}
 					}
 					?>
 				</dt>

--- a/gp-templates/projects.php
+++ b/gp-templates/projects.php
@@ -15,7 +15,7 @@ gp_tmpl_header();
 					<?php
 
 					/**
-					 * Filter a project row items, like title, action buttons and active bubble.
+					 * Filter a project row items, like title, action buttons and active bubble in the root projects template.
 					 *
 					 * @since 4.0.2
 					 *
@@ -23,7 +23,7 @@ gp_tmpl_header();
 					 * @param GP_Project $project        GP_Project object.
 					 */
 					$project_row_items = apply_filters(
-						'gp_project_row_items',
+						'gp_projects_template_project_items',
 						array(
 							'link-name'     => gp_link_project_get( $project, esc_html( $project->name ) ),
 							'button-edit'   => gp_link_project_edit_get( $project, null, array( 'class' => 'button is-small' ) ),


### PR DESCRIPTION
## Problem

Customizing the GlotPress UI relies heavily on the templates.
If multiple plugins are used to add funcionallities, and all rely on templates, one could either use templates from one or other plugin, not both. On top of this, there is no template versioning, so, it's hard to keep track and keep templates up to date.

If one wants to add a custom column to the **Translation Sets** table, can use only one extra column with the hook `gp_project_template_translation_set_extra`, the column is labeled "Extra" with the custom data in it.

## Solution

This PR adds some more hooks and filters to allow adding features with plugins without the need to override templates.
This is also a good practice to keep templates up to date.

### Templates and hooks

#### projects.php

`gp_projects_template_project_items`
Allows to filter an array of the project items like name, buttons and bubble in the projects template.

#### project.php

`gp_project_template_subproject_items`
Allows to filter an array of the subproject items like name, buttons and bubble in the project template.

`gp_project_template_translation_set_manage_columns`
Allows to filter the **Translation Sets** table columns, in the same WP way of [manage_{$screen->id}_columns](https://developer.wordpress.org/reference/hooks/manage_screen-id_columns/).

`gp_project_template_translation_set_custom_column`
Allows to add **Translation Sets** table custom columns, in the same WP way of [manage_plugins_custom_column](https://developer.wordpress.org/reference/hooks/manage_plugins_custom_column//).

## Testing Instructions

1. Check the root Projects and single Project pages, all the default behavior should be kept.
2. Add custom columns and filter the project row items in the projects lists and check how easy it is to customize.

