### PR TITLE
Check if $set->all_count is > 0

### DIFF
--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -93,7 +93,7 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 				<td>
 					<strong><?php gp_link( gp_url_project( $project, gp_url_join( $set->locale, $set->slug ) ), $set->name_with_locale() ); ?></strong>
 					<?php
-					if ( $set->current_count && $set->current_count >= $set->all_count * 0.9 ) :
+					if ( $set->current_count && $set->all_count && $set->current_count >= $set->all_count * 0.9 ) :
 							$percent = floor( $set->current_count / $set->all_count * 100 );
 					?>
 						<span class="bubble morethan90"><?php echo number_format_i18n( $percent ); ?>%</span>


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In some projects, like [these inactive projects](https://translate.wordpress.org/projects/disabled/swiss-german/), we have some incorrect sets. If the set has the `all_count` property settled to 0, we have a `Uncaught DivisionByZeroError: Division by zero` error.

![screenshot](https://github.com/user-attachments/assets/da990089-2142-4b67-aa46-5e4458274a06)

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

<!--
Please, describe how this PR improves the situation.
-->

This PR checks if the `all_count` property is greater than zero to avoid using it if this is not true. With this check, we prevent a PHP fatal error.