### PR TITLE
Copy the placeholders and spaces to the translation textarea

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -434,9 +434,15 @@ $gp.editor = (
 				link.parents( '.textareas' ).find( 'textarea' ).val( original_text ).focus();
 			},
 			copyPlaceholder: function( link ) {
+				$gp.editor.copyToTextarea( link, link.text() );
+			},
+			copyInvisibleSpaces: function( link ) {
+				$gp.editor.copyToTextarea( link, ' '.repeat( link.text().length ) );
+			},
+			copyToTextarea: function( link, valueToCopy ) {
 				var text_area = link.closest( 'p' ).nextAll( '.textareas' ).first().find( 'textarea.foreign-text' );
 				var cursorPos = text_area.prop( 'selectionStart' ) ? text_area.prop( 'selectionStart' ) : 0;
-				var placeholderText = link.text();
+				var placeholderText = valueToCopy;
 				var textareaValue = text_area.val() ? text_area.val() : '';
 				var textBefore = textareaValue.substring( 0, cursorPos ) ? textareaValue.substring( 0, cursorPos ) : '';
 				var textAfter = textareaValue.substring( cursorPos, textareaValue.length ) ? textareaValue.substring( cursorPos, textareaValue.length ) : '';
@@ -444,17 +450,6 @@ $gp.editor = (
 				text_area.val( textareaValue );
 				text_area.focus();
 				text_area[ 0 ].selectionEnd = cursorPos + placeholderText.length;
-			},
-			copyInvisibleSpaces: function( link ) {
-				var text_area = link.closest( 'p' ).nextAll( '.textareas' ).first().find( 'textarea.foreign-text' );
-				var cursorPos = text_area.prop( 'selectionStart' ) ? text_area.prop( 'selectionStart' ) : 0;
-				var textareaValue = text_area.val() ? text_area.val() : '';
-				var textBefore = textareaValue.substring( 0, cursorPos ) ? textareaValue.substring( 0, cursorPos ) : '';
-				var textAfter = textareaValue.substring( cursorPos, textareaValue.length ) ? textareaValue.substring( cursorPos, textareaValue.length ) : '';
-				textareaValue = textBefore + ' '.repeat( link.text().length ) + textAfter;
-				text_area.val( textareaValue );
-				text_area.focus();
-				text_area[ 0 ].selectionEnd = cursorPos + link.text().length;
 			},
 			tab: function( link ) {
 				var text_area = link.parents( '.textareas' ).find( 'textarea' );

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -139,6 +139,7 @@ $gp.editor = (
 					.on( 'click', 'button.changesrequested', $gp.editor.hooks.set_status_changesrequested )
 					.on( 'click', 'button.fuzzy', $gp.editor.hooks.set_status_fuzzy )
 					.on( 'click', 'button.ok', $gp.editor.hooks.ok )
+					.on( 'click', '.editor .original span.notranslate.placeholder', $gp.editor.hooks.placeholder )
 					.on( 'keydown', 'tr.editor textarea', $gp.editor.hooks.keydown )
 					.on( 'focus input', 'tr.editor textarea.foreign-text', $gp.editor.hooks.update_count );
 				$( '#translations' ).tooltip( {
@@ -431,6 +432,18 @@ $gp.editor = (
 
 				link.parents( '.textareas' ).find( 'textarea' ).val( original_text ).focus();
 			},
+			copyPlaceholder: function( link ) {
+				var text_area = link.closest( 'p' ).nextAll( '.textareas' ).first().find( 'textarea.foreign-text' );
+				var cursorPos = text_area.prop( 'selectionStart' ) ? text_area.prop( 'selectionStart' ) : 0;
+				var placeholderText = link.text();
+				var textareaValue = text_area.val() ? text_area.val() : '';
+				var textBefore = textareaValue.substring( 0, cursorPos ) ? textareaValue.substring( 0, cursorPos ) : '';
+				var textAfter = textareaValue.substring( cursorPos, textareaValue.length ) ? textareaValue.substring( cursorPos, textareaValue.length ) : '';
+				textareaValue = textBefore + placeholderText + textAfter;
+				text_area.val( textareaValue );
+				text_area.focus();
+				text_area[ 0 ].selectionEnd = cursorPos + placeholderText.length;
+			},
 			tab: function( link ) {
 				var text_area = link.parents( '.textareas' ).find( 'textarea' );
 				var cursorPos = text_area.prop( 'selectionStart' );
@@ -466,6 +479,10 @@ $gp.editor = (
 				},
 				ok: function() {
 					$gp.editor.save( $( this ) );
+					return false;
+				},
+				placeholder: function() {
+					$gp.editor.copyPlaceholder( $( this ) );
 					return false;
 				},
 				cancel: function() {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -140,6 +140,7 @@ $gp.editor = (
 					.on( 'click', 'button.fuzzy', $gp.editor.hooks.set_status_fuzzy )
 					.on( 'click', 'button.ok', $gp.editor.hooks.ok )
 					.on( 'click', '.editor .original span.notranslate.placeholder', $gp.editor.hooks.placeholder )
+					.on( 'click', '.editor .original span.invisible-spaces', $gp.editor.hooks.invisible_space )
 					.on( 'keydown', 'tr.editor textarea', $gp.editor.hooks.keydown )
 					.on( 'focus input', 'tr.editor textarea.foreign-text', $gp.editor.hooks.update_count );
 				$( '#translations' ).tooltip( {
@@ -444,6 +445,17 @@ $gp.editor = (
 				text_area.focus();
 				text_area[ 0 ].selectionEnd = cursorPos + placeholderText.length;
 			},
+			copyInvisibleSpaces: function( link ) {
+				var text_area = link.closest( 'p' ).nextAll( '.textareas' ).first().find( 'textarea.foreign-text' );
+				var cursorPos = text_area.prop( 'selectionStart' ) ? text_area.prop( 'selectionStart' ) : 0;
+				var textareaValue = text_area.val() ? text_area.val() : '';
+				var textBefore = textareaValue.substring( 0, cursorPos ) ? textareaValue.substring( 0, cursorPos ) : '';
+				var textAfter = textareaValue.substring( cursorPos, textareaValue.length ) ? textareaValue.substring( cursorPos, textareaValue.length ) : '';
+				textareaValue = textBefore + ' '.repeat( link.text().length ) + textAfter;
+				text_area.val( textareaValue );
+				text_area.focus();
+				text_area[ 0 ].selectionEnd = cursorPos + link.text().length;
+			},
 			tab: function( link ) {
 				var text_area = link.parents( '.textareas' ).find( 'textarea' );
 				var cursorPos = text_area.prop( 'selectionStart' );
@@ -483,6 +495,10 @@ $gp.editor = (
 				},
 				placeholder: function() {
 					$gp.editor.copyPlaceholder( $( this ) );
+					return false;
+				},
+				invisible_space: function() {
+					$gp.editor.copyInvisibleSpaces( $( this ) );
 					return false;
 				},
 				cancel: function() {


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In https://github.com/GlotPress/GlotPress/pull/1620 we introduced a wrapper to highlight the placeholders, and in https://github.com/GlotPress/GlotPress/pull/1500 we introduced a similar wrapper to highlight leading and trailing spaces, and double/multiple spaces in the middle.

When a translator clicks on some of these elements, they are not copied to the translation textarea when you click on the placeholder or in the space.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds this improvement, so when you click on one of these gray squares (see the screenshot below), this item (placeholders or space) is copied to the translation textarea, where the cursor is placed.

![image](https://github.com/user-attachments/assets/c8b135d6-29f1-49de-8a52-f28c6afd3804)

<!--
Please, describe how this PR improves the situation.
-->

