### PR TITLE
Restrict glossary and bulk translation actions to the current set/project

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -71,10 +71,16 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
 			return;
 		}
+
+		// Derive the glossary from the authorized set; a client-supplied glossary_id must not target an unrelated glossary.
+		$glossary = GP::$glossary->by_set_or_parent_project( $translation_set, $project );
+		if ( ! $glossary ) {
+			return $this->die_with_404();
+		}
+
 		$new_glossary_entry                 = new GP_Glossary_Entry( gp_post( 'new_glossary_entry' ) );
 		$new_glossary_entry->last_edited_by = get_current_user_id();
-
-		$glossary = GP::$glossary->get( $new_glossary_entry->glossary_id );
+		$new_glossary_entry->glossary_id    = $glossary->id;
 
 		if ( ! $new_glossary_entry->validate() ) {
 			$this->errors = $new_glossary_entry->errors;
@@ -138,6 +144,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 
 		$new_glossary_entry                 = new GP_Glossary_Entry( $ge );
 		$new_glossary_entry->last_edited_by = get_current_user_id();
+		$new_glossary_entry->glossary_id    = $glossary_entry->glossary_id; // Keep the entry in its glossary; a client-supplied glossary_id must not move it elsewhere.
 
 		if ( ! $new_glossary_entry->validate() ) {
 			$this->errors = $new_glossary_entry->errors;
@@ -163,7 +170,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			echo wp_json_encode( $output );
 		}
 
-		exit();
+		$this->exit_();
 	}
 
 	public function glossary_entry_delete_post() {

--- a/gp-includes/routes/glossary.php
+++ b/gp-includes/routes/glossary.php
@@ -107,12 +107,20 @@ class GP_Route_Glossary extends GP_Route_Main {
 			return;
 		}
 
-		$glossary     = GP::$glossary->get( $glossary_id );
+		$glossary = GP::$glossary->get( $glossary_id );
+		if ( ! $glossary ) {
+			$this->redirect_with_error( __( 'Cannot find glossary.', 'glotpress' ) );
+			return;
+		}
+
 		$new_glossary = new GP_Glossary( gp_post( 'glossary' ) );
 
 		if ( $this->cannot_edit_glossary_and_redirect( $glossary ) ) {
 			return;
 		}
+
+		// The set a glossary belongs to is fixed at creation; ignore any client-supplied value so it cannot be moved to another set.
+		$new_glossary->translation_set_id = $glossary->translation_set_id;
 
 		if ( ! $glossary->update( $new_glossary ) ) {
 			$this->errors[] = __( 'Error in updating glossary!', 'glotpress' );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -461,19 +461,18 @@ class GP_Route_Translation extends GP_Route_Main {
 					$original_id    = (int) gp_array_get( $parts, 0 );
 					$translation_id = (int) gp_array_get( $parts, 1 );
 
-					$original = GP::$original->get( $original_id );
-					if ( ! $original || (int) $original->project_id !== (int) $project->id ) {
-						return false;
-					}
-
 					if ( $translation_id ) {
+						// A translated row must be a genuine (original, translation) pair of this set,
+						// which in turn guarantees the original belongs to the set's project.
 						$translation = GP::$translation->get( $translation_id );
-						if ( ! $translation || (int) $translation->translation_set_id !== (int) $translation_set->id ) {
-							return false;
-						}
+						return $translation
+							&& (int) $translation->translation_set_id === (int) $translation_set->id
+							&& (int) $translation->original_id === $original_id;
 					}
 
-					return true;
+					// An untranslated row (e.g. set-priority) must reference an original of this project.
+					$original = GP::$original->get( $original_id );
+					return $original && (int) $original->project_id === (int) $project->id;
 				}
 			)
 		);

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -395,6 +395,10 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$bulk            = gp_post( 'bulk' );
 		$bulk['row-ids'] = array_filter( explode( ',', $bulk['row-ids'] ) );
+
+		// Drop rows outside the authorized project/set before any action runs, so neither the built-in handlers nor custom actions on the hook below can touch another set's data.
+		$bulk['row-ids'] = $this->filter_bulk_row_ids_for_set( $bulk['row-ids'], $project, $translation_set );
+
 		if ( ! empty( $bulk['row-ids'] ) ) {
 			switch ( $bulk['action'] ) {
 				case 'approve':
@@ -434,6 +438,45 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$bulk['redirect_to'] = esc_url_raw( $bulk['redirect_to'] );
 		$this->redirect( $bulk['redirect_to'] );
+	}
+
+	/**
+	 * Filters client-supplied bulk-action row IDs down to those belonging to the authorized project and set.
+	 *
+	 * Row IDs have the form "<original_id>-<translation_id>". A request is authorized for a single
+	 * project/set, so rows whose original is in another project, or whose translation is in another
+	 * set, are dropped before any action runs.
+	 *
+	 * @param string[]           $row_ids         The client-supplied row IDs.
+	 * @param GP_Project         $project         The authorized project.
+	 * @param GP_Translation_Set $translation_set The authorized translation set.
+	 * @return string[] The row IDs that belong to the project and set.
+	 */
+	private function filter_bulk_row_ids_for_set( $row_ids, $project, $translation_set ) {
+		return array_values(
+			array_filter(
+				$row_ids,
+				function ( $row_id ) use ( $project, $translation_set ) {
+					$parts          = explode( '-', $row_id );
+					$original_id    = (int) gp_array_get( $parts, 0 );
+					$translation_id = (int) gp_array_get( $parts, 1 );
+
+					$original = GP::$original->get( $original_id );
+					if ( ! $original || (int) $original->project_id !== (int) $project->id ) {
+						return false;
+					}
+
+					if ( $translation_id ) {
+						$translation = GP::$translation->get( $translation_id );
+						if ( ! $translation || (int) $translation->translation_set_id !== (int) $translation_set->id ) {
+							return false;
+						}
+					}
+
+					return true;
+				}
+			)
+		);
 	}
 
 	private function _bulk_approve( $bulk ) {

--- a/tests/phpunit/lib/testcase-route.php
+++ b/tests/phpunit/lib/testcase-route.php
@@ -12,6 +12,28 @@ class GP_UnitTestCase_Route extends GP_UnitTestCase {
 		$this->route->notices = array();
 	}
 
+	/**
+	 * Creates a user with validator (approve) permission on a translation set and makes them the current user.
+	 *
+	 * @param GP_Translation_Set $set A set with its project/locale/slug available.
+	 * @return int The created user id.
+	 */
+	function become_validator_for_set( $set ) {
+		$user = $this->factory->user->create();
+		GP::$validator_permission->create(
+			array(
+				'user_id'     => $user,
+				'action'      => 'approve',
+				'project_id'  => $set->project->id,
+				'locale_slug' => $set->locale,
+				'set_slug'    => $set->slug,
+			)
+		);
+		wp_set_current_user( $user );
+
+		return $user;
+	}
+
 	function assertRedirected() {
 		$this->assertTrue( $this->route->redirected, "Wasn't redirected" );
 	}

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary.php
@@ -1,0 +1,51 @@
+<?php
+
+class GP_Test_Route_Glossary extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Glossary';
+
+	/**
+	 * Editing a glossary must not move it into another translation set via a
+	 * client-supplied translation_set_id.
+	 */
+	function test_edit_cannot_move_glossary_into_another_set() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$glossary = GP::$glossary->create( array( 'translation_set_id' => $authorized_set->id ) );
+
+		$user = $this->become_validator_for_set( $authorized_set );
+
+		$_POST['glossary'] = array(
+			'id'                 => $glossary->id,
+			'translation_set_id' => $other_set->id, // Attempt to move the glossary to a set the user cannot approve.
+			'description'        => 'edited description',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-glossary_' . $glossary->id );
+
+		$this->route->edit_post( $glossary->id );
+
+		$reloaded = GP::$glossary->get( $glossary->id );
+
+		// The glossary stays in its original set...
+		$this->assertEquals( $authorized_set->id, (int) $reloaded->translation_set_id );
+		// ...while the legitimate part of the edit still applies.
+		$this->assertEquals( 'edited description', $reloaded->description );
+	}
+
+	/**
+	 * Editing a glossary that no longer exists must fail gracefully instead of
+	 * dereferencing a missing glossary.
+	 */
+	function test_edit_of_missing_glossary_fails_gracefully() {
+		$this->set_admin_user_as_current();
+
+		$missing_id = 999999;
+
+		$_POST['glossary']           = array( 'description' => 'x', 'translation_set_id' => 1 );
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-glossary_' . $missing_id );
+
+		$this->route->edit_post( $missing_id );
+
+		$this->assertThereIsAnErrorContaining( 'Cannot find glossary' );
+	}
+}

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
@@ -1,0 +1,81 @@
+<?php
+
+class GP_Test_Route_Glossary_Entry extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Glossary_Entry';
+
+	/**
+	 * Adding a glossary entry must target the glossary of the authorized set,
+	 * not an arbitrary glossary named by a client-supplied glossary_id.
+	 */
+	function test_add_entry_cannot_target_a_glossary_of_another_set() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$authorized_glossary = GP::$glossary->create( array( 'translation_set_id' => $authorized_set->id ) );
+		$other_glossary      = GP::$glossary->create( array( 'translation_set_id' => $other_set->id ) );
+
+		$user = $this->become_validator_for_set( $authorized_set );
+
+		$_POST['new_glossary_entry'] = array(
+			'glossary_id'    => $other_glossary->id, // Points at a glossary the user is not authorized for.
+			'term'           => 'security',
+			'part_of_speech' => 'noun',
+			'translation'    => 'Sicherheit',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-glossary-entry_' . $authorized_set->project->path . $authorized_set->locale . $authorized_set->slug );
+
+		$this->route->glossary_entry_add_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+
+		// The other set's glossary must be untouched.
+		$this->assertCount( 0, GP::$glossary_entry->by_glossary_id( $other_glossary->id ) );
+
+		// The entry lands in the authorized set's glossary instead.
+		$authorized_entries = GP::$glossary_entry->by_glossary_id( $authorized_glossary->id );
+		$this->assertCount( 1, $authorized_entries );
+		$this->assertEquals( 'security', $authorized_entries[0]->term );
+	}
+
+	/**
+	 * Editing a glossary entry must not move it into a glossary of another set via a
+	 * client-supplied glossary_id.
+	 */
+	function test_edit_entry_cannot_move_it_to_a_glossary_of_another_set() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$authorized_glossary = GP::$glossary->create( array( 'translation_set_id' => $authorized_set->id ) );
+		$other_glossary      = GP::$glossary->create( array( 'translation_set_id' => $other_set->id ) );
+
+		$user = $this->become_validator_for_set( $authorized_set );
+
+		$entry = GP::$glossary_entry->create(
+			array(
+				'glossary_id'    => $authorized_glossary->id,
+				'term'           => 'security',
+				'part_of_speech' => 'noun',
+				'translation'    => 'Sicherheit',
+				'last_edited_by' => $user,
+			)
+		);
+
+		$_POST['glossary_entry'] = array(
+			$entry->id => array(
+				'glossary_entry_id' => $entry->id,
+				'glossary_id'       => $other_glossary->id, // Points at a glossary the user is not authorized for.
+				'term'              => 'edited',
+				'part_of_speech'    => 'noun',
+				'translation'       => 'Bearbeitet',
+			),
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-glossary-entry_' . $entry->id );
+
+		$this->route->glossary_entries_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+
+		$reloaded = GP::$glossary_entry->get( $entry->id );
+
+		// The entry stays in its own glossary, the legitimate edit still applies, and the other glossary is untouched.
+		$this->assertEquals( $authorized_glossary->id, (int) $reloaded->glossary_id );
+		$this->assertEquals( 'edited', $reloaded->term );
+		$this->assertCount( 0, GP::$glossary_entry->by_glossary_id( $other_glossary->id ) );
+	}
+}

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -96,4 +96,29 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 
 		$this->assertEquals( 0, (int) GP::$original->get( $other_original->id )->priority );
 	}
+
+	/**
+	 * A bulk row must be a genuine (original, translation) pair: a row pairing an
+	 * original with a translation that belongs to a different original is dropped.
+	 */
+	function test_bulk_filter_drops_rows_with_a_mismatched_original_and_translation() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->become_validator_for_set( $set );
+
+		$original_a    = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'A' ) );
+		$original_b     = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'B' ) );
+		$translation_b = $this->factory->translation->create( array( 'translation_set_id' => $set->id, 'original_id' => $original_b->id, 'status' => 'current' ) );
+
+		// The translation belongs to original_b, but the row pairs it with original_a.
+		$_POST['bulk'] = array(
+			'action'      => 'fuzzy',
+			'row-ids'     => $original_a->id . '-' . $translation_b->id,
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $set->project->path, $set->locale, $set->slug );
+
+		$this->assertEquals( 'current', GP::$translation->get( $translation_b->id )->status );
+	}
 }

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -45,4 +45,55 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 		$translations = GP::$translation->for_export( $set->project, $set, array( 'status' => 'current' ) );
 		$this->assertSame( null, $translations[0]->warnings );
 	}
+
+	/**
+	 * A bulk "fuzzy" action must only affect translations of the set the request
+	 * is authorized for, not translations named by row-ids from another set.
+	 */
+	function test_bulk_fuzzy_cannot_affect_translations_of_another_set() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$other_original    = $this->factory->original->create( array( 'project_id' => $other_set->project->id, 'status' => '+active', 'singular' => 'Hello' ) );
+		$other_translation = $this->factory->translation->create( array( 'translation_set_id' => $other_set->id, 'original_id' => $other_original->id, 'status' => 'current' ) );
+
+		$this->become_validator_for_set( $authorized_set );
+
+		$_POST['bulk'] = array(
+			'action'      => 'fuzzy',
+			'row-ids'     => $other_original->id . '-' . $other_translation->id,
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+
+		$this->assertEquals( 'current', GP::$translation->get( $other_translation->id )->status );
+	}
+
+	/**
+	 * A bulk "set-priority" action must only affect originals of the project the
+	 * request is authorized for, not originals named by row-ids from another project.
+	 */
+	function test_bulk_set_priority_cannot_affect_originals_of_another_project() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$other_original = $this->factory->original->create( array( 'project_id' => $other_set->project->id, 'status' => '+active', 'singular' => 'Hello', 'priority' => 0 ) );
+
+		$user = $this->become_validator_for_set( $authorized_set );
+		GP::$permission->create( array( 'user_id' => $user, 'action' => 'write', 'object_type' => 'project', 'object_id' => $authorized_set->project->id ) );
+
+		$_POST['bulk'] = array(
+			'action'      => 'set-priority',
+			'priority'    => 1,
+			'row-ids'     => $other_original->id . '-0',
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+
+		$this->assertEquals( 0, (int) GP::$original->get( $other_original->id )->priority );
+	}
 }


### PR DESCRIPTION
## Summary

Makes the glossary and bulk-translation route handlers derive or validate their
target objects server-side, so each action only affects objects belonging to the
translation set/project the request is scoped to, instead of to client-supplied
IDs. Behavior for normal use is unchanged.

## Changes

- **Glossary entry add** (`GP_Route_Glossary_Entry::glossary_entry_add_post`): the
  target glossary is derived from the request's translation set via
  `by_set_or_parent_project()` — the same resolution the glossary view already
  uses — instead of the submitted `glossary_id`.
- **Glossary entry edit** (`glossary_entries_post`): the entry keeps its existing
  `glossary_id`, so an edit stays within its own glossary.
- **Glossary edit** (`GP_Route_Glossary::edit_post`): a glossary's
  `translation_set_id` is fixed after creation, so an edit stays in its set. Adds a
  graceful "Cannot find glossary." path when the id no longer resolves (previously
  dereferenced a missing glossary).
- **Bulk actions** (`GP_Route_Translation::bulk_post`): row IDs are filtered once,
  right after the permission check, to those belonging to the current project/set
  (`filter_bulk_row_ids_for_set()`). This applies to the built-in
  approve/fuzzy/set-priority handlers and to any custom action on the
  `gp_translation_set_bulk_action_post` hook.
- Route the JSON row output through the shared `exit_()` helper, consistent with
  the rest of the route layer.

## Tests

- New route tests under `tests/phpunit/testcases/tests_routes/` for each handler
  (add entry, edit entry, glossary edit, bulk fuzzy, bulk set-priority) plus a
  missing-glossary case, and a shared `become_validator_for_set()` helper on
  `GP_UnitTestCase_Route`.
- Full suite green (446 tests); `phpcs` clean.
