### PR TITLE
Delay the translation of parts of speech to the init hook

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -56,6 +56,13 @@ class GP_Glossary_Entry extends GP_Thing {
 			return;
 		}
 
+		add_action( 'init', array( $this, 'translate_parts_of_speech' ) );
+	}
+
+	/**
+	 * Translates the parts of speech.
+	 */
+	public function translate_parts_of_speech() {
 		$this->parts_of_speech = array(
 			'noun'         => _x( 'noun', 'part-of-speech', 'glotpress' ),
 			'verb'         => _x( 'verb', 'part-of-speech', 'glotpress' ),


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In WordPress 6.7 we introduced some [Internationalization improvements](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/). One of these improvements fires a warning if translations are loaded too early, and this is the problem we are having with the last version of GlotPress and WordPress.

``` 
PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>glotpress</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /home/XXX/public_html/blog/wp-includes/functions.php on line 6114
``` 
Fixes #1875.


<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

<!--
Please, describe how this PR improves the situation.
-->

This PR fixes this problem, translating the `parts_of_speech` array when the `init` hook is fired. 

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

To test it, you can:
- Set WordPress in a translated language.
- Go to the glossary of a locale and see that you get the `parts_of_speech` translated: 
	- noun 
	- verb         
	- adjective    
	- adverb       
	- interjection 
	- conjunction  
	- preposition  
	- pronoun      
	- expression   
	- abbreviation 

## Screenshots or screencast
<!-- 
Only if it is applicable 
-->

![image](https://github.com/user-attachments/assets/26933130-e106-4d77-93e6-a6d3746fae82)
