### PR TITLE
Install SVN in the GitHub action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -62,6 +62,11 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: composer
 
+      - name: Install SVN
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -62,10 +62,9 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: composer
 
+      # SVN is required by the WordPress test installer script
       - name: Install SVN
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In the last executions of the GitHub action that runs the PHP tests, they always fail because they can't find SVN. Example [here](https://github.com/GlotPress/GlotPress/actions/runs/15387842646/job/43629917344?pr=1828).

![image](https://github.com/user-attachments/assets/fa64b61b-cafb-4ca4-8704-04fafdf27505)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

This PR adds SVN in the GitHub action. You can see in this own PR that the tests are running fine.
<!--
Please, describe how this PR improves the situation.
-->
