### PR TITLE
Add a new gp_is_valid_utf8 helper function

### DIFF
--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -752,7 +752,6 @@ function gp_set_translations_import_max_memory_limit() {
 function gp_is_valid_utf8( $string ) {
 	if ( function_exists( 'wp_is_valid_utf8' ) ) {
 		return wp_is_valid_utf8( $string );
-	} else {
-		return seems_utf8( $string );
 	}
+	return seems_utf8( $string );
 }

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -736,3 +736,23 @@ function gp_get_sort_by_fields() {
 function gp_set_translations_import_max_memory_limit() {
 	return '256M';
 }
+
+/**
+ * Checks if a string is valid UTF-8.
+ *
+ * The wp_is_valid_utf8() was introduced in WordPress 6.9.0, so we need a fallback for older versions.
+ * seems_utf8() was deprecated in WordPress 6.9.0.
+ * See https://core.trac.wordpress.org/changeset/60630
+ *
+ * @since 4.1.0
+ *
+ * @param string $string The string to check.
+ * @return bool True if the string is valid UTF-8, false otherwise.
+ */
+function gp_is_valid_utf8( $string ) {
+	if ( function_exists( 'wp_is_valid_utf8' ) ) {
+		return wp_is_valid_utf8( $string );
+	} else {
+		return seems_utf8( $string );
+	}
+}

--- a/gp-includes/strings.php
+++ b/gp-includes/strings.php
@@ -2,7 +2,6 @@
 /**
  * Functions, which make work with strings easier
  */
-
 function gp_startswith( $haystack, $needle ) {
 	return 0 === strpos( $haystack, $needle );
 }
@@ -150,7 +149,7 @@ function gp_sanitize_slug( $slug ) {
 	// Restore octets.
 	$slug = preg_replace( '|---([a-fA-F0-9][a-fA-F0-9])---|', '%$1', $slug );
 
-	if ( seems_utf8( $slug ) ) {
+	if ( gp_is_valid_utf8( $slug ) ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
 			$slug = mb_strtolower( $slug, 'UTF-8' );
 		}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -6,9 +6,6 @@
  * @subpackage Tests
  */
 
-// Skip WordPress deprecation tracking during tests to avoid cluttering test output with deprecation notices.
-define( 'WP_TESTS_SKIP_DEPRECATION', true );
-
 if ( ! defined( 'GP_TESTS_DIR' ) ) {
 	define( 'GP_TESTS_DIR', __DIR__ );
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -6,6 +6,9 @@
  * @subpackage Tests
  */
 
+// Skip WordPress deprecation tracking during tests to avoid cluttering test output with deprecation notices.
+define( 'WP_TESTS_SKIP_DEPRECATION', true );
+
 if ( ! defined( 'GP_TESTS_DIR' ) ) {
 	define( 'GP_TESTS_DIR', __DIR__ );
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

<!--
Please, describe what is the status/problem before the PR.
-->

In this [commit](https://core.trac.wordpress.org/changeset/60630), it was introduced a new `wp_is_valid_utf8()` function, deprecating the current `seems_utf8()` function.  `wp_is_valid_utf8()` is present in the 6.9.x branch, while `seems_utf8()` is deprecated since 6.9.0.

We have some GitHub actions running the current WordPress version (6.8.2) and the nightly (6.9-alpha-x). With the `seems_utf8()` function, the tests running in the 6.9-alpha-x version show a warning, breaking these tests. You can see these problems: https://github.com/GlotPress/GlotPress/pull/1928, https://github.com/GlotPress/GlotPress/pull/1927, https://github.com/GlotPress/GlotPress/pull/1926,...

## Solution

<!--
Please, describe how this PR improves the situation.
-->

The solution is to create this `gp_is_valid_utf8 ` helper function, that uses `wp_is_valid_utf8()` or `seems_utf8()`, depending on the WordPress version.

You can see in this PR that this change solve this problem, because the tests have passed.