### PR TITLE
Declare plurals type variable.

### DIFF
--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -15,7 +15,7 @@
 class GP_Project extends GP_Thing {
 
 	var $table_basename           = 'gp_projects';
-	var $field_names              = array( 'id', 'name', 'slug', 'path', 'description', 'parent_project_id', 'source_url_template', 'active' );
+	var $field_names              = array( 'id', 'name', 'slug', 'path', 'description', 'parent_project_id', 'source_url_template', 'active', 'plurals_type' );
 	var $int_fields               = array( 'id', 'parent_project_id', 'active' );
 	var $non_updatable_attributes = array( 'id' );
 
@@ -27,6 +27,7 @@ class GP_Project extends GP_Thing {
 	public $parent_project_id;
 	public $source_url_template;
 	public $active;
+	public $plurals_type;
 	public $user_source_url_template;
 
 	/**


### PR DESCRIPTION
Avoid the dynamic variable creation errors in PHP 8.

Resolves #1873 

## Problem

plurals_type variable no defined in project thing.

## Solution

Define plurals_type variable in project thing.

## To-do

None.

## Testing Instructions
Follow instructions to reproduce issue in #1873.

