### PR TITLE
Rest API [WIP]

### DIFF
--- a/gp-includes/gp.php
+++ b/gp-includes/gp.php
@@ -95,6 +95,15 @@ class GP {
 	public static $glossary_entry;
 
 	/**
+	 * Singleton for REST API.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @var GP_REST_API
+	 */
+	public static $rest;
+
+	/**
 	 * Singleton for router.
 	 *
 	 * @since 1.0.0

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -753,3 +753,26 @@ function gp_is_valid_utf8( $string ) {
 	}
 	return seems_utf8( $string );
 }
+
+/**
+ * Fetch a thing from the DB.
+ * Ex: gp_get_thing( 1, 'project' );
+ *
+ * @since 5.0.0
+ *
+ * @param  int    $id   Thing ID.
+ * @param  string $type Thing type.
+ * @return object|false The object or false on failure.
+ */
+function gp_get_thing( $id = 0, $type = '' ) {
+	$object = GP::${ $type } ?? null;
+	$id     = (int) $id;
+
+	if ( ! $id || ! is_callable( array( $object, 'get' ) ) ) {
+		return false;
+	}
+
+	$thing = $object->get( $id );
+
+	return false !== $thing ? $thing : false;
+}

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -59,6 +59,7 @@ class GP_REST_API {
 	 */
 	protected function get_v1_controllers() {
 		return array(
+			'api'              => 'GP_REST_Api_V1_Controller',
 			'projects'         => 'GP_REST_Projects_V1_Controller',
 			'import'           => 'GP_REST_Import_V1_Controller',
 			'languages'        => 'GP_REST_Languages_V1_Controller',

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Initialize this version of the REST API.
+ *
+ * @package GlotPress\RestApi
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class responsible for loading the REST API and all REST API namespaces.
+ */
+class GP_REST_API {
+
+	/**
+	 * REST API namespaces and endpoints.
+	 *
+	 * @var array
+	 */
+	protected $controllers = array();
+
+	/**
+	 * Hook into WordPress ready to init the REST API as needed.
+	 */
+	public function __construct() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod -- Not an injection method.
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_rest_routes() {
+		foreach ( $this->get_rest_namespaces() as $namespace => $controllers ) {
+			foreach ( $controllers as $controller_name => $controller_class ) {
+				$this->controllers[ $namespace ][ $controller_name ] = new $controller_class;
+				$this->controllers[ $namespace ][ $controller_name ]->register_routes();
+			}
+		}
+	}
+
+	/**
+	 * Get API namespaces - new namespaces should be registered here.
+	 *
+	 * @return array List of Namespaces and Main controller classes.
+	 */
+	protected function get_rest_namespaces() {
+		$namespaces = array(
+			'gp/v1'        => $this->get_v1_controllers(),
+		);
+
+        return $namespaces;
+	}
+
+	/**
+	 * List of controllers in the gp/v1 namespace.
+	 *
+	 * @return array
+	 */
+	protected function get_v1_controllers() {
+		return array(
+			'projects'         => 'GP_REST_Projects_V1_Controller',
+		);
+	}
+
+}

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -59,6 +59,7 @@ class GP_REST_API {
 	protected function get_v1_controllers() {
 		return array(
 			'projects'         => 'GP_REST_Projects_V1_Controller',
+			'import'           => 'GP_REST_Import_V1_Controller',
 		);
 	}
 

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -23,6 +23,7 @@ class GP_REST_API {
 	 * Hook into WordPress ready to init the REST API as needed.
 	 */
 	public function __construct() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod -- Not an injection method.
+		require_once GP_TMPL_PATH . 'helper-functions.php';
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 	}
 
@@ -61,6 +62,7 @@ class GP_REST_API {
 			'projects'         => 'GP_REST_Projects_V1_Controller',
 			'import'           => 'GP_REST_Import_V1_Controller',
 			'languages'        => 'GP_REST_Languages_V1_Controller',
+			'translations'     => 'GP_REST_Translations_V1_Controller',
 			'translation_sets' => 'GP_REST_Translation_Sets_V1_Controller',
 		);
 	}

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -61,6 +61,7 @@ class GP_REST_API {
 			'projects'         => 'GP_REST_Projects_V1_Controller',
 			'import'           => 'GP_REST_Import_V1_Controller',
 			'languages'        => 'GP_REST_Languages_V1_Controller',
+			'translation_sets' => 'GP_REST_Translation_Sets_V1_Controller',
 		);
 	}
 

--- a/gp-includes/rest-api/rest-api.php
+++ b/gp-includes/rest-api/rest-api.php
@@ -60,6 +60,7 @@ class GP_REST_API {
 		return array(
 			'projects'         => 'GP_REST_Projects_V1_Controller',
 			'import'           => 'GP_REST_Import_V1_Controller',
+			'languages'        => 'GP_REST_Languages_V1_Controller',
 		);
 	}
 

--- a/gp-includes/rest-api/rest-functions.php
+++ b/gp-includes/rest-api/rest-functions.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Rest API helper functions.
+ *
+ * @package GlotPress\RestApi
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Safely encode a project path for REST API links.
+ *
+ * Preserves slashes between path segments, but encodes unsafe characters in each segment.
+ * 
+ * @since 5.0.0
+ *
+ * @param string $path The project path (may contain slashes).
+ * @return string Encoded path safe for URLs
+ */
+function gp_rest_encode_project_path( string $path ): string {
+	$segments = explode( '/', $path );
+	$encoded_segments = array_map( 'rawurlencode', $segments );
+	return implode( '/', $encoded_segments );
+}
+
+/**
+ * Retrieves a project from request.
+ *
+ * @since 5.0.0
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return GP_Project|WP_Error Project object on success, or WP_Error object on failure.
+ */
+function gp_rest_get_project( $request ) {
+	static $cache = array();
+	
+	$project_key = $request->get_url_params()['project'] ?? $request->get_body_params()['project'] ?? $request['project'] ?? null;
+	
+	// Return cached result if available.
+	if ( isset( $cache[ $project_key ] ) ) {
+		return $cache[ $project_key ];
+	}
+	
+	// Perform lookup.
+	$project = $project_key ? GP::$project->by_path_or_id( $project_key ) : false;
+	
+	if ( ! $project || ! $project instanceof GP_Project ) {
+		$error = new WP_Error( 
+			'gp_rest_project_invalid_id', 
+			__( 'No project found with that ID.', 'glotpress' ), 
+			array( 'status' => 404 ) 
+		);
+		
+		// Cache the error too (avoid repeated lookups for invalid IDs).
+		$cache[ $project_key ] = $error;
+		return $error;
+	}
+	
+	// Cache the successful result.
+	$cache[ $project_key ] = $project;
+	return $project;
+}

--- a/gp-includes/rest-api/routes/v1/api.php
+++ b/gp-includes/rest-api/routes/v1/api.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * REST API Update controller
+ *
+ * Handles requests to the /api endpoint for serving language pack updates.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Update controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_REST_Api_V1_Controller extends GP_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'api';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'language_pack';
+
+	/**
+	 * Register the routes for projects.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<project>[^/]+)',
+			array(
+				'args'   => array(
+					'project' => array(
+						'description' => __( 'Unique identifier for the resource (ID or slug).', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+						'percent_translated' => array(
+                            'description' => __( 'Minimum percent translated to include.', 'glotpress' ),
+                            'type'        => 'integer',
+                            'default'     => 90,
+                            'minimum'     => 0,
+                            'maximum'     => 100,
+                        ),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Retrieve the desired resource from the request.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return GP_Project|WP_Error The requested resource, or WP_Error if not found.
+	 */
+	protected function get_resource( $request ) {
+		return gp_rest_get_project( $request );
+	}
+
+	/**
+	 * Retrieves one item from the collection.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+
+		$project = $this->get_resource( $request );
+
+		if ( is_wp_error( $project ) ) {
+			return $project;
+		}
+
+		$translation_sets = GP::$translation_set->by_project_id( $project->id );
+
+		$items = array();
+		foreach ( $translation_sets as $set ) {
+
+			$locale = GP_Locales::by_slug( $set->locale );
+
+			if ( ! $locale ) {
+				continue;
+			}
+
+			$set->wp_locale = $locale ? $locale->wp_locale : '';
+
+			// Skip sets that don't meet the translation threshold.
+			if ( $set->percent_translated() < $request['percent_translated'] ) {
+				continue;
+			}
+
+			$data = $this->prepare_item_for_response( $set, $request );
+
+			$items[$set->wp_locale] = $this->prepare_response_for_collection( $data );
+		}
+
+		return rest_ensure_response( $items );
+
+	}
+
+	/**
+	 * Prepare a single translation set output for response.
+	 *
+	 * @param GP_Translation_Set        $set Translation Set object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $set, $request ) {
+
+		$context = $request['context'] ?: 'view';
+
+		$locale = GP_Locales::by_slug( $set->locale );
+		
+		$data = array(
+                'language'      => $set->wp_locale,
+                'updated'       => $set->current_count() ? $set->last_modified() : false,
+                'english_name'  => $locale->english_name,
+                'native_name'   => $locale->native_name,
+                'package'       => $this->get_language_pack_url( $this->get_resource( $request ), $set ),
+            );
+
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $set, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param GP_Translation_Set $set        Translation set object.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $set, $request );
+	}
+
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param GP_Translation_Set $set     Translation set object.
+	 * @param WP_REST_Request    $request Request object.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $set, $request ) {
+		return array();
+	}
+
+    /**
+     * Get the language pack URL.
+     *
+     * @since 5.0.0
+     *
+     * @param GP_Project         $project         Project object.
+     * @param GP_Translation_Set $translation_set Translation set object.
+     * @param string             $version         Version string.
+     * @return string|false Package URL or false if not found.
+     */
+    protected function get_language_pack_url( $project, $translation_set ) {
+
+        // Default URL structure
+        // Example: https://example.com/downloads/my-plugin/1.2.3/my-plugin-1.2.3-es_ES.zip
+        $base_url = defined( 'GP_LANGUAGE_PACK_URL' ) ? GP_LANGUAGE_PACK_URL : home_url( '/downloads' );
+
+		$filename = sprintf(
+			'%s-%s.zip',
+			$project->slug,
+			$translation_set->wp_locale
+		);
+
+		return sprintf(
+			'%s/%s/%s',
+			untrailingslashit( $base_url ),
+			$project->slug,
+			$filename
+		);
+    }
+
+	/**
+	 * Get the project's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		if ( isset( $this->schema ) ) {
+			return $this->schema;
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->thing_type,
+			'type'       => 'object',
+			'properties' => array(
+				'translations' => array(
+					'description' => __( 'Available translation sets.', 'glotpress' ),
+					'type'        => 'array',
+					'context'     => array( 'view' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'language' => array(
+								'description' => __( 'WordPress language code.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'view' ),
+							),
+							'updated' => array(
+								'description' => __( 'Last update date.', 'glotpress' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'english_name' => array(
+								'description' => __( 'English name of the language.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'native_name' => array(
+								'description' => __( 'Native name of the language.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'package' => array(
+								'description' => __( 'URL to download the language pack.', 'glotpress' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->schema;
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/crud.php
+++ b/gp-includes/rest-api/routes/v1/crud.php
@@ -1,0 +1,511 @@
+<?php
+/**
+ * Abstract Rest CRUD Controller Class
+ *
+ * @package GlotPress\RestApi
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * GP_REST_CRUD_Controller
+ *
+ * @package GlotPress\RestApi
+ * @version 5.0.0
+ */
+abstract class GP_REST_CRUD_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = '';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = '';
+
+	/**
+	 * Retrieve the desired resource from the request.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	protected function get_resource( $request ) {
+
+		$thing = gp_get_thing( (int) $request['id'], $this->thing_type );
+
+		if ( ! $thing ) {
+			return new WP_Error( 'gp_rest_invalid_resource', __( 'Sorry, no resource found with those parameters.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+	
+		return $thing;
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! GP::$permission->current_user_can( 'read', $this->thing_type ) ) {
+			return new WP_Error( 'gp_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to create an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! GP::$permission->current_user_can( 'write', $this->thing_type ) ) {
+			return new WP_Error( 'gp_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to read an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		if ( ! GP::$permission->current_user_can( 'read', $this->thing_type, $thing->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+	
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to update an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		if ( ! GP::$permission->current_user_can( 'write', $this->thing_type, $thing->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_edit', __( 'Sorry, you are not allowed to edit this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to delete an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		if ( ! GP::$permission->current_user_can( 'delete', $this->thing_type, $thing->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_delete', __( 'Sorry, you are not allowed to delete this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		$data = $this->prepare_item_for_response( $thing, $request );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a single item output for response.
+	 *
+	 * @param GP_Thing        $thing   Thing object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $thing, $request ) {
+
+		$data = array(
+			'id'                => (int) $thing->id,
+		);
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $thing, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param GP_Thing           $thing      Thing object.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $thing, $request );
+	}
+
+	/**
+	 * Create a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		global $wpdb;
+		$wpdb->hide_errors();
+
+		$thing = $this->get_resource( $request );
+
+		if ( ! is_wp_error( $thing ) && $thing->id ) {
+			/* translators: %s: object type */
+			return new WP_Error( "gp_rest_{$this->thing_type}_exists", __( 'Cannot create existing resource.', 'glotpress' ), array( 'status' => 400 ) );
+		}
+
+		$thing = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		if ( ! $thing->save() ) {
+			return new WP_Error( "gp_rest_{$this->thing_type}_failed_to_create", sprintf( __( 'Resource could not be created. %s', 'glotpress' ), $wpdb->last_error ), array( 'status' => 400 ) );
+		}
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param GP_Thing        $thing     Thing object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "gp_rest_insert_{$this->thing_type}", $thing, $request, true );
+
+		$request->set_param( 'context', 'edit' );
+		$data     = $this->prepare_item_for_response( $thing, $request );
+		$response = rest_ensure_response( $data );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $thing->id ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Update a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		global $wpdb;
+		$wpdb->hide_errors();
+
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		$thing = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+		
+		if ( ! $thing->save() ) {
+			/* translators: 1: object type, 2: database error message */
+			return new WP_Error( "gp_rest_{$this->thing_type}_failed_to_update", sprintf( __( '%1$s could not be updated. %2$s', 'glotpress' ), ucfirst($this->thing_type), $wpdb->last_error ), array( 'status' => 400 ) );
+		}
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param GP_Thing        $thing     Thing object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "gp_rest_insert_{$this->thing_type}", $thing, $request, false );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $thing, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get a collection of items.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$args = $this->prepare_items_query( $request->get_params(), $request );
+
+		$object = GP::${ $this->thing_type } ?? null;
+
+		$things = array();
+
+		if ( ! $object || ! is_callable( array( $object, 'find_some' ) ) ) {
+			return rest_ensure_response( $things );
+		}
+
+		$query_result = $object->find_some( $args );
+
+		foreach ( $query_result as $thing ) {
+			if ( ! GP::$permission->current_user_can( 'read', $this->thing_type, $thing->id ) ) {
+				continue;
+			}
+
+			$data = $this->prepare_item_for_response( $thing, $request );
+			$things[] = $this->prepare_response_for_collection( $data );
+		}
+
+		if ( ! $object || ! is_callable( array( $object, 'count' ) ) ) {
+			rest_ensure_response( $things );
+		}
+
+		// Add pagination headers.
+		$response = rest_ensure_response( $things );
+
+		$page         = (int) $args['page'];
+		$total_things = $object->count( array( 'per_page' => -1 ) );
+
+		$max_pages = ceil( $total_things / (int) $args['per_page'] );
+
+		$response->header( 'X-WP-Total', (int) $total_things );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$request_params = $request->get_query_params();
+		if ( ! empty( $request_params['filter'] ) ) {
+			// Normalize the pagination params.
+			unset( $request_params['filter']['per_page'] );
+			unset( $request_params['filter']['page'] );
+		}
+		$base = add_query_arg( $request_params, rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Delete a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		global $wpdb;
+		$wpdb->hide_errors();
+
+		$thing = $this->get_resource( $request );
+
+		if ( is_wp_error( $thing ) ) {
+			return $thing;
+		}
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $thing, $request );
+
+		if ( ! $thing->delete() ) {
+			/* translators: %s: post type */
+			return new WP_Error( 'gp_rest_cannot_delete', sprintf( __( 'The resource cannot be deleted. %s', 'glotpress' ), $wpdb->last_error ), array( 'status' => 500 ) );
+		}
+
+		/**
+		 * Fires after a single item is deleted or trashed via the REST API.
+		 *
+		 * @param object           $thing     The deleted or trashed item.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
+		 */
+		do_action( "gp_rest_delete_{$this->thing_type}", $thing, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param GP_Thing        $thing   Thing object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $thing, $request ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $thing->id ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Determine the allowed query_vars for a get_items() response and
+	 * prepare for WP_Query.
+	 *
+	 * @param array           $prepared_args Prepared arguments.
+	 * @param WP_REST_Request $request       The request used.
+	 * @return array          $query_args
+	 */
+	protected function prepare_items_query( $prepared_args, $request ) {
+		$query_args = array();
+		foreach ( $this->get_allowed_query_vars() as $var ) {
+			if ( array_key_exists( $var, $prepared_args ) ) {
+				$query_args[ $var ] = $prepared_args[ $var ];
+			}
+		}
+
+		/**
+		 * Filter the query arguments for a request.
+		 *
+		 * Enables adding extra arguments or setting defaults for a thing
+		 * collection request.
+		 *
+		 * @param array           $query_args Key value array of query var to query value.
+		 * @param WP_REST_Request $request    The request used.
+		 */
+		return apply_filters( "gp_rest_{$this->thing_type}_query_args", $query_args, $request );
+	}
+
+	/**
+	 * Get all the Query vars that are allowed for the API request.
+	 *
+	 * @return array
+	 */
+	protected function get_allowed_query_vars() {
+		return array(
+			'order',
+			'orderby',
+			'page',
+			'per_page',
+		);
+	}
+
+	/**
+	 * Get the query params for collections of attachments.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+
+		$params['context']['default'] = 'view';
+
+		$params['id'] = array(
+			'description'       => __( 'Limit result set to specific ids.', 'glotpress' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type'          => 'integer',
+			),
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+		$params['order'] = array(
+			'description'        => __( 'Order sort attribute ascending or descending.', 'glotpress' ),
+			'type'               => 'string',
+			'default'            => 'asc',
+			'enum'               => array( 'asc', 'desc' ),
+			'validate_callback'  => 'rest_validate_request_arg',
+		);
+		$params['orderby'] = array(
+			'description'        => __( 'Sort collection by object attribute.', 'glotpress' ),
+			'type'               => 'string',
+			'default'            => 'id',
+			'enum'               => GP::${ $this->thing_type }->query_vars ?? array(),
+			'validate_callback'  => 'rest_validate_request_arg',
+		);
+		$param['per_page'] = array(
+			'description'       => __( 'Maximum number of items to be returned in result set. Use "no-limit" for all items.', 'glotpress' ),
+			'type'              => array( 'integer', 'string' ),  // ← Accept both types
+			'default'           => GP::${ $this->thing_type }->per_page ?? 10,
+			'sanitize_callback' => function( $value ) {
+				if ( 'no-limit' === $value ) {
+					return 'no-limit';
+				}
+				return absint( $value );
+			},
+			'validate_callback' => function( $value, $request, $param ) {
+				// Allow 'no-limit' string
+				if ( 'no-limit' === $value ) {
+					return true;
+				}
+				// Otherwise validate as integer
+				$value = (int) $value;
+				if ( $value < 1 || $value > 100 ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'per_page must be between 1 and 100, or "no-limit".', 'glotpress' ),
+						array( 'status' => 400 )
+					);
+				}
+				return true;
+			},
+		);
+
+		unset( $params['search'] );
+
+		return $params;
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/import.php
+++ b/gp-includes/rest-api/routes/v1/import.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * REST API Projects controller
+ *
+ * Handles requests to the /projects endpoint.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Import controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_REST_Import_V1_Controller extends GP_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'projects';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'project';
+
+	/**
+	 * Register the routes for import.
+	 */
+	public function register_routes() {
+		register_rest_route( 
+			$this->namespace,
+			'/' . $this->rest_base .
+			'/(?P<project>[^/]+)/import',
+			array(
+				'args' => array(
+					'project' => array(
+						'description' => __( 'Unique identifier for the project (ID or slug)', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'file' => array(
+						'description' => __( 'The import file', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to update an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function import_permissions_check( $request ) {
+		$project = gp_rest_get_project( $request );
+
+		if ( ! is_wp_error( $project ) && ! GP::$permission->current_user_can( 'write', $this->thing_type, $project->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_import', __( 'Sorry, you are not allowed to import strings for this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+	
+	/**
+	 * Prepare a single project output for response.
+	 *
+	 * @param array           $results Import results.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $results, $request ) {
+
+		list( $originals_added, $originals_existing, $originals_fuzzied, $originals_obsoleted, $originals_error ) = $results;
+
+		$data = array(
+			'originals_added'     => (int) $originals_added,
+			'originals_existing'  => (int) $originals_existing,
+			'originals_fuzzied'   => (int) $originals_fuzzied,
+			'originals_obsoleted' => (int) $originals_obsoleted,
+			'originals_error'     => (int) $originals_error,
+		);
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+	//	$response->add_links( $this->prepare_links( $project, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param array              $results    Original strings processing results.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_import", $response, $results, $request );
+	}
+
+	/**
+	 * Import originals for a single project.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function import( $request ) {
+
+		$project = gp_rest_get_project( $request );
+
+		if ( is_wp_error( $project ) ) {
+			return $project;
+		}
+
+		$files = $request->get_file_params();
+  
+		if ( empty( $files['file'] ) ) {
+			return new WP_Error( 'gp_rest_missing_file', __( 'No file uploaded.', 'glotpress' ), array( 'status' => 400 ) );
+		}
+
+		$format = gp_get_import_file_format( gp_post( 'format', 'po' ), $files['file']['name'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		if ( ! $format ) {
+			return new WP_Error( 'gp_rest_unsupported_format', __( 'File format not supported.', 'glotpress' ), array( 'status' => 400 ) );
+		}
+
+		$translations = $format->read_originals_from_file( $files['file']['tmp_name'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		if ( ! $translations ) {
+			return new WP_Error( 'gp_rest_unsupported_format', __( 'Couldn&#8217;t load translations from file!', 'glotpress' ), array( 'status' => 400 ) );
+			return;
+		}
+
+		$result = GP::$original->import_for_project( $project, $translations );
+
+		/**
+		 * Fires after a single file is uploaded via the REST API.
+		 *
+		 * @param array           $result    Results of import.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "gp_rest_originals_imported", $result, $request, false );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $result, $request );
+		return rest_ensure_response( $response );
+
+	}
+
+
+	/**
+	 * Get the projects's schema, conforming to JSON Schema.
+	 * 
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->thing_type,
+			'type'       => 'object',
+			'properties' => array(
+				'project' => array(
+					'description' => __( 'Unique identifier for the project.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Project name.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'slug' => array(
+					'description' => __( 'Project slug', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'active' => array(
+					'description' => __( 'Active status', 'glotpress' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description' => array(
+					'description' => __( 'Description', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'parent_project_id' => array(
+					'description' => __( 'Parent project ID', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/languages.php
+++ b/gp-includes/rest-api/routes/v1/languages.php
@@ -1,0 +1,444 @@
+<?php
+/**
+ * REST API Languages controller
+ *
+ * Handles requests to the /languages endpoint.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Languages controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_REST_Languages_V1_Controller extends GP_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'languages';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'project';
+
+	/**
+	 * Register the routes for projects.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>.+)', array(
+			'args' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource (slug).', 'glotpress' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'context'         => $this->get_context_param( array( 'default' => 'detail' ) ),
+				),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+
+	}
+
+	/**
+	 * Retrieves a collection of items.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+
+		$existing_locales = GP::$translation_set->existing_locales();
+		$locales          = array();
+
+		foreach ( $existing_locales as $locale ) {
+			$locale = GP_Locales::by_slug( $locale );
+			if ( ! $locale ) {
+				continue;
+			}
+			$data = $this->prepare_item_for_response( $locale, $request );
+			$locales[] = $this->prepare_response_for_collection( $data );
+		}
+
+		return rest_ensure_response( $locales );
+	}
+	
+	/**
+	 * Retrieves one item from the collection.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+
+		$locale = GP_Locales::by_slug( sanitize_title( $request['id'] ) );
+
+		if ( ! $locale ) {
+			return new WP_Error( 'gp_rest_language_not_found', __( 'Language not found.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+
+		$data = $this->prepare_item_for_response( $locale, $request );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a single locale output for response.
+	 *
+	 * @param GP_Project        $locale Project object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $locale, $request ) {
+
+		$context = $request['context'] ?: 'view';
+
+		$data = array(
+			'slug'         => $locale->slug,
+			'name'         => $locale->english_name,
+			'native_name'  => $locale->native_name,
+			'country_code' => $locale->country_code,
+			'wp_locale'    => $locale->wp_locale,
+		);
+
+		if ( 'detail' === $context ) {
+			$data['projects'] = $this->prepare_projects( $locale->slug, $request );
+		}
+
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $locale, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param array         $data    Data object.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $data, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param GP_Locale       $locale Locale object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given locale.
+	 */
+	protected function prepare_links( $thing, $request ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $thing->slug ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Prepare projects and translation sets for REST output.
+	 *
+	 * @param string          $locale_slug Locale slug.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	protected function prepare_projects( $locale_slug, $request ) {
+
+		$sets = GP::$translation_set->by_locale( $locale_slug, 'project_id' );
+
+		$projects          = array(); // Cached GP_Project objects.
+		$prepared_projects = array(); // Final REST output.
+		$project_sets      = array(); // Sets grouped by root project.
+		$project_stats     = array(); // Aggregated stats per root project.
+
+		foreach ( $sets as $set ) {
+
+			$project = $projects[ $set->project_id ]
+				?? $projects[ $set->project_id ] = GP::$project->get( $set->project_id );
+
+			// Skip inactive projects.
+			if ( empty( $project ) || empty( $project->active ) ) {
+				continue;
+			}
+
+			// Resolve root project.
+			$root_id = $project->parent_project_id ?: $project->id;
+
+			if ( ! isset( $projects[ $root_id ] ) ) {
+				$projects[ $root_id ] = GP::$project->get( $root_id );
+			}
+
+			// Initialize containers.
+			$project_sets[ $root_id ]  ??= array();
+			$project_stats[ $root_id ] ??= array(
+				'all_count'        => 0,
+				'translated_count' => 0,
+				'fuzzy_count'      => 0,
+				'waiting_count'    => 0,	
+			);
+
+			// Prepare set data (schema-aligned).
+			$project_sets[ $root_id ][] = array(
+				'project_id'         => $project->id,
+				'project_path'       => $project->path,
+				'slug'               => $set->slug,
+				'all_count'          => $set->all_count(),
+				'translated_count'   => $set->current_count(),
+				'untranslated_count' => $set->untranslated_count(),
+				'fuzzy_count'        => $set->fuzzy_count(),
+				'waiting_count'      => $set->waiting_count(),
+				'percent_translated' => (int) $set->percent_translated(),
+				'last_modified'      => $set->current_count() ? $set->last_modified() : false,
+			);
+
+			// Accumulate stats.
+			$project_stats[ $root_id ]['all_count']        += $set->all_count();
+			$project_stats[ $root_id ]['translated_count'] += $set->current_count();
+			$project_stats[ $root_id ]['fuzzy_count']      += $set->fuzzy_count();
+			$project_stats[ $root_id ]['waiting_count']    += $set->waiting_count();			
+		}
+
+		// Build final response.
+		foreach ( $project_sets as $project_id => $sets ) {
+
+			$totals = $project_stats[ $project_id ];
+
+			$percentage = $totals['all_count'] > 0
+				? (int) number_format_i18n( ( $totals['translated_count'] / $totals['all_count'] ) * 100, 0 )
+				: '0';
+
+			$prepared_sets = array();
+
+			foreach ( $sets as $set ) {
+				$prepared_set = $set;
+				$prepared_set['_links'] = array(
+					'self' => array(
+						array(
+							'href' => rest_url(
+								sprintf(
+									'%s/translations/%s/%s/%s',
+									$this->namespace,
+									rawurlencode( $projects[ $project_id ]->slug ),
+									rawurlencode( $locale_slug ),
+									rawurlencode( $set['slug'] )
+								)
+							),
+						),
+					),
+				);
+				$prepared_sets[] = $prepared_set;
+			}
+
+			$prepared_project = array(
+				'name'  => $projects[ $project_id ]->name,
+				'slug'  => $projects[ $project_id ]->path,
+				'stats' => array(
+					'total'              => $totals['all_count'],
+					'percent_translated' => $percentage,
+				),
+				'sets'  => $prepared_sets,
+			);
+
+			$prepared_project['_links'] = array(
+				'self' => array(
+					array(
+						'href' => rest_url(
+							sprintf(
+								'%s/projects/%s',
+								$this->namespace,
+								rawurlencode( $projects[ $project_id ]->slug )
+							)
+						),
+					),
+				),
+			);
+
+			$prepared_projects[] = $prepared_project;
+		}
+
+		return $prepared_projects;
+	}
+
+	/**
+	 * Get the projects's schema, conforming to JSON Schema.
+	 * 
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->thing_type,
+			'type'       => 'object',
+			'properties' => array(
+				'slug' => array(
+					'description' => __( 'Slug', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Name (in English).', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'native_name' => array(
+					'description' => __( 'Native name', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'country_code' => array(
+					'description' => __( 'Language code', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'wp_locale' => array(
+					'description' => __( 'WordPress locale', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'projects' => array(
+					'description' => __( 'Active projects', 'glotpress' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'detail' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name' => array(
+								'description' => __( 'Project name', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'detail' ),
+							),
+							'stats' => array(
+								'description' => __( 'Project / Stats', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'detail' ),
+								'type'       => 'object',
+								'properties' => array(
+									'total' => array(
+										'description' => __( 'Total strings', 'glotpress' ),
+										'type'        => 'int',
+										'context'     => array( 'view', 'detail' ),
+									),
+									'percent_translated' => array(
+										'description' => __( 'Percent translated', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'view', 'detail' ),
+									),
+								),
+							),
+							'sets' => array(
+								'description' => __( 'Set / Sub Project', 'glotpress' ),
+								'type'       => 'object',
+								'properties' => array(
+									'project_id' => array(
+										'description' => __( 'Project ID.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'view' ),
+									),
+									'project_slug' => array(
+										'description' => __( 'Project slug.', 'glotpress' ),
+										'type'        => 'string',
+										'context'     => array( 'view' ),
+									),
+									'slug' => array(
+										'description' => __( 'Set slug.', 'glotpress' ),
+										'type'        => 'string',
+										'context'     => array( 'view' ),
+									),
+									'all_count' => array(
+										'description' => __( 'Number of all translatable strings.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'translated_count' => array(
+										'description' => __( 'Number of translated strings.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'untranslated_count' => array(
+										'description' => __( 'Number of untranslated strings.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'fuzzy_count' => array(
+										'description' => __( 'Number of fuzzy strings.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'waiting_count' => array(
+										'description' => __( 'Number of waiting strings.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'percent_translated' => array(
+										'description' => __( 'Percent translated.', 'glotpress' ),
+										'type'        => 'integer',
+										'context'     => array( 'detail' ),
+									),
+									'last_modified' => array(
+										'description' => __( 'Date set last modified.', 'glotpress' ),
+										'type'        => 'datetime',
+										'context'     => array( 'detail' ),
+									),
+								),
+							)
+						),
+					),
+				),
+			),
+		);
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/projects.php
+++ b/gp-includes/rest-api/routes/v1/projects.php
@@ -1,0 +1,613 @@
+<?php
+/**
+ * REST API Projects controller
+ *
+ * Handles requests to the /projects endpoint.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Projects controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_Rest_Projects_V1_Controller extends GP_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'projects';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'project';
+
+	/**
+	 * Register the routes for projects.
+	 */
+	public function register_routes() {
+		register_rest_route( 
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+						'name' => array(
+							'description' => __( 'Project name.', 'glotpress' ),
+							'required'    => true,
+							'type'        => 'string',
+						),
+					) ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<project>[^/]+)', array(
+			'args' => array(
+				'project' => array(
+					'description' => __( 'Project ID or path.', 'glotpress' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+
+	/**
+	 * Retrieve the desired resource from the request.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return GP_Project|WP_Error The requested resource, or WP_Error if not found.
+	 */
+	protected function get_resource( $request ) {
+		return gp_rest_get_project( $request );
+	}
+
+	/**
+	 * Retrieves a collection of items.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$args = $this->prepare_items_query( $request->get_params(), $request );
+
+		$projects = GP::$project->find_some( $args );
+
+		$items = array();
+		foreach ( $projects as $project ) {
+			$data = $this->prepare_item_for_response( $project, $request );
+			$items[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$total_projects = GP::$project->count( array( 'per_page' => 'no-limit' ) );
+
+		$page           = (int) $args['page'];
+		$max_pages      = ceil( (int) $total_projects / (int) $args['per_page'] );
+
+		$response = rest_ensure_response( $items );
+
+		$response->header( 'X-WP-Total', (int) $total_projects );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$request_params = $request->get_query_params();
+
+		if ( ! empty( $request_params['filter'] ) ) {
+			// Normalize the pagination params.
+			unset( $request_params['filter']['per_page'] );
+			unset( $request_params['filter']['page'] );
+		}
+		$base = add_query_arg( $request_params, rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+	
+	/**
+	 * Retrieves one item from the collection.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$project = $this->get_resource( $request );
+
+		if ( is_wp_error( $project ) ) {
+			return $project;
+		}
+
+		$data     = $this->prepare_item_for_response( $project, $request );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a single project output for response.
+	 *
+	 * @param GP_Project        $project Project object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $project, $request ) {
+
+		$context = $request['context'] ?: 'view';
+
+		$data = array(
+			'id'                => (int) $project->id,
+			'name'              => $project->name,
+			'path'              => $project->path,
+			'active'            => (bool) $project->active,
+			'description'       => $project->description,
+			'parent_project_id' => (int) $project->parent_project_id,
+			'source_url'        => $project->source_url_template,
+		);
+
+		if ( 'view' === $context ) {
+			$data['sets']         = $this->prepare_sets_for_response( $project, $request );
+			$data['sub_projects'] = $this->prepare_subprojects_for_response( $project, $request );
+		}
+
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $project, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param GP_Project         $project    Project object.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $project, $request );
+	}
+
+	/**
+	 * Prepare sets for response.
+	 *
+	 * @param GP_Project        $project Project object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return array
+	 */
+	protected function prepare_sets_for_response( $project, $request ) {
+		$translation_sets = GP::$translation_set->by_project_id( $project->id );
+
+		// Sort sets by translated count if not full data.
+		usort(
+			$translation_sets,
+			function ( $a, $b ) {
+				return( $a->current_count <=> $b->current_count );
+			}
+		);
+
+		// Slice top 30 sets for this page.
+		$paged_sets = array_slice( $translation_sets, 0, GP::$translation_set->per_page );
+
+		$prepared_sets = array();
+
+		foreach ( $paged_sets as $set ) {
+
+			$prepared_set = array(
+				'name'   => $set->name,
+				'locale' => $set->locale,
+				'slug'   => $set->slug,
+			);
+
+			$prepared_set['_links'] = array(
+				'self' => array(
+					array(
+						'href' => rest_url(
+							sprintf(
+								'%s/%s/%s/%s/%s',
+								$this->namespace,
+								$this->rest_base,
+								gp_rest_encode_project_path( $project->path ),
+								rawurlencode( $set->locale ),
+								rawurlencode( $set->slug )
+							)
+						)
+					),
+				),
+			);
+
+			$prepared_sets[] = $prepared_set;
+		}
+
+		return $prepared_sets;
+
+	}
+
+	/**
+	 * 
+	 * Prepare sub-projects for response. 
+	 *
+	 * @param GP_Project $project
+	 * @param WP_REST_Request $request
+	 * @return array
+	 */
+	protected function prepare_subprojects_for_response( $project, $request ) {
+		$sub_projects = $project->sub_projects();
+
+		$items = array();
+		foreach ( $sub_projects as $sub_project ) {
+			$prepared_project = array(
+				'id'   => (int) $sub_project->id,
+				'slug' => $sub_project->path,
+				'name' => $sub_project->name,
+			);
+			$prepared_project['_links'] = array(
+				'self' => array(
+					array(
+						'href' => rest_url(
+							sprintf(
+								'%s/%s/%s',
+								$this->namespace,
+								$this->rest_base,
+								rawurlencode( $sub_project->path ),
+							)
+						),
+					),
+				),
+			);
+			$items[] = $prepared_project;
+		}
+
+		return $items;
+	}
+	/**
+	 * Create a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+
+		if ( isset( $request['path'] ) ) {
+			$existing_project = GP::$project->by_path_or_id( $request['path'] );
+
+			if ( $existing_project instanceof GP_Project && $existing_project->path === $request['path'] ) {
+				return new WP_Error( "gp_rest_{$this->thing_type}_already_exists", __( 'Resource already exists with this path.', 'glotpress' ), array( 'status' => 400 ) );
+			}
+		}
+
+		$response = parent::create_item( $request );
+
+		$data = $response->get_data();
+
+		$path = $data['path'] ?? '';
+
+		if ( $path ) {
+			$path = gp_rest_encode_project_path( $path );
+			$response->header( 'Location', rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $path ) ) );
+		}
+
+		return $response;		
+	}
+
+	/**
+	 * Prepare a single product for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_Error|WP_Project     $project Project object or WP_Error if not valid.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$project = $this->get_resource( $request );
+
+		if ( is_wp_error( $project ) ) {
+			$project = new GP_Project();
+		}
+
+		$args = array();
+
+		// Project title.
+		if ( isset( $request['name'] ) ) {
+			$args['name'] = wp_filter_post_kses( $request['name'] );
+		} elseif ( ! $project->id ) {
+			return new WP_Error( "gp_rest_{$this->thing_type}_missing_name", __( 'Resource name is required.', 'glotpress' ), array( 'status' => 400 ) );
+		}
+
+		// Project parent ID.
+		if ( isset( $request['parent_project_id'] ) ) {
+			$args['parent_project_id'] = intval( $request['parent_project_id'] );
+
+			$parent_project = GP::$project->get( $args['parent_project_id'] );
+
+			if ( ! $parent_project || ! $parent_project instanceof GP_Project ) {
+				return new WP_Error( "gp_rest_{$this->thing_type}_nonexistant_parent_id", __( 'That parent resource does not exist.', 'glotpress' ), array( 'status' => 400 ) );
+			}
+
+			if ( $project->id && $project->id === $args['parent_project_id'] ) {
+				return new WP_Error( "gp_rest_{$this->thing_type}_invalid_parent_id", __( 'Resource cannot be a parent of itself.', 'glotpress' ), array( 'status' => 400 ) );
+			}
+
+		}
+
+		// Project description.
+		if ( isset( $request['description'] ) ) {
+			$args['description'] = wp_filter_post_kses( $request['description'] );
+		}
+
+		// Project status.
+		if ( isset( $request['active'] ) ) {
+			$args['active'] = boolval( $request['active'] ) ? 1 : 0;
+		} elseif ( ! $project->id ) {
+			$args['active'] = 1; // Default to active on create.
+		}
+
+		// Project slug.
+		if ( isset( $request['slug'] ) ) {
+			$args['slug'] = sanitize_title( $request['slug'] );
+		}
+
+		// Source template.
+		if ( isset( $request['source_url_template'] ) ) {
+			$args['source_url_template'] = sanitize_url( $request['source_url_template'] );
+		}
+
+		$project->set_fields( $args );
+
+		/**
+		 * Filter the project object before it is inserted or updated in the database.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the post being
+		 * prepared for insertion.
+		 *
+		 * @param GP_Project       $project An object representing a single item prepared
+		 *                                       for inserting or updating the database.
+		 * @param WP_REST_Request $request       Request object.
+		 */
+		return apply_filters( "gp_rest_pre_insert_{$this->thing_type}", $project, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param GP_Project      $project   Project object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $project, $request ) {
+		$links = parent::prepare_links( $project, $request );
+
+		$links['self'] = array(
+			'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $project->path ) ),
+		);
+
+		if ( $project->parent_project_id ) {
+			$parent_project = GP::$project->get( $project->parent_project_id );
+			if ( $parent_project ) {
+				$links['up'] = array(
+					array(
+						'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, rawurlencode( $parent_project->path ) ) ),
+					),
+				);
+			}
+		}
+
+		return $links;
+	}
+
+	/**
+	 * Get the project's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		if ( isset( $this->schema ) ) {
+			return $this->schema;
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->thing_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the project.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'detail' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Project name.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'slug' => array(
+					'description' => __( 'Project slug.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'active' => array(
+					'description' => __( 'Whether the project is active.', 'glotpress' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'description' => array(
+					'description' => __( 'Project description.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'parent_project_id' => array(
+					'description' => __( 'Parent project ID.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'source_url' => array(
+					'description' => __( 'Source URL template.', 'glotpress' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit', 'detail' ),
+				),
+				'sub_projects' => array(
+					'description' => __( 'Sub-projects of this project.', 'glotpress' ),
+					'type'        => 'array',
+					'context'     => array( 'detail' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Project ID.', 'glotpress' ),
+								'type'        => 'integer',
+								'context'     => array( 'detail' ),
+							),
+							'slug' => array(
+								'description' => __( 'Project slug.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+							'name' => array(
+								'description' => __( 'Project name.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+						),
+					),
+				),
+				'sets' => array(
+					'description' => __( 'Translation sets. On the product detail this is limited to top 30 sets. For full list see the project/{project}/sets endpoint', 'glotpress' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'detail' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name' => array(
+								'description' => __( 'Set name.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+							'locale' => array(
+								'description' => __( 'Set locale.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+							'slug' => array(
+								'description' => __( 'Set slug.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+							'wp_locale' => array(
+								'description' => __( 'WordPress locale.', 'glotpress' ),
+								'type'        => 'string',
+								'context'     => array( 'detail' ),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->schema;
+	}
+
+	/**
+	 * Get all the Query vars that are allowed for the API request.
+	 *
+	 * @return array
+	 */
+	protected function get_allowed_query_vars() {
+		$valid_vars = array(
+			'id',
+			'name',
+			'path',
+			'parent_project_id'
+		);
+
+		return array_merge( parent::get_allowed_query_vars(), $valid_vars );
+	}
+
+	/**
+	 * Get the query params for collections of projects.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		$params = parent::get_collection_params();
+
+		$params['context']['default'] = 'view';
+
+		$params['parent_project_id'] = array(
+			'description'       => __( 'Limit result set to specific parent project IDs.', 'glotpress' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type'          => 'integer',
+			),
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+
+		return $params;
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/translation-sets.php
+++ b/gp-includes/rest-api/routes/v1/translation-sets.php
@@ -1,0 +1,497 @@
+<?php
+/**
+ * REST API Translation sets controller
+ *
+ * Handles requests to the /projects/{$project}/sets endpoint.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Translation sets controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_Rest_Translation_Sets_V1_Controller extends GP_REST_CRUD_Controller {
+
+private $counter = 1;
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'projects';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'translation-set';
+
+	/**
+	 * Register the routes for projects.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<project>[^/]+)/sets', array(
+			'args' => array(
+				'project' => array(
+					'description' => __( 'Project ID or path.', 'glotpress' ),
+					'type'        => 'string',
+					'required'    => true,
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => array_merge(
+					$this->get_collection_params(),
+					array(
+						'project' => array(
+							'description' => __( 'Project ID or path.', 'glotpress' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+					),
+				),
+			),
+			array(
+				'methods'         => WP_REST_Server::CREATABLE,
+				'callback'        => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+					'name' => array(
+						'description' => __( 'Translation set name.', 'glotpress' ),
+						'required'    => true,
+						'type'        => 'string',
+					),
+					'locale' => array(
+						'description' => __( 'Locale.', 'glotpress' ),
+						'required'    => true,
+						'type'        => 'string',
+					),
+				) ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<project>[^/]+)/sets/(?P<locale>[^/]+)/(?P<slug>[^/]+)',
+			array(
+				'args' => array(
+					'project' => array(
+						'description' => __( 'Project ID or path.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'locale' => array(
+						'description' => __( 'Locale slug.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'slug' => array(
+						'description' => __( 'Translation set slug.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+
+				// GET /projects/{project}/sets/{locale}/{slug}
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+
+				// PUT /projects/{project}/sets/{locale}/{slug}
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => array(
+						'name' => array(
+							'type'     => 'string',
+							'required' => false,
+						),
+						'active' => array(
+							'type'     => 'boolean',
+							'required' => false,
+						),
+					),
+				),
+
+				// DELETE /projects/{project}/sets/{locale}/{slug}
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				),
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieve the desired resource from the request.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return GP_Project|WP_Error The requested resource, or WP_Error if not found.
+	 */
+	protected function get_resource( $request ) {
+		
+		// Static cache persists across multiple calls within the same request.
+		static $cache = array();
+		
+		$original_params = $request->get_url_params();
+		
+		// Create a cache key from the relevant parameters.
+		$cache_key = md5( serialize( array(
+			'project' => $original_params['project'] ?? null,
+			'slug'    => $original_params['slug'] ?? null,
+			'locale'  => $original_params['locale'] ?? null,
+		) ) );
+		
+		// Return cached result if available.
+		if ( isset( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+
+		$project = gp_rest_get_project( $request );
+
+		if ( is_wp_error( $project ) ) {
+			return $project;
+		}
+
+		$translation_set = new GP_Translation_Set(
+			array( 
+				'project_id' => $project->id,
+			)
+		);
+
+		if ( ! empty( $original_params['slug'] ) && ! empty( $original_params['locale'] ) ) {
+
+			$locale = GP_Locales::by_slug( $original_params['locale'] );
+
+			if ( ! $locale ) {
+				return new WP_Error( 'gp_rest_locale_invalid_id', __( 'Locale not found.', 'glotpress' ) );
+			}
+
+			$existing_set = GP::$translation_set->find_one(
+				array( 
+					'slug'       => $original_params['slug'],
+					'project_id' => $project->id,
+					'locale'     => $locale->slug,
+				)
+			);
+
+			if ( $existing_set ) {
+				$translation_set = $existing_set;
+			}
+		}
+
+		// Store in cache before returning.
+    	$cache[ $cache_key ] = $translation_set;
+
+		return $translation_set;
+	}
+
+
+	/**
+	 * Prepare a single set output for response.
+	 *
+	 * @param GP_Translation_Set $set Translation set object.
+	 * @param WP_REST_Request    $request Request object.
+	 * @return WP_REST_Response  $data
+	 */
+	public function prepare_item_for_response( $set, $request ) {
+
+		$context = $request['context'] ?: 'view';
+
+		$locale = GP_Locales::by_slug( $set->locale );
+
+		$data = array(
+			'name'               => $set->name,
+			'locale'             => $set->locale,
+			'slug'               => $set->slug,
+			'wp_locale'          => $locale->wp_locale,
+			'all_count'          => $set->all_count(),
+			'translated_count'   => $set->current_count(),
+			'untranslated_count' => $set->untranslated_count(),
+			'fuzzy_count'        => $set->fuzzy_count(),
+			'waiting_count'      => $set->waiting_count(),
+			'percent_translated' => $set->percent_translated(),
+			'last_modified'      => $set->current_count() ? $set->last_modified() : false,
+		);
+
+		$data     = $this->add_additional_fields_to_object( $data, $request );	
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $set, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response The response object.
+		 * @param GP_Translation_Set $set      Translation set object.
+		 * @param WP_REST_Request    $request  Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $set, $request );
+	}
+
+	/**
+	 * Prepare a single set for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return GP_Translation_Set     $set Translation set object.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$set = $this->get_resource( $request );
+
+		if ( is_wp_error( $set ) ) {
+			return $set;
+		}
+
+		$args = array();
+
+		// Set locale.
+		if ( isset( $request['locale'] ) ) {
+			$args['locale'] = sanitize_locale_name( $request['locale'] );
+		}
+
+		// Set name.
+		if ( isset( $request['name'] ) ) {
+			$args['name'] = wp_filter_post_kses( $request['name'] );
+		}
+
+		// Set slug.
+		if ( isset( $request['slug'] ) ) {
+			$args['slug'] = sanitize_title( $request['slug'] );
+		} elseif ( ! $set->slug ) {
+			$args['slug'] = 'default';
+		}
+
+		if ( isset( $request['active'] ) ) {
+			$args['active'] = (bool) $request['active'];
+		}
+
+		$set->set_fields( $args );
+
+		/**
+		 * Filter the set object before it is inserted or updated in the database.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the post being
+		 * prepared for insertion.
+		 *
+		 * @param GP_Translation_Set       $set An object representing a single item prepared
+		 *                                       for inserting or updating the database.
+		 * @param WP_REST_Request $request       Request object.
+		 */
+		return apply_filters( "gp_rest_pre_insert_{$this->thing_type}", $set, $request );
+	}
+
+	/**
+	 * Get a project's translation sets.
+	 * 
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+
+		$args = $this->prepare_items_query( $request->get_params(), $request );
+		$project = gp_rest_get_project( $request );
+
+		if ( ! $project || ! $project instanceof GP_Project ) {
+			return new WP_Error( "gp_rest_project_invalid_id", __( 'Invalid project ID.', 'glotpress' ), array( 'status' => 400 ) );
+		}
+
+		$translation_sets = GP::$translation_set->by_project_id( $project->id );
+
+		// Slice sets for this page.
+		$paged_sets = array_slice( $translation_sets, ( $args['page'] - 1) * $args['per_page'], $args['per_page'] );
+
+		$items = array();
+		foreach ( $paged_sets as $set ) {
+			$data = $this->prepare_item_for_response( $set, $request );
+			$items[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$response = rest_ensure_response( $data );
+
+		$total_sets = count( $translation_sets );
+
+		$page           = (int) $args['page'];
+		$max_pages      = ceil( (int) $total_sets / (int) $args['per_page'] );
+
+		$response = rest_ensure_response( $items );
+
+		$response->header( 'X-WP-Total', (int) $total_sets );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$request_params = $request->get_query_params();
+
+		$base = add_query_arg( $request_params, rest_url( sprintf( '/%s/%s/%s/sets', $this->namespace, $this->rest_base, $request['project'] ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param GP_Translation_Set $set     Project object.
+	 * @param WP_REST_Request    $request Request object.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $set, $request ) {
+		$links = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s/sets/%s/%s', $this->namespace, $this->rest_base, $request['project'], $set->locale, $set->slug ) ),
+			),
+			'translations' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s/sets/%s/%s/translations', $this->namespace, $this->rest_base, $request['project'], $set->locale, $set->slug ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s/sets', $this->namespace, $this->rest_base, $request['project'] ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the project's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		if ( isset( $this->schema ) ) {
+			return $this->schema;
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->thing_type,
+			'type'       => 'object',
+			'properties' => array(
+				'name' => array(
+					'description' => __( 'Set name.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'locale' => array(
+					'description' => __( 'Set locale.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'slug' => array(
+					'description' => __( 'Set slug.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'wp_locale' => array(
+					'description' => __( 'WordPress locale.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'all_count' => array(
+					'description' => __( 'Number of all translatable strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'translated_count' => array(
+					'description' => __( 'Number of translated strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'untranslated_count' => array(
+					'description' => __( 'Number of untranslated strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'fuzzy_count' => array(
+					'description' => __( 'Number of fuzzy strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'waiting_count' => array(
+					'description' => __( 'Number of waiting strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'percent_translated' => array(
+					'description' => __( 'Number of waiting strings.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit', 'view' ),
+				),
+				'last_modified' => array(
+					'description' => __( 'Date set last modified.', 'glotpress' ),
+					'type'        => 'datetime',
+					'context'     => array( 'edit', 'view' ),
+				),
+			),
+		);
+
+		return $this->schema;
+	}
+
+
+	/**
+	 * Get the query params for collections of projects.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		$params = parent::get_collection_params();
+
+		$params['context']['default'] = 'view';
+
+		$params['parent_project_id'] = array(
+			'description'       => __( 'Limit result set to specific parent project IDs.', 'glotpress' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type'          => 'integer',
+			),
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+
+		return $params;
+	}
+
+}

--- a/gp-includes/rest-api/routes/v1/translations.php
+++ b/gp-includes/rest-api/routes/v1/translations.php
@@ -1,0 +1,940 @@
+<?php
+/**
+ * REST API Translations controller
+ *
+ * Handles requests to the /projects/{$project}/sets/{$set}/translations endpoint.
+ *
+ * @package GlotPress\RestApi
+ * @since   5.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Translations controller class.
+ *
+ * @package GlotPress\RestApi
+ * @extends GP_REST_CRUD_Controller
+ */
+class GP_Rest_Translations_V1_Controller extends GP_REST_CRUD_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'gp/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'projects';
+
+	/**
+	 * Object type.
+	 *
+	 * @var string
+	 */
+	protected $thing_type = 'translation';
+
+	/**
+	 * Register the routes for translations.
+	 */
+	public function register_routes() {
+		register_rest_route( 
+			$this->namespace,
+			'/' . $this->rest_base .
+			'/(?P<project>[^/]+)/sets/(?P<locale>[^/]+)/(?P<set>[^/]+)/translations',
+			array(
+				'args' => array(
+					'project' => array(
+						'description' => __( 'Unique identifier for the project (ID or slug).', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'locale' => array(
+						'description' => __( 'Unique identifier for the locale.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'set' => array(
+						'description' => __( 'Unique identifier for the translation set.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+						'original_id' => array(
+							'description' => __( 'Original translation ID.', 'glotpress' ),
+							'required'    => true,
+							'type'        => 'integer',
+						),
+					) ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route( 
+			$this->namespace,
+			'/' . $this->rest_base .
+			'/(?P<project>[^/]+)/sets/(?P<locale>[^/]+)/(?P<set>[^/]+)/translations/(?P<original_id>\d+)',
+			array(
+				'args' => array(
+					'project' => array(
+						'description' => __( 'Unique identifier for the project (ID or slug).', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'locale' => array(
+						'description' => __( 'Unique identifier for the locale.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'set' => array(
+						'description' => __( 'Unique identifier for the translation set.', 'glotpress' ),
+						'type'        => 'string',
+						'required'    => true,
+					),
+					'original_id' => array(
+						'description' => __( 'Original string ID.', 'glotpress' ),
+						'type'        => 'integer',
+						'required'    => false,
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'         => WP_REST_Server::EDITABLE,
+					'callback'        => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), array(
+						'original_id' => array(
+							'description' => __( 'Original string ID.', 'glotpress' ),
+							'required'    => true,
+							'type'        => 'integer',
+						),
+						'status' => array(
+							'required'          => false,
+							'type'              => 'string',
+							'default'           => 'current',
+							'enum'              => array( 'current', 'waiting', 'rejected', 'fuzzy' ),
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					) ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieve the desired resource from the request.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	protected function get_resource( $request ) {
+
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translation ) = $objects;
+	
+		return $translation;
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! GP::$permission->current_user_can( 'read', 'translation-set' ) ) {
+			return new WP_Error( 'gp_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to read an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set ) = $objects;
+
+		if ( ! $translation_set || ! GP::$permission->current_user_can( 'read', 'translation-set', $translation_set->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+	
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to update an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set ) = $objects;
+
+		if ( ! $translation_set || ! GP::$permission->current_user_can( 'write', 'translation-set', $translation_set->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_edit', __( 'Sorry, you are not allowed to edit this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to delete an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set ) = $objects;
+
+		if ( ! $translation_set || ! GP::$permission->current_user_can( 'delete', 'translation-set', $translation_set->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_delete', __( 'Sorry, you are not allowed to delete this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves item from the collection.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translations ) = $objects;
+
+		$data = array();
+		foreach ( $translations as $entry ) {
+			$translation = $this->prepare_item_for_response( $entry, $request );
+			$translation = $this->prepare_response_for_collection( $translation );
+			$data[]   = $translation;
+		}
+
+		$response = rest_ensure_response( $data );
+
+		$total_strings  = GP::$translation->found_rows;
+		error_log('found X strings: ' . $total_strings);
+
+		$page           = (int) $request['page'];
+		$max_pages      = ceil( $total_strings / (int) $request['per_page'] );
+
+		$response->header( 'X-WP-Total', (int) $total_strings );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$request_params = $request->get_query_params();
+
+		$base = add_query_arg( $request_params, rest_url( sprintf( '/%s/%s/%s/%s/%s', $this->namespace, $this->rest_base, $request['project'], $request['locale'], $request['set'] ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Get relevant objects from request.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @param bool $force Whether to force re-fetching the objects instead of using cache.
+	 * @return array|WP_Error Array of [GP_Project, GP_Translation_Set, GP_Translation] or WP_Error
+	 */
+	protected function get_objects( $request, $force = false ) {
+		// Static cache persists across multiple calls within the same request.
+		static $cache = array();
+		
+		$params = $request->get_params();
+		
+		// Create a cache key from the relevant parameters.
+		$cache_key = md5( serialize( array(
+			'project'     => $params['project'] ?? 0,
+			'locale'      => $params['locale'] ?? '',
+			'set'         => $params['set'] ?? '',
+			'original_id' => $params['original_id'] ?? 0,
+		) ) );
+		
+		// Return cached result if available.
+		if ( ! $force && isset( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+		
+		$project = GP::$project->by_path_or_id( $params['project'] ?? 0 );
+		if ( ! $project || ! $project instanceof GP_Project ) {
+			return new WP_Error( "gp_rest_{$this->thing_type}_invalid_id", __( 'Invalid project ID.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+		
+		$locale = GP_Locales::by_slug( $params['locale'] ?? '' );
+		if ( ! $locale ) {
+			return new WP_Error( 'gp_rest_locale_invalid_id', __( 'Locale not found.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+		
+		$translation_set = GP::$translation_set->find_one(
+			array( 
+				'slug'       => $params['set'] ?? '',
+				'project_id' => $project->id,
+				'locale'     => $locale->slug,
+			)
+		);
+		
+		if ( ! $translation_set ) {
+			return new WP_Error( 'gp_rest_translation_set_invalid_id', __( 'Translation set not found.', 'glotpress' ), array( 'status' => 404 )  );
+		}
+		
+		$args = $this->prepare_items_query( $params, $request );
+
+		$original_id = (int) ( $params['original_id'] ?? 0 );
+		if ( $original_id && ! GP::$original->get( (int) $params['original_id'] ) ) {
+			return new WP_Error( 'gp_rest_translation_invalid_original_id', __( 'Original ID not found.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+
+		$args    = $this->prepare_items_query( $params, $request );
+		$filters = array();
+
+		// When reading we allow filtering by status and translated_by.
+		if ( WP_REST_Server::READABLE === $request->get_method() ) {
+			if ( ! empty( $args['status'] ) ) {
+				$filters['status'] = $args['status'];
+			}
+			if ( ! empty( $args['translated_by'] ) ) {
+				$filters['user_login'] = $args['translated_by'];
+			}
+		}
+
+		if ( ! empty( $args['id'] ) ) {
+			$filters['translation_id'] = (int) $args['id'];
+		}
+
+		if ( $original_id ) {
+			$filters['original_id'] = $original_id;
+		}
+
+		$translations = GP::$translation->for_translation(
+			$project,
+			$translation_set,
+			$args['page'] ?? 'no-limit',
+			$filters,
+			array( $args['orderby'] ?? 'id' ),
+			$args['per_page'] ?? ''
+		);
+
+		if ( empty( $translations ) ) {
+			return new WP_Error( 'gp_rest_translation_not_found', __( 'Translation not found.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+
+		$result = array(
+			$project,
+			$translation_set,
+			$translations,
+			$locale,
+		);
+		
+		// Store in cache before returning.
+		$cache[ $cache_key ] = $result;
+		
+		return $result;
+	}
+
+	/**
+	 * Retrieves item from the collection.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translations ) = $objects;
+
+		if ( ! GP::$permission->current_user_can( 'read', $this->thing_type, $translation_set->id ) ) {
+			return new WP_Error( 'gp_rest_cannot_view', __( 'Sorry, you are not allowed to read this resource.', 'glotpress' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		$data = array();
+		foreach ( $translations as $entry ) {
+			$translation = $this->prepare_item_for_response( $entry, $request );
+			$translation = $this->prepare_response_for_collection( $translation );
+			$data[]   = $translation;
+		}
+
+		return rest_ensure_response( $data );
+
+	}
+
+	/**
+	 * Prepare a single translation output for response.
+	 *
+	 * @param Translation_Entry $translation Translation object.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $translation, $request ) {
+
+		$context = $request['context'] ?? 'view';
+
+		$data = array(
+			'id'            => (int) $translation->id,
+			'original_id'   => (int) $translation->original_id,
+			'priority'      => gp_array_get( GP::$original->get_static( 'priorities' ), $translation->priority ),
+			'status'        => display_status( $translation->translation_status ),
+			'date_added'    => $translation->date_added ?? '',
+			'date_modified' => $translation->date_modified ?? '',
+			'translated_by' => isset( $translation->user ) ? $translation->user->user_login: '',
+			'singular'      => $translation->singular ?? '',
+			'plural'        => $translation->plural ?? '',
+			'context'       => $translation->context ?? '',
+			'translations'  => $translation->translations,
+		);
+		
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $translation, $request ) );
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the item being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response    The response object.
+		 * @param Translation_Entry  $translation Translation object.
+		 * @param WP_REST_Request    $request     Request object.
+		 */
+		return apply_filters( "gp_rest_prepare_{$this->thing_type}", $response, $translation, $request );
+	}
+
+	/**
+	 * Create a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translation ) = $objects;
+
+		if ( $translation->id ) {
+			/* translators: %s: object type */
+			return new WP_Error( "gp_rest_{$this->thing_type}_exists", sprintf( __( 'Cannot create existing %s.', 'glotpress' ), $this->thing_type ), array( 'status' => 400 ) );
+		}
+
+		$translation = $this->save_translation( $request );
+
+		if ( is_wp_error( $translation ) ) {
+			return $translation;
+		}
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param GP_Translation $translation   Project object.
+		 * @param WP_REST_Request    $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "gp_rest_insert_{$this->thing_type}", $translation, $request, false );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $translation, $request );
+		return rest_ensure_response( $response );
+
+	}
+
+	/**
+	 * Update a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		global $wpdb;
+		$wpdb->hide_errors();
+
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translation ) = $objects;
+
+		// Return a duplicate translation if one exists.
+		$duplicate = $this->check_for_duplicate_translation( $request );
+
+		if ( is_wp_error( $duplicate ) ) {
+			$error_data = $duplicate->get_error_data();
+			if ( isset( $error_data['duplicate'] ) ) {
+				$response = $this->prepare_item_for_response( $error_data['duplicate'], $request );
+				return rest_ensure_response( $response );
+			}			
+		}
+
+		// Proceed to create a new translation entry.
+		$translation = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $translation ) ) {
+			return $translation;
+		}
+
+		if ( ! $translation->save() ) {
+			/* translators: 1: object type, 2: database error message */
+			return new WP_Error( "gp_rest_{$this->thing_type}_failed_to_update", sprintf( __( '%1$s could not be updated. %2$s', 'glotpress' ), ucfirst($this->thing_type), $wpdb->last_error ), array( 'status' => 400 ) );
+		}
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param GP_Translation        $translation     Thing object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "gp_rest_insert_{$this->thing_type}", $translation, $request, false );
+		$request->set_param( 'context', 'edit' );
+
+		// Response returns Translation_Entry object, so we need to get the new resource.
+		$translations = GP::$translation->for_translation(
+			$project,
+			$translation_set,
+			'no-limit',
+			array(
+				'translation_id' => $translation->id
+			),
+			array()
+		);
+
+		if ( empty( $translations ) ) {
+			return new WP_Error( 'gp_rest_translation_not_found', __( 'Translation not found.', 'glotpress' ), array( 'status' => 404 ) );
+		}
+
+		$response = $this->prepare_item_for_response( $translations[0], $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Check for duplicate translations.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|true
+	 */
+	protected function check_for_duplicate_translation( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translations_ignore, $locale ) = $objects;
+
+		$translations = $request['translations'] ?? [];
+		$original_id = (int) $request['original_id'];
+
+		if ( ! empty( $translations ) && $original_id ) {
+			// Check this is not a duplicate of an existing current or waiting translation.
+			$existing_translations = GP::$translation->for_translation(
+				$project,
+				$translation_set,
+				'no-limit',
+				array(
+					'original_id' => $original_id,
+					'status'      => 'current_or_waiting',
+				),
+				array()
+			);
+
+			foreach ( $existing_translations as $e ) {
+				if ( array_pad( $translations, $locale->nplurals, null ) == $e->translations ) {
+					return new WP_Error( 'gp_rest_duplicate_translation', __( 'Identical current or waiting translation already exists.', 'glotpress' ), array( 'status' => 400, 'duplicate' => $e ) );
+				}
+			}
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Prepare a single product for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return GP_Translation $translation Translation object.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$objects = $this->get_objects( $request );
+
+		if ( is_wp_error( $objects ) ) {
+			return $objects;
+		}
+
+		list( $project, $translation_set, $translation, $locale ) = $objects;
+
+		$data = array(
+			'original_id'        => (int) $request['original_id'],
+			'translation_set_id' => (int) $translation_set->id,
+			'user_id'            => get_current_user_id(),
+			'priority'           => gp_array_get( GP::$original->get_static( 'priorities' ), $request['priority'], 5 ),
+			'status'             => $this->prepare_translation_status( $request['status'] ?? 'current', $translation_set, $project ),
+		);
+
+		// Normalize plural translations.
+		$nplurals = GP::$translation->get_static( 'number_of_plural_translations' );
+
+		$translations = (array) $request['translations'];
+
+		foreach ( range( 0, $nplurals - 1 ) as $i ) {
+			if ( isset( $translations[ $i ] ) ) {
+				$data[ "translation_$i" ] = $translations[ $i ];
+			}
+		}
+
+		$original         = GP::$original->get( $data['original_id'] );
+		$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );
+
+		// Validation.
+		$errors           = GP::$translation_errors->check( $original, $translations, $locale );
+
+		if ( is_array( $errors ) ) {
+			return new WP_Error( 'gp_rest_invalid_translation', __( 'The translation contains errors.', 'glotpress' ), array( 'status' => 400, 'errors' => $errors ) );
+		}
+		
+		if ( $request['id'] ) {
+			$translation = GP::$translation->get( $request['id'] );
+			$translation->set_fields( $data );
+		} else {
+			$translation = new GP_Translation( $data );
+		}
+
+		/**
+		 * Filter the project object before it is inserted or updated in the database.
+		 *
+		 * The dynamic portion of the hook name, $this->thing_type, refers to thing_type of the post being
+		 * prepared for insertion.
+		 *
+		 * @param GP_Translation       $translation An object representing a single item prepared
+		 *                                       for inserting or updating the database.
+		 * @param WP_REST_Request $request       Request object.
+		 */
+		return apply_filters( "gp_rest_pre_insert_translation", $translation, $request );
+	}
+
+	/**
+	 * Prepare translation status.
+	 *
+	 * @param string $status The requested status
+	 * @param GP_Translation_Set $translation_set The Translation Set object.
+	 * @param GP_Project $project The Project object.
+	 * @return string The determined status.
+	 */
+	private function prepare_translation_status( $requested_status, $translation_set, $project ) {
+		$can_approve = GP::$permission->current_user_can( 'approve', 'translation-set', $translation_set->id ) || 
+					GP::$permission->current_user_can( 'write', 'project', $project->id );
+
+		// Privileged users can set any valid status.
+		if ( $can_approve ) {
+			$valid_statuses = array( 'current', 'waiting', 'fuzzy', 'rejected', 'old' );
+			return in_array( $requested_status, $valid_statuses, true ) ? $requested_status : 'waiting';
+		}
+
+		// Regular users can only set 'fuzzy' or 'waiting'
+		if ( 'fuzzy' === $requested_status ) {
+			return 'fuzzy';
+		}
+
+		return 'waiting';
+	}
+
+	/**
+	 * Delete a single item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		global $wpdb;
+
+		list( $project, $translation_set, $translation_entry ) = $this->get_objects( $request );
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $translation_entry, $request );
+
+		// Get the translation object before deletion.
+		$translation = GP::$translation->get( $translation_entry->id );
+
+		// Delete the translation.
+		if ( ! GP::$translation->delete_all( array( 'id' => $translation_entry->id ) ) ) {
+			/* translators: %s: object type */
+			return new WP_Error( 'gp_rest_cannot_delete', sprintf( __( 'The translation cannot be deleted. %s', 'glotpress' ), $this->thing_type, $wpdb->last_error ), array( 'status' => 500 ) );
+		}
+
+		/**
+		 * Fires after a single item is deleted or trashed via the REST API.
+		 *
+		 * @param GP_Translation   $translation The deleted translation.
+		 * @param WP_REST_Response $response    The response data.
+		 * @param WP_REST_Request  $request     The request sent to the API.
+		 */
+		do_action( "gp_rest_delete_{$this->thing_type}", $translation, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param Translation_Entry  $translation Translation object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $translation, $request ) {
+		$links = parent::prepare_links( $translation, $request );
+
+		$links['self']['href'] = rest_url( sprintf( '/%s/%s/%s/sets/%s/%s/translations/%d', $this->namespace, $this->rest_base, rawurlencode( $request['project'] ), rawurlencode( $request['locale'] ), rawurlencode( $request['set'] ), $translation->original_id ) );
+		$links['collection']['href'] = rest_url( sprintf( '/%s/%s/%s/sets/%s/%s/translations', $this->namespace, $this->rest_base, rawurlencode( $request['project'] ), rawurlencode( $request['locale'] ), rawurlencode( $request['set'] ) ) );
+
+		if ( $request['id'] ) {
+			$links['self']['href'] = add_query_arg( 'id', (int) $request['id'], $links['self']['href'] );
+		}
+
+		return $links;
+	}
+
+	/**
+	 * Get the translation's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+ 		if ( isset( $this->schema ) ) {
+			return $this->schema;
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'translation',
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the translation.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'original_id' => array(
+					'description' => __( 'Original string ID this translation belongs to.', 'glotpress' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly' => true, 
+				),
+				'priority' => array(
+					'description' => __( 'Priority of the original string.', 'glotpress' ),
+					'type'        => 'string',
+					'enum'        => array( 'hidden', 'low', 'normal', 'high' ),
+					'default'     => 'normal',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'status' => array(
+					'description' => __( 'Translation status.', 'glotpress' ),
+					'type'        => 'string',
+					'enum'        => array( 'current', 'waiting', 'rejected', 'fuzzy' ),
+					'default'     => 'current',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_added' => array(
+					'description' => __( 'The date the translation was added, in site timezone.', 'glotpress' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => array( 'view' ),
+					'readonly' => true, 
+				),
+				'date_modified' => array(
+					'description' => __( 'The date the translation was last modified, in site timezone.', 'glotpress' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => array( 'view' ),
+					'readonly' => true, 
+				),
+				'translated_by' => array(
+					'description' => __( 'Username of the translator.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly' => true, 
+				),
+				'singular' => array(
+					'description' => __( 'Singular translation string.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly' => true, 
+				),
+				'plural' => array(
+					'description' => __( 'Plural translation string.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly' => true, 
+				),
+				'context' => array(
+					'description' => __( 'Translation context.', 'glotpress' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly' => true, 
+				),
+				'translations' => array(
+					'description' => __( 'Translated strings keyed by plural form.', 'glotpress' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'additionalProperties' => array(
+						'type' => 'string',
+					),
+				),
+			),
+		);
+
+		return $this->schema;
+	}
+
+	/**
+	 * Get all the Query vars that are allowed for the API request.
+	 *
+	 * @return array
+	 */
+	protected function get_allowed_query_vars() {
+		$valid_vars = array(		
+			'id',
+			'original_id',
+			'priority',
+			'status',
+			'translated_by',
+		);
+
+		return array_merge( parent::get_allowed_query_vars(), $valid_vars );
+	}
+
+	/**
+	 * Get the query params for collections of translations.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+
+		$params = parent::get_collection_params();
+
+		$params['status'] = array(
+			'description' => __( 'Filter translations by status.', 'glotpress' ),
+			'type'        => 'string',
+			'enum'        => array( 'current', 'waiting', 'fuzzy', 'rejected' ),
+		);
+
+		$params['priority'] = array(
+			'description' => __( 'Filter by priority.', 'glotpress' ),
+			'type'        => 'integer',
+		);
+
+		$params['original_id'] = array(
+			'description' => __( 'Filter by original string ID.', 'glotpress' ),
+			'type'        => 'integer',
+		);
+
+		$params['id'] = array(
+			'description' => __( 'Filter by translation ID.', 'glotpress' ),
+			'type'        => 'integer',
+		);
+
+		$params['translated_by'] = array(
+			'description' => __( 'Filter by Translator user name.', 'glotpress' ),
+			'type'        => 'string',	
+		);
+
+		$params['orderby'] = array(
+			'description' => __( 'Sort collection by object attribute.', 'glotpress' ),
+			'type'        => 'string',
+			'default'     => 'date_modified',
+			'enum'        => array( 'date_added', 'date_modified', 'priority', 'id' ),
+		);
+
+		return $params;
+	}
+
+}

--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -34,9 +34,7 @@ class GP_Route_Locale extends GP_Route_Main {
 
 	public function single( $locale_slug, $current_set_slug = 'default' ) {
 		$locale = GP_Locales::by_slug( $locale_slug );
-		$sets   = GP::$translation_set->by_locale( $locale_slug );
-
-		usort( $sets, array( $this, 'sort_sets_by_project_id' ) );
+		$sets   = GP::$translation_set->by_locale( $locale_slug, 'project_id' );
 
 		$projects_data   = $projects = $parents = $set_slugs = $set_list = array();
 		$locale_projects = wp_list_pluck( $sets, 'project_id' );

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -672,15 +672,18 @@ class GP_Thing {
 
 			foreach ( $conditions as $field => $sql_condition ) {
 				if ( is_array( $sql_condition ) ) {
-					$string_conditions[] = '(' . implode(
-						' OR ',
-						array_map(
-							function ( $cond ) use ( $field ) {
-								return "$field $cond";
-							},
-							$sql_condition
-						)
-					) . ')';
+					$values = array_map(
+						static function ( $cond ) {
+							return trim( preg_replace( '/^[=!<>]+/', '', $cond ) );
+						},
+						$sql_condition
+					);
+
+					$string_conditions[] = sprintf(
+						'%s IN (%s)',
+						$field,
+						implode( ', ', $values )
+					);
 				} else {
 					$string_conditions[] = "$field $sql_condition";
 				}

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -435,7 +435,16 @@ class GP_Thing {
 
 		$args = $this->prepare_fields_for_save( $args );
 
-		$update_res = $this->update( $args );
+		// Update if thing has id, create new if not.
+		if ( $this->id  ) {
+			$update_res = $this->update( $args );
+		} else {
+			$new_thing  = $this->create( $args );
+			$update_res = $new_thing ? true : false;
+			if ( $new_thing ) {
+				$args['id'] = $new_thing->id;
+			}
+		}
 
 		$this->set_fields( $args );
 

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -15,7 +15,6 @@
 class GP_Thing {
 
 	var $field_names        = array();
-	var $query_vars         = array();
 	var $non_db_field_names = array();
 	var $int_fields         = array();
 	var $validation_rules   = null;

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -682,6 +682,22 @@ class GP_Thing {
 		return $this->apply_default_conditions( $conditions );
 	}
 
+	/**
+	 * Generates SQL ORDER BY clause from provided ordering parameters.
+	 *
+	 * This method constructs an ORDER BY clause for SQL queries based on the provided
+	 * column name(s) and sort direction. If no order is specified, it falls back to
+	 * the object's default order.
+	 * 
+	 * @since 1.0.0
+	 *
+	 * @param string|array $order_by  The column name(s) to order by. Can be a string
+	 *                                 or an array of column names.
+	 * @param string       $order_how Optional. The sort direction (ASC or DESC).
+	 *                                 Ignored if $order_by is an array. Default empty string.
+	 *
+	 * @return string The SQL ORDER BY clause, or the default order if no valid order is provided.
+	 */
 	public function sql_from_order( $order_by, $order_how = '' ) {
 		if ( ! $order_by ) {
 			$order_by = '';
@@ -697,6 +713,23 @@ class GP_Thing {
 		return 'ORDER BY ' . $order_by . ( $order_how ? " $order_how" : '' );
 	}
 
+	/**
+	 * Builds a complete SQL SELECT query with conditions and ordering.
+	 *
+	 * This method generates a full SQL SELECT statement by combining the table name,
+	 * WHERE conditions, and ORDER BY clause. It uses the object's table property and
+	 * delegates to sql_from_conditions() and sql_from_order() for building the
+	 * respective SQL clauses.
+	 * 
+	 * @since 1.0.0
+	 *
+	 * @param mixed        $conditions The conditions to use in the WHERE clause.
+	 *                                  Format depends on sql_from_conditions() implementation.
+	 * @param string|array $order      Optional. The ordering parameters passed to sql_from_order().
+	 *                                  Default null.
+	 *
+	 * @return string The complete SQL SELECT query with optional WHERE and ORDER BY clauses.
+	 */
 	public function select_all_from_conditions_and_order( $conditions, $order = null ) {
 		$query          = "SELECT * FROM $this->table";
 		$conditions_sql = $this->sql_from_conditions( $conditions );

--- a/gp-includes/thing.php
+++ b/gp-includes/thing.php
@@ -15,6 +15,7 @@
 class GP_Thing {
 
 	var $field_names        = array();
+	var $query_vars         = array();
 	var $non_db_field_names = array();
 	var $int_fields         = array();
 	var $validation_rules   = null;
@@ -92,6 +93,27 @@ class GP_Thing {
 		$this->set_fields( $fields );
 
 		return $this;
+	}
+
+	/**
+	 * Count rows from the database based on conditions.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param array $conditions {
+	 *    Conditions to match.
+	 *    @type string $orderby   Optional. Column to order by. Default 'id'.
+	 *    @type string $order     Optional. Sort direction (ASC/DESC). Default 'asc'.
+	 *    @type int    $page      Optional. Page number for pagination. Default 1.
+	 *    @type int    $per_page  Optional. Number of results per page. Default $this->per_page.
+	 * 
+	 * }
+	 * @return int
+	 */
+	public function count( $conditions = array() ) {
+		global $wpdb;
+		$conditions['count'] = true;
+		return $wpdb->get_var( $this->select( $conditions ) );
 	}
 
 	/**
@@ -248,6 +270,25 @@ class GP_Thing {
 	 */
 	public function find( $conditions, $order = null ) {
 		return $this->find_many( $conditions, $order );
+	}
+
+	/**
+	 * Find rows from the database based on conditions.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param array $conditions {
+	 *    Conditions to match.
+	 *    @type string $orderby   Optional. Column to order by. Default 'id'.
+	 *    @type string $order     Optional. Sort direction (ASC/DESC). Default 'asc'.
+	 *    @type int    $page      Optional. Page number for pagination. Default 1.
+	 *    @type int    $per_page  Optional. Number of results per page. Default $this->per_page.
+	 * 
+	 * }
+	 * @return mixed
+	 */
+	public function find_some( $conditions = array() ) {
+		return $this->many( $this->select( $conditions ) );
 	}
 
 	/**
@@ -752,6 +793,61 @@ class GP_Thing {
 		if ( $order_sql ) {
 			$query .= " $order_sql";
 		}
+		return $query;
+	}
+
+	/**
+	 * Builds a complete SQL SELECT query.
+	 *
+	 * This method generates a full SQL SELECT statement by combining the table name,
+	 * WHERE conditions, ORDER BY clause and LIMIT/OFFSET. It uses the object's table property and
+	 * delegates to sql_from_conditions() and sql_from_order() and sql_limit_for_paging() for building the
+	 * respective SQL clauses.
+	 * 
+	 * @since 5.0.0
+	 *
+	 * @param mixed        $args The conditions to use
+	 *
+	 * @return string The complete SQL SELECT query with optional WHERE, LIMIT, and ORDER BY clauses.
+	 */
+	public function select( $args = array() ) {
+
+		$defaults = array(
+			'orderby'  => 'id',
+			'order'    => 'asc',
+			'page'     => 1,
+			'per_page' => $this->per_page,
+			'count'    => false,
+		);
+
+		// Merge defaults with provided args.
+		$args = wp_parse_args( $args, $defaults );
+
+		// Remove keys from $args, leaving only the extra where conditions.
+		$conditions = array_intersect_key( $args, array_flip($this->field_names) );
+
+		// Begin building the query string.
+		if ( $args['count'] ) {
+			$query = "SELECT COUNT(*) FROM $this->table";
+			$args['per_page'] = 'no-limit';
+			$args['page'] = 1;
+		} else {
+			$query = "SELECT * FROM $this->table";
+		}
+
+		$conditions_sql = $this->sql_from_conditions( $conditions );
+		if ( $conditions_sql ) {
+			$query .= " WHERE $conditions_sql";
+		}
+		$order_sql = $this->sql_from_order( $args['orderby'], $args['order'] );
+		if ( $order_sql ) {
+			$query .= " $order_sql";
+		}
+		$pagination_sql = $this->sql_limit_for_paging( $args['page'], $args['per_page'] );
+		if ( $pagination_sql ) {
+			$query .= " $pagination_sql";
+		}
+
 		return $query;
 	}
 

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -66,6 +66,36 @@ class GP_Project extends GP_Thing {
 	}
 
 	/**
+	 * Fetches the project by a path or ID.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param int|string $identifier A project path or the ID.
+	 * @return GP_Project|false The project on success or false on failure.
+	 */
+	public function by_path_or_id( $identifier ) {
+		/**
+		 * Filters the prefix for the locale glossary path.
+		 *
+		 * @since 2.3.1
+		 *
+		 * @param string $$locale_glossary_path_prefix Prefix for the locale glossary path.
+		 */
+		$locale_glossary_path_prefix = apply_filters( 'gp_locale_glossary_path_prefix', '/languages' );
+
+		if ( $locale_glossary_path_prefix === $identifier ) {
+			return GP::$glossary->get_locale_glossary_project();
+		}
+
+		$path = rawurlencode( urldecode( $identifier ) );
+		$path = str_replace( '%2F', '/', $path );
+		$path = str_replace( '%20', ' ', $path );
+		$path = trim( $path, '/' );
+
+		return $this->one( "SELECT * FROM $this->table WHERE path = %s OR id = %d", $path, $identifier );
+	}
+
+	/**
 	 * Fetches the project by ID or object.
 	 *
 	 * @since 2.3.0

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -198,12 +198,16 @@ class GP_Project extends GP_Thing {
 			$args['parent_project_id'] = $this->force_false_to_null( $args['parent_project_id'] );
 		}
 
-		if ( isset( $args['slug'] ) && ! $args['slug'] ) {
+		if ( empty( $args['slug'] ) && ! empty( $args['name'] ) ) {
 			$args['slug'] = $args['name'];
 		}
 
 		if ( ! empty( $args['slug'] ) ) {
 			$args['slug'] = gp_sanitize_slug( $args['slug'] );
+		}
+
+		if ( empty( $args['description'] ) ) {
+			$args['description'] = '';
 		}
 
 		if ( ( isset( $args['path'] ) && ! $args['path'] ) || ! isset( $args['path'] ) || is_null( $args['path'] ) ) {

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -235,12 +235,25 @@ class GP_Translation_Set extends GP_Thing {
 		return $result;
 	}
 
-	public function by_locale( $locale_slug ) {
-		return $this->many(
-			"SELECT * FROM $this->table
-			WHERE locale = %s",
-			$locale_slug
-		);
+	/**
+	 * Retrieves translation sets filtered by locale slug.
+	 *
+	 * @param string      $locale_slug The locale slug to filter translation sets by.
+	 * @param string|null $orderby     Optional. Field to order the results by. Default null.
+	 *
+	 * @return GP_Translation_Set[] Array of translation set objects.
+	 */
+	public function by_locale( $locale_slug, $orderby = null ) {
+		$sql = "SELECT * FROM $this->table
+			WHERE locale = %s";
+
+		$params = array( $locale_slug );
+
+		if ( $orderby && in_array( $orderby, $this->field_names, true ) ) {
+			$sql .= " ORDER BY %s";
+			$params[] = $orderby;
+		}
+		return $this->many( $sql, $params);
 	}
 
 	public function existing_locales() {

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -212,6 +212,24 @@ class GP_Translation extends GP_Thing {
 	}
 
 	/**
+	 * Saves an existing translation.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param mixed $args Values to update.
+	 * @return bool|null Null and false on failure, true on success.
+	 */
+	public function save( $args = null ) {
+		$update_res = parent::save( $args );
+
+		if ( $update_res ) {
+			gp_clean_translation_set_cache( $this->translation_set_id );
+		}
+
+		return $update_res;
+	}
+
+	/**
 	 * Normalizes an array with key-value pairs representing
 	 * a GP_Translation object.
 	 *

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -304,7 +304,21 @@ class GP_Translation extends GP_Thing {
 		return GP::$translation->for_translation( $project, $translation_set, 'no-limit', $filters ? $filters : array( 'status' => 'current_or_untranslated' ) );
 	}
 
-	public function for_translation( $project, $translation_set, $page, $filters = array(), $sort = array() ) {
+	/**
+	 * Retrieves translations for a translation set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GP_Project         $project         The project to retrieve translations for.
+	 * @param GP_Translation_Set $translation_set The translation set to retrieve translations for.
+	 * @param int|string         $page            The page number or 'no-limit' for all translations.
+	 * @param array              $filters         Optional. An array of filters to apply. Default empty array.
+	 * @param array              $sort            Optional. An array of sort settings. Default empty array.
+	 * @param int|null           $per_page        Optional. Number of translations per page. Default null. @since 5.0.0
+	 * @return array Array of Translation_Entry objects.
+	 */
+	public function for_translation( $project, $translation_set, $page, $filters = array(), $sort = array(), $per_page = null ) {
+
 		global $wpdb;
 
 		$locale = GP_Locales::by_slug( $translation_set->locale );
@@ -494,7 +508,10 @@ class GP_Translation extends GP_Thing {
 
 		$orderby = sprintf( $sort_by, $sort_how );
 
-		$limit = $this->sql_limit_for_paging( $page, $this->per_page );
+		if ( null === $per_page ) {
+			$per_page = $this->per_page;
+		}
+		$limit = $this->sql_limit_for_paging( (int) $page, (int) $per_page );
 
 		/**
 		 * Filters the 'for_translation' query SQL clauses.

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -103,6 +103,10 @@ require_once GP_PATH . GP_INC . 'routes/glossary.php';
 require_once GP_PATH . GP_INC . 'routes/glossary-entry.php';
 require_once GP_PATH . GP_INC . 'routes/locale.php';
 
+require_once GP_PATH . GP_INC . '/rest-api/rest-functions.php';
+require_once GP_PATH . GP_INC . '/rest-api/rest-api.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/crud.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';
 
 GP::$translation_warnings         = new GP_Translation_Warnings();
 GP::$builtin_translation_warnings = new GP_Builtin_Translation_Warnings();
@@ -112,6 +116,7 @@ GP::$builtin_translation_errors = new GP_Builtin_Translation_Errors();
 GP::$builtin_translation_errors->add_all( GP::$translation_errors );
 GP::$router  = new GP_Router();
 GP::$formats = array();
+GP::$rest  = new GP_REST_API();
 
 require_once GP_PATH . GP_INC . 'format.php';
 require_once GP_PATH . GP_INC . 'formats/format-android.php';

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -106,6 +106,7 @@ require_once GP_PATH . GP_INC . 'routes/locale.php';
 require_once GP_PATH . GP_INC . '/rest-api/rest-functions.php';
 require_once GP_PATH . GP_INC . '/rest-api/rest-api.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/crud.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/import.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';
 
 GP::$translation_warnings         = new GP_Translation_Warnings();

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -109,6 +109,7 @@ require_once GP_PATH . GP_INC . 'rest-api/routes/v1/crud.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/import.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/languages.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/translation-sets.php';
 
 GP::$translation_warnings         = new GP_Translation_Warnings();
 GP::$builtin_translation_warnings = new GP_Builtin_Translation_Warnings();

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -106,6 +106,7 @@ require_once GP_PATH . GP_INC . 'routes/locale.php';
 require_once GP_PATH . GP_INC . '/rest-api/rest-functions.php';
 require_once GP_PATH . GP_INC . '/rest-api/rest-api.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/crud.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/api.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/import.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/languages.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -107,6 +107,7 @@ require_once GP_PATH . GP_INC . '/rest-api/rest-functions.php';
 require_once GP_PATH . GP_INC . '/rest-api/rest-api.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/crud.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/import.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/languages.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';
 
 GP::$translation_warnings         = new GP_Translation_Warnings();

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -110,6 +110,7 @@ require_once GP_PATH . GP_INC . 'rest-api/routes/v1/import.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/languages.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/projects.php';
 require_once GP_PATH . GP_INC . 'rest-api/routes/v1/translation-sets.php';
+require_once GP_PATH . GP_INC . 'rest-api/routes/v1/translations.php';
 
 GP::$translation_warnings         = new GP_Translation_Warnings();
 GP::$builtin_translation_warnings = new GP_Builtin_Translation_Warnings();


### PR DESCRIPTION
Hi translators! I got stuck in a hyperfocus this week and started playing around with some REST routes. My ideal goal would be to self-host translation pack updates, but the intermediary step was to try to add routes for things that are already exposed at the `/glotpress` url. 

Definitely not complete, and I can't promise I will be able to complete it. But I wanted to share what I had been working on.

## Problem

#338 
maybe also #521

## Solution

`wp-json/gp/v1/projects`
`wp-json/gp/v1/projects/{project}`
`wp-json/gp/v1/languages`
`wp-json/gp/v1/languages/{locale}`
`wp-json/gp/v1/projects/{project}\sets`
`wp-json/gp/v1/projects/{project}\sets\{locale}\{slug}` ex: `gp/v1/translations/my-plugin/sets/fr/default`
`wp-json/gp/v1/projects/{project}\sets\{locale}\{slug}\translations` ex: `gp/v1/translations/my-plugin/sets/fr/default/translations`
`wp-json/gp/v1/import/{project}` Imports originals from `file` in multipart form data

## To-do

- [x] Add create, update, delete support for individual translations
- [ ] Add proper pagination links to `wp-json/gp/v1/translations/{$projectpath}/{$locale}/{$set}`  but I am not certain how to detect the total number of strings.
- [ ] Add create, update, delete support for batch translations?
- [ ] Generate language packs?
- [x] Add `wp-json/gp/v1/api/{$projectpath}` that serves the update response something like:

```
[
  {
    "{language}": [
      {
        "type": "{plugin|theme} from self hosting",
        "slug": "{$slug}",
        "language": "en_US",
        "updated": "PO-Revision-Date from .po file header",
        "package": "/packages/github-updater-en_US.zip",
        "autoupdate": "1"
      }
    ]
  }
]
```


## Testing Instructions
Create a REST API key for your user and hit the above endpoints with username/password authorization. Might be worth switching the read responses to public like GlotPress already is? and reserve authorization for editing content.


