### PR TITLE
Pass created translation IDs to gp_translations_imported

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -303,7 +303,8 @@ class GP_Translation_Set extends GP_Thing {
 		}
 		unset( $current_translations_list );
 
-		$translations_added = 0;
+		$translations_added      = 0;
+		$created_translation_ids = array();
 		foreach ( $translations->entries as $entry ) {
 			if ( empty( $entry->translations ) ) {
 				continue;
@@ -398,7 +399,8 @@ class GP_Translation_Set extends GP_Thing {
 				$translation = GP::$translation->create( $entry );
 				if ( is_object( $translation ) ) {
 					$translation->set_status( $entry->status );
-					$translations_added += 1;
+					$translations_added       += 1;
+					$created_translation_ids[] = $translation->id;
 				}
 			}
 		}
@@ -409,10 +411,12 @@ class GP_Translation_Set extends GP_Thing {
 		 * Fires after translations have been imported to a translation set.
 		 *
 		 * @since 1.0.0
+		 * @since 4.1.0 Added the `$created_translation_ids` parameter.
 		 *
-		 * @param int $translation_set The ID of the translation set the import was made into.
+		 * @param int   $translation_set         The ID of the translation set the import was made into.
+		 * @param int[] $created_translation_ids The IDs of the translations created during the import.
 		 */
-		do_action( 'gp_translations_imported', $this->id );
+		do_action( 'gp_translations_imported', $this->id, $created_translation_ids );
 
 		return $translations_added;
 	}

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -400,11 +400,14 @@ class GP_Import extends GP_UnitTestCase {
 		) ) );
 
 		$action_args = array();
-		add_action( 'gp_translations_imported', function( $set_id, $created_translation_ids = null ) use ( &$action_args ) {
+		$closure = function( $set_id, $created_translation_ids = null ) use ( &$action_args ) {
 			$action_args = array( $set_id, $created_translation_ids );
-		}, 10, 2 );
+		};
+		add_action( 'gp_translations_imported', $closure, 10, 2 );
 
 		$set->import( $translations );
+
+		remove_action( 'gp_translations_imported', $closure );
 
 		$this->assertSame( $set->id, $action_args[0] );
 		$this->assertIsArray( $action_args[1] );
@@ -432,11 +435,14 @@ class GP_Import extends GP_UnitTestCase {
 		) ) );
 
 		$created_translation_ids = null;
-		add_action( 'gp_translations_imported', function( $set_id, $ids = null ) use ( &$created_translation_ids ) {
+		$closure = function( $set_id, $ids = null ) use ( &$created_translation_ids ) {
 			$created_translation_ids = $ids;
-		}, 10, 2 );
+		};
+		add_action( 'gp_translations_imported', $closure, 10, 2 );
 
 		$set->import( $translations );
+
+		remove_action( 'gp_translations_imported', $closure );
 
 		$this->assertSame( array(), $created_translation_ids );
 	}

--- a/tests/phpunit/testcases/test_import.php
+++ b/tests/phpunit/testcases/test_import.php
@@ -369,4 +369,76 @@ class GP_Import extends GP_UnitTestCase {
 		));
 	}
 
+	/**
+	 * The `gp_translations_imported` action should pass the IDs of the created translations.
+	 *
+	 * @ticket gh-1467
+	 */
+	function test_gp_translations_imported_passes_created_translation_ids() {
+		$user = $this->factory->user->create();
+		wp_set_current_user( $user );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		GP::$validator_permission->create( array(
+			'user_id'    => $user,
+			'action'     => 'approve',
+			'project_id' => $set->project_id,
+			'locale_slug' => $set->locale,
+			'set_slug'   => $set->slug,
+		) );
+
+		$this->factory->original->create( array(
+			'project_id' => $set->project_id,
+			'status'     => '+active',
+			'singular'   => 'Good morning',
+		) );
+
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		$action_args = array();
+		add_action( 'gp_translations_imported', function( $set_id, $created_translation_ids = null ) use ( &$action_args ) {
+			$action_args = array( $set_id, $created_translation_ids );
+		}, 10, 2 );
+
+		$set->import( $translations );
+
+		$this->assertSame( $set->id, $action_args[0] );
+		$this->assertIsArray( $action_args[1] );
+		$this->assertCount( 1, $action_args[1] );
+		$this->assertContainsOnly( 'int', $action_args[1] );
+		$this->assertGreaterThan( 0, $action_args[1][0] );
+	}
+
+	/**
+	 * The `gp_translations_imported` action should pass an empty array when no translations are created.
+	 *
+	 * @ticket gh-1467
+	 */
+	function test_gp_translations_imported_passes_empty_array_when_nothing_created() {
+		$user = $this->factory->user->create();
+		wp_set_current_user( $user );
+
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+
+		// No originals exist, so nothing can be created from the import.
+		$translations = new Translations();
+		$translations->add_entry( new Translation_Entry( array(
+			'singular'     => 'Good morning',
+			'translations' => array( 'Guten Morgen' ),
+		) ) );
+
+		$created_translation_ids = null;
+		add_action( 'gp_translations_imported', function( $set_id, $ids = null ) use ( &$created_translation_ids ) {
+			$created_translation_ids = $ids;
+		}, 10, 2 );
+
+		$set->import( $translations );
+
+		$this->assertSame( array(), $created_translation_ids );
+	}
+
 }


### PR DESCRIPTION
Fixes #1467.

The `gp_translations_imported` action only passed the translation-set ID, so callbacks had no way to know which strings an import actually created without re-deriving the list through slower per-string actions or by re-parsing the upload.

This tracks the IDs of the translations created during the import and passes them as a second argument. The change is additive, so existing one-argument callbacks are unaffected. It unblocks crediting contributors on their WordPress.org profiles for bulk imports (WordPress/five-for-the-future#196).

Tests covering both the populated and empty-array cases are included.