### PR TITLE
Add buttons from the glossary to the translation area

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -134,6 +134,7 @@ $gp.editor = (
 					.on( 'click', 'button.copy', $gp.editor.hooks.copy )
 					.on( 'click', 'button.inserttab', $gp.editor.hooks.tab )
 					.on( 'click', 'button.insertnl', $gp.editor.hooks.newline )
+					.on( 'click', 'button.insert-glossary-item', $gp.editor.hooks.insert_glossary_item )
 					.on( 'click', 'button.approve', $gp.editor.hooks.set_status_current )
 					.on( 'click', 'button.reject', $gp.editor.hooks.set_status_rejected )
 					.on( 'click', 'button.changesrequested', $gp.editor.hooks.set_status_changesrequested )
@@ -455,6 +456,18 @@ $gp.editor = (
 				text_area.focus();
 				text_area[ 0 ].selectionEnd = cursorPos + 1;
 			},
+			insert_glossary_item: function( link ) {
+				var text_area = link.closest( '.textareas' ).first().find( 'textarea.foreign-text' );
+				var cursorPos = text_area.prop( 'selectionStart' ) ? text_area.prop( 'selectionStart' ) : 0;
+				var buttonText = link.data( 'title' );
+				var textareaValue = text_area.val() ? text_area.val() : '';
+				var textBefore = textareaValue.substring( 0, cursorPos ) ? textareaValue.substring( 0, cursorPos ) : '';
+				var textAfter = textareaValue.substring( cursorPos, textareaValue.length ) ? textareaValue.substring( cursorPos, textareaValue.length ) : '';
+				textareaValue = textBefore + buttonText + textAfter;
+				text_area.val( textareaValue );
+				text_area.focus();
+				text_area[ 0 ].selectionEnd = cursorPos + buttonText.length;
+			},
 			hooks: {
 				show: function() {
 					$gp.editor.show( $( this ) );
@@ -495,6 +508,10 @@ $gp.editor = (
 				},
 				newline: function() {
 					$gp.editor.newline( $( this ) );
+					return false;
+				},
+				insert_glossary_item: function() {
+					$gp.editor.insert_glossary_item( $( this ) );
 					return false;
 				},
 				discard_warning: function() {

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -105,7 +105,7 @@ $i = 0;
 		$sort_values_only    = array_filter( $sort );
 		$filters_and_sort    = array_merge( $filters_values_only, $sort_values_only );
 		// Remove any non-string or non-numeric values from the array.
-		$filters_and_sort    = array_filter( $filters_and_sort, 'is_scalar' );
+		$filters_and_sort = array_filter( $filters_and_sort, 'is_scalar' );
 
 		/**
 		 * Check to see if a term or user login has been added to the filter or one of the other filter options, if so,
@@ -455,6 +455,21 @@ do_action( 'gp_before_translation_table', get_defined_vars() );
 	</tr>
 	</thead>
 <?php
+$locale_glossary_translation_set = GP::$translation_set->by_project_id_slug_and_locale( 0, $translation_set->slug, $translation_set->locale );
+$locale_glossary                 = GP::$glossary->by_set_id( $locale_glossary_translation_set->id );
+$glossary_entries                = GP::$glossary_entry->by_glossary_id( $locale_glossary->id );
+$glossary_entries                = array_filter( $glossary_entries, fn( $value ) => 'glossary-button' === $value->comment );
+$new_actions                     = '';
+// Create the buttons from the glossary entries.
+foreach ( $glossary_entries as $glossary_entry ) {
+	$new_actions .= '<button type="button" class="button is-small insert-glossary-item" data-title="' . esc_attr( $glossary_entry->translation ) . '" title="' . esc_attr( $glossary_entry->translation ) . '">' . esc_attr( $glossary_entry->translation ) . '</button>';
+}
+add_filter(
+	'gp_entry_actions',
+	function( $actions ) use ( $new_actions ) {
+		return array( str_replace( '</div>', $new_actions . '</div>', $actions[0] ) );
+	}
+);
 foreach ( $translations as $translation ) {
 	if ( ! $translation->translation_set_id ) {
 		$translation->translation_set_id = $translation_set->id;


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

We encounter translation scenarios where having a button with specific characters, which can be copied to the translation area with one click, would be highly beneficial.

E.g., in Galician and Spanish, they use Latin quotation marks (« ») instead of double quotes ("). To type these symbols, you need to press:
- Windows: `Alt + 174` for `«` and `Alt + 175` for `»`.
- Mac: `Shift+Alt+{` for `«` and `Shift+Alt+}` for `»`.
- Linux: `Ctrl + Shift + u followed by 00AB` for `«` and `Ctrl + Shift + u followed by 00BB` for `»`.

Having buttons that provide quick access to frequently used symbols, organized by locale, would be very useful. A single click on a button could copy the desired symbol to the translation textarea directly.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR propose a solution, adding these buttons for each locale, based on the glossary content. To add a new button, you need to add a new row in the glossary, with:
- "Translation" as the text you want in the button. We can't use the "Original term" field because it doesn't admit symbols.
- "Comments" with the `glossary-button` text, you GlotPress can detect this as a button.

![image](https://github.com/user-attachments/assets/bec102fc-1ad7-4d72-9005-7cb6cf38036d)

Maximum number of buttons: TBD.

This is the proposed UI.

![image](https://github.com/user-attachments/assets/4738af5e-03f1-4d36-b319-7d5196af0659)


<!--
Please, describe how this PR improves the situation.
-->


## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

To test it:
- Add one or more  `glossary-button` elements to the locale glossary.
- Go to the translation interface. 
- Open a translation row.
- Click on the new buttons.
- Their text should be copied to the position of the cursor in the textarea.