### PR TITLE
Add the untranslated parts of speech

### DIFF
--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -56,6 +56,19 @@ class GP_Glossary_Entry extends GP_Thing {
 			return;
 		}
 
+		$this->parts_of_speech = array(
+			'noun'         => 'noun',
+			'verb'         => 'verb',
+			'adjective'    => 'adjective',
+			'adverb'       => 'adverb',
+			'interjection' => 'interjection',
+			'conjunction'  => 'conjunction',
+			'preposition'  => 'preposition',
+			'pronoun'      => 'pronoun',
+			'expression'   => 'expression',
+			'abbreviation' => 'abbreviation',
+		);
+
 		add_action( 'init', array( $this, 'translate_parts_of_speech' ) );
 	}
 


### PR DESCRIPTION
<!-- 
Thanks for contributing to GlotPress! Please, follow the GlotPress Contributing Guidelines:
https://github.com/GlotPress/GlotPress/blob/develop/CONTRIBUTING.md 
-->

## Problem

In https://github.com/GlotPress/GlotPress/pull/1907 I introduced a bug, and the functionality that adds an item to the glossary broke.

<!--
Please, describe what is the status/problem before the PR.
-->

## Solution

<!--
Please, describe how this PR improves the situation.
-->

This PR adds a new array to populate the parts_of_speech immediately with non-localized labels, so validation (which run before the 'init' hook) has the correct allowed keys. This PR doesn't call translation functions, to avoid triggering translation loading too early.

Fixes https://github.com/GlotPress/GlotPress/issues/1942.

## Testing Instructions
<!-- 
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
Please, include step-by-step instructions on how to test this PR:
1. Open a original string in a project.
2. Add the translation.
3. etc. 
-->

1. Test it in a localized GlotPress.
2. Go to a local glossary.
3. Try to add a new correct item.
4. You will get a new item added.
5. You will see the "Part of speech" localized in your local glossary.

<img width="1284" height="1920" alt="image" src="https://github.com/user-attachments/assets/d4534f81-d387-45bf-8cb6-168f447f144f" />
