### PR TITLE
Fix PHP 8.5 deprecation warnings

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '7.4', '8.3' ]
+        php: [ '7.4', '8.3', '8.5' ]
         wordpress: [ 'latest', 'nightly' ]
         multisite: [ false, true ]
         experimental: [ false ]

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -752,5 +752,9 @@ function gp_is_valid_utf8( $string ) {
 		return wp_is_valid_utf8( $string );
 	}
 
+	if ( function_exists( 'mb_check_encoding' ) ) {
+		return mb_check_encoding( $string, 'UTF-8' );
+	}
+
 	return 1 === preg_match( '//u', $string );
 }

--- a/gp-includes/misc.php
+++ b/gp-includes/misc.php
@@ -751,5 +751,6 @@ function gp_is_valid_utf8( $string ) {
 	if ( function_exists( 'wp_is_valid_utf8' ) ) {
 		return wp_is_valid_utf8( $string );
 	}
-	return seems_utf8( $string );
+
+	return 1 === preg_match( '//u', $string );
 }

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -305,7 +305,7 @@ class GP_Route_Translation extends GP_Route_Main {
 				foreach ( $errors as $error ) {
 					foreach ( $error as $key => $value ) {
 						$output .= '<li>';
-						$output .= htmlentities( $value );
+						$output .= htmlentities( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 						$output .= '</li>';
 					}
 				}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -305,7 +305,7 @@ class GP_Route_Translation extends GP_Route_Main {
 				foreach ( $errors as $error ) {
 					foreach ( $error as $key => $value ) {
 						$output .= '<li>';
-						$output .= htmlentities( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+						$output .= htmlentities( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8' );
 						$output .= '</li>';
 					}
 				}

--- a/gp-includes/validation.php
+++ b/gp-includes/validation.php
@@ -107,8 +107,7 @@ class GP_Validation_Rules {
 				}
 			}
 		}
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error(
+		throw new BadMethodCallException(
 			sprintf(
 				/* translators: %s: Method name. */
 				esc_html__( 'Call to undefined method: %s.', 'glotpress' ),
@@ -117,8 +116,7 @@ class GP_Validation_Rules {
 					esc_html( get_class( $this ) ),
 					esc_html( $name )
 				)
-			),
-			E_USER_ERROR
+			)
 		);
 	}
 

--- a/gp-templates/profile-public.api.php
+++ b/gp-templates/profile-public.api.php
@@ -7,7 +7,7 @@ $meta = array(
 );
 
 foreach ( $recent_projects as $project ) {
-	$project->set_name = html_entity_decode( $project->set_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+	$project->set_name = html_entity_decode( $project->set_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8' );
 	unset( $project->project_id );
 	unset( $project->set_id );
 }

--- a/gp-templates/profile-public.api.php
+++ b/gp-templates/profile-public.api.php
@@ -7,7 +7,7 @@ $meta = array(
 );
 
 foreach ( $recent_projects as $project ) {
-	$project->set_name = html_entity_decode( $project->set_name );
+	$project->set_name = html_entity_decode( $project->set_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 	unset( $project->project_id );
 	unset( $project->set_id );
 }

--- a/tests/phpunit/includes/install.php
+++ b/tests/phpunit/includes/install.php
@@ -6,7 +6,7 @@
  * @subpackage Tests
  */
 
-error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
+error_reporting( E_ALL & ~E_DEPRECATED );
 
 $config_file_path = $argv[1];
 $tests_dir_path = $argv[2];

--- a/tests/phpunit/testcases/test_misc.php
+++ b/tests/phpunit/testcases/test_misc.php
@@ -52,4 +52,14 @@ class GP_Test_Misc extends GP_UnitTestCase {
 		$this->assertEquals( null, gp_get_import_file_format( 'thiswillneverbeafileformat', 'filename.thiswillneverbeafileformat' ) );
 		$this->assertEquals( null, gp_get_import_file_format( null, 'filename.thiswillneverbeafileformat' ) );
 	}
+
+	function test_gp_is_valid_utf8() {
+		$this->assertTrue( gp_is_valid_utf8( '' ) );
+		$this->assertTrue( gp_is_valid_utf8( 'just a test' ) );
+		$this->assertTrue( gp_is_valid_utf8( "\xE2\x9C\x8F" ) );
+		$this->assertFalse( gp_is_valid_utf8( "\xE2\x9C" ) );
+		$this->assertFalse( gp_is_valid_utf8( "\xC1\xBF" ) );
+		$this->assertFalse( gp_is_valid_utf8( "\xED\xB0\x80" ) );
+		$this->assertFalse( gp_is_valid_utf8( "B\xFCch" ) );
+	}
 }

--- a/tests/phpunit/testcases/test_validation.php
+++ b/tests/phpunit/testcases/test_validation.php
@@ -86,4 +86,13 @@ class GP_Test_Validation extends GP_UnitTestCase {
 		$this->assertEquals( false, $f( '-foo' ) );
 		$this->assertEquals( false, $f( 'Hello world.' ) );
 	}
+
+	function test_undefined_validation_method_throws_exception() {
+		$rules = new GP_Validation_Rules( array( 'name' ) );
+
+		$this->expectException( BadMethodCallException::class );
+		$this->expectExceptionMessage( 'Call to undefined method: GP_Validation_Rules::unknown_method().' );
+
+		$rules->unknown_method();
+	}
 }

--- a/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_glossary_entry.php
@@ -165,7 +165,7 @@ class GP_Test_Glossary_Entry extends GP_UnitTestCase {
 						'pos' => $pos,
 					);
 
-					$regex = '#<span class="glossary-word" data-translations="\[.*?' . preg_quote( htmlspecialchars( substr( json_encode( $translation_json ), 0, -2 ) ), '#' ) . '[^"]+">[^<]+</span>#';
+					$regex = '#<span class="glossary-word" data-translations="\[.*?' . preg_quote( htmlspecialchars( substr( json_encode( $translation_json ), 0, -2 ), ENT_QUOTES, 'UTF-8' ), '#' ) . '[^"]+">[^<]+</span>#';
 
 					$this->assertMatchesRegularExpression( $regex, $translation->singular_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->singular . '".' );
 					$this->assertMatchesRegularExpression( $regex, $translation->plural_glossary_markup, 'Glossary term "' . $term . '" should have been found in "' . $translation->plural . '".' );


### PR DESCRIPTION
Related to https://wordpress.org/support/topic/phpwp-compatibility/

## Proposed changes

* Throw a `BadMethodCallException` from `GP_Validation_Rules::__call()` instead of calling `trigger_error()` with `E_USER_ERROR`, which PHP 8.4 deprecated.
* Use `wp_is_valid_utf8()` in `gp_is_valid_utf8()` when it exists, with a `preg_match( '//u' )` fallback for older WordPress versions, since WordPress 6.9 deprecated `seems_utf8()`.
* Pass explicit `$flags` to `htmlentities()` in the translation error output and to `html_entity_decode()` in the public profile API template. PHP 8.1 changed the default from `ENT_COMPAT` to `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`, so an explicit value keeps the output identical on every supported PHP version.
* Remove `E_STRICT` from the `error_reporting()` call in the tests installer. PHP 8.4 deprecated the constant.
* Pass `ENT_QUOTES` and `UTF-8` to `htmlspecialchars()` in the glossary markup test so the test matches the escaping used in `gp-templates/helper-functions.php`.
* Add tests for `gp_is_valid_utf8()` and for the new exception.
* Add PHP 8.5 to the PHPUnit CI matrix.

## Why are these changes being made?

* A user reported PHP 8.5 warnings in the wordpress.org support forum. A full scan with the PHPCompatibility develop branch (which includes the PHP 8.4 and 8.5 sniffs) plus manual checks for issues the sniffs miss turned up these remaining problems. The `fputcsv()`/`fgetcsv()` warnings from the forum report were already fixed in `develop`. The scan also flags `array_is_list()` in `format-php.php`, but that one is a false positive: the call sits inside a `function_exists()` guard with a manual fallback.

## Testing instructions

* Run `composer lint`: no new issues (the warning count matches `develop`).
* Run the test suite under PHP 8.5, for example `npm run env:phpunit`. All 440 tests pass, and `--group locales` passes too. Verified locally with PHP 8.5.8 and 8.0.30.
* Run PHPCompatibility `dev-develop` with `testVersion 7.4-` against the plugin: only the `array_is_list()` false positive remains.
