### PR TITLE
Escape the link text in gp_link_get()

### DIFF
--- a/gp-includes/routes/locale.php
+++ b/gp-includes/routes/locale.php
@@ -124,7 +124,7 @@ class GP_Route_Locale extends GP_Route_Main {
 						$set_list[ $set->slug ] = __( 'Default', 'glotpress' );
 					}
 				} elseif ( $set->slug != $current_set_slug ) {
-						$set_list[ $set->slug ] = gp_link_get( gp_url( gp_url_join( '/languages', $locale->slug, $set->slug ) ), esc_html( $set->name ) );
+						$set_list[ $set->slug ] = gp_link_get( gp_url( gp_url_join( '/languages', $locale->slug, $set->slug ) ), $set->name );
 				} else {
 					$set_list[ $set->slug ] = esc_html( $set->name );
 				}

--- a/gp-includes/template-links.php
+++ b/gp-includes/template-links.php
@@ -34,7 +34,7 @@ function gp_link_get( $url, $text, $attrs = array() ) {
 		$before,
 		esc_url( $url ),
 		$attributes,
-		$text,
+		esc_html( $text ),
 		$after
 	);
 }

--- a/gp-includes/template.php
+++ b/gp-includes/template.php
@@ -254,7 +254,7 @@ function gp_project_links_from_root( $leaf_project ) {
 	$links[]        = empty( $path_from_root ) ? __( 'Projects', 'glotpress' ) : gp_link_get( gp_url( '/projects' ), __( 'Projects', 'glotpress' ) );
 	foreach ( $path_from_root as $project ) {
 		if ( ! is_null( $project->id ) ) {
-			$links[] = gp_link_project_get( $project, esc_html( $project->name ) );
+			$links[] = gp_link_project_get( $project, $project->name );
 		}
 	}
 	return $links;
@@ -281,7 +281,7 @@ function gp_breadcrumb_project( $project, $extra_items = array() ) {
 		end( $breadcrumb );
 		$last_key = key( $breadcrumb );
 
-		$breadcrumb[ $last_key ] = $project->name;
+		$breadcrumb[ $last_key ] = esc_html( $project->name );
 	}
 
 	// Add extra items.

--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -206,7 +206,7 @@ class GP_Translation_Set extends GP_Thing {
 		$parts  = array( $locale->english_name );
 
 		if ( 'default' !== $this->slug ) {
-			$parts[] = $this->name;
+			$parts[] = esc_html( $this->name );
 		}
 
 		return implode( '&nbsp;' . $separator . '&nbsp;', $parts );

--- a/gp-templates/locale.php
+++ b/gp-templates/locale.php
@@ -12,7 +12,7 @@ $breadcrumb[] = gp_link_get( gp_url( '/languages' ), __( 'Locales', 'glotpress' 
 if ( 'default' == $current_set_slug ) {
 	$breadcrumb[] = esc_html( $locale->english_name );
 } else {
-	$breadcrumb[] = gp_link_get( gp_url_join( gp_url( '/languages' ), $locale->slug ), esc_html( $locale->english_name ) );
+	$breadcrumb[] = gp_link_get( gp_url_join( gp_url( '/languages' ), $locale->slug ), $locale->english_name );
 	$breadcrumb[] = $set_list[ $current_set_slug ];
 }
 gp_breadcrumb( $breadcrumb );

--- a/gp-templates/project-import.php
+++ b/gp-templates/project-import.php
@@ -3,7 +3,7 @@ if ( 'originals' === $kind ) {
 	$gp_title = sprintf(
 		/* translators: %s: Project name. */
 		__( 'Import Originals &lt; %s &lt; GlotPress', 'glotpress' ),
-		esc_html( $project->name )
+		$project->name
 	);
 	$return_link = gp_url_project( $project );
 	gp_breadcrumb_project(
@@ -16,7 +16,7 @@ if ( 'originals' === $kind ) {
 	$gp_title = sprintf(
 		/* translators: %s: Project name. */
 		__( 'Import Translations &lt; %s &lt; GlotPress', 'glotpress' ),
-		esc_html( $project->name )
+		$project->name
 	);
 	$return_link = gp_url_project_locale( $project, $locale->slug, $translation_set->slug );
 	gp_breadcrumb_project(

--- a/gp-templates/project-permissions.php
+++ b/gp-templates/project-permissions.php
@@ -68,7 +68,7 @@ gp_tmpl_header();
 					<td><?php echo esc_html( $permission->action ); ?></td>
 					<td><?php echo esc_html( $permission->locale_slug ); ?></td>
 					<td><?php echo esc_html( $permission->set_slug ); ?></td>
-					<td><?php gp_link_project( $permission->project, esc_html( $permission->project->name ) ); ?></td>
+					<td><?php gp_link_project( $permission->project, $permission->project->name ); ?></td>
 				</tr>
 			<?php endforeach; ?>
 		</tbody>

--- a/gp-templates/project.php
+++ b/gp-templates/project.php
@@ -190,7 +190,7 @@ $project_class = $sub_projects ? 'with-sub-projects' : '';
 			$sub_project_class = $sub_project->active ? 'project-active' : 'project-inactive';
 			?>
 			<dt class="<?php echo esc_attr( $sub_project_class ); ?>">
-				<?php gp_link_project( $sub_project, esc_html( $sub_project->name ) ); ?>
+				<?php gp_link_project( $sub_project, $sub_project->name ); ?>
 				<?php gp_link_project_edit( $sub_project, null, array( 'class' => 'button is-small' ) ); ?>
 				<?php gp_link_project_delete( $sub_project, null, array( 'class' => 'button is-small' ) ); ?>
 				<?php

--- a/gp-templates/projects.php
+++ b/gp-templates/projects.php
@@ -12,7 +12,7 @@ gp_tmpl_header();
 				$project_class = $project->active ? 'project-active' : 'project-inactive';
 				?>
 				<dt class="<?php echo esc_attr( $project_class ); ?>">
-					<?php gp_link_project( $project, esc_html( $project->name ) ); ?>
+					<?php gp_link_project( $project, $project->name ); ?>
 					<?php gp_link_project_edit( $project, null, array( 'class' => 'button is-small' ) ); ?>
 					<?php gp_link_project_delete( $project, null, array( 'class' => 'button is-small' ) ); ?>
 					<?php

--- a/gp-templates/translation-set-delete.php
+++ b/gp-templates/translation-set-delete.php
@@ -18,7 +18,7 @@ gp_title(
 gp_breadcrumb_project(
 	$project,
 	array(
-		gp_link_get( $url, $locale->english_name . 'default' !== $set->slug ? ' ' . $set->name : '' ),
+		gp_link_get( $url, $locale->english_name . ( 'default' !== $set->slug ? ' ' . $set->name : '' ) ),
 		__( 'Delete', 'glotpress' ),
 	)
 );

--- a/gp-templates/translation-set-edit.php
+++ b/gp-templates/translation-set-edit.php
@@ -10,7 +10,7 @@ gp_title(
 gp_breadcrumb_project(
 	$project,
 	array(
-		gp_link_get( $url, $locale->english_name . 'default' !== $set->slug ? ' ' . $set->name : '' ),
+		gp_link_get( $url, $locale->english_name . ( 'default' !== $set->slug ? ' ' . $set->name : '' ) ),
 		__( 'Edit', 'glotpress' ),
 	)
 );

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -23,7 +23,7 @@ if ( ! $project->active ) {
 gp_breadcrumb_project(
 	$project,
 	array(
-		$translation_set->name . $inactive_bubble,
+		esc_html( $translation_set->name ) . $inactive_bubble,
 	)
 );
 gp_enqueue_scripts( array( 'gp-editor', 'gp-translations-page' ) );

--- a/tests/phpunit/testcases/test_links.php
+++ b/tests/phpunit/testcases/test_links.php
@@ -24,7 +24,11 @@ class GP_Test_Links extends GP_UnitTestCase {
 	}
 
 	function test_gp_link_get_escape() {
-		$this->assertEquals( '<a href="http://dir.bg/">Baba & Dyado</a>', gp_link_get( 'http://dir.bg/', 'Baba & Dyado' ) );
+		// The link text is escaped so the output is safe by default.
+		$this->assertEquals( '<a href="http://dir.bg/">Baba &amp; Dyado</a>', gp_link_get( 'http://dir.bg/', 'Baba & Dyado' ) );
+		$this->assertEquals( '<a href="http://dir.bg/">&lt;b&gt;x&lt;/b&gt;</a>', gp_link_get( 'http://dir.bg/', '<b>x</b>' ) );
+		// Existing entities in the text are preserved, not double-encoded.
+		$this->assertEquals( '<a href="http://dir.bg/">&larr; Prev</a>', gp_link_get( 'http://dir.bg/', '&larr; Prev' ) );
 		$this->assertEquals( '<a href="http://dir.bg/?x=5&#038;y=11">Baba</a>', gp_link_get( 'http://dir.bg/?x=5&y=11', 'Baba' ) );
 		$this->assertEquals( '<a href="http://dir.bg/" a="&quot;">Baba</a>', gp_link_get( 'http://dir.bg/', 'Baba', array( 'a' => '"') ) );
 	}

--- a/tests/phpunit/testcases/test_template.php
+++ b/tests/phpunit/testcases/test_template.php
@@ -45,4 +45,15 @@ class GP_Test_Template_Functions extends GP_UnitTestCase {
 		$entry = new Translation_Entry ( array( 'singular' => 'ganoush', 'warnings' => null, 'priority'=> '1', 'translation_status' =>'untranslated' ) );
 		$this->assertEqualsCanonicalizing( array( 'status-untranslated', 'no-warnings', 'priority-high', 'no-translations' ), gp_get_translation_row_classes( $entry ) );
 	}
+
+	function test_gp_breadcrumb_project_escapes_project_name() {
+		$name    = '<b>abc123</b>';
+		$project = $this->factory->project->create( array( 'name' => $name, 'slug' => 'markup-name' ) );
+
+		gp_breadcrumb_project( $project );
+		$html = gp_breadcrumb();
+
+		$this->assertStringNotContainsString( $name, $html );
+		$this->assertStringContainsString( esc_html( $name ), $html );
+	}
 }

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_escaping.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_escaping.php
@@ -1,0 +1,19 @@
+<?php
+
+class GP_Test_Route_Glossary_Entry_Escaping extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Glossary_Entry';
+
+	/**
+	 * The glossary view must escape the translation set name it renders in the breadcrumb.
+	 */
+	function test_glossary_view_escapes_translation_set_name() {
+		$name = '<b>abc123</b>';
+		$set  = $this->factory->translation_set->create_with_project_and_locale( array( 'name' => $name ) );
+		GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		$this->route->glossary_entries_get( $set->project->path, $set->locale, $set->slug );
+
+		$this->assertStringNotContainsString( $name, $this->route->template_output );
+		$this->assertStringContainsString( esc_html( $name ), $this->route->template_output );
+	}
+}

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_escaping.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_escaping.php
@@ -1,0 +1,18 @@
+<?php
+
+class GP_Test_Route_Translation_Escaping extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Translation';
+
+	/**
+	 * The translations page must escape the translation set name it renders in the breadcrumb.
+	 */
+	function test_translations_page_escapes_translation_set_name() {
+		$name = '<b>abc123</b>';
+		$set  = $this->factory->translation_set->create_with_project_and_locale( array( 'name' => $name ) );
+
+		$this->route->translations_get( $set->project->path, $set->locale, $set->slug );
+
+		$this->assertStringNotContainsString( $name, $this->route->template_output );
+		$this->assertStringContainsString( esc_html( $name ), $this->route->template_output );
+	}
+}

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -321,4 +321,14 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertEquals( $previous_set->name, 'Before' );
 		$this->assertEquals( $translation_set->name, 'After' );
 	}
+
+	function test_name_with_locale_escapes_the_set_name() {
+		$name = '<b>abc123</b>';
+		$set  = $this->factory->translation_set->create_with_project_and_locale( array( 'name' => $name, 'slug' => 'markup' ) );
+
+		$html = $set->name_with_locale();
+
+		$this->assertStringNotContainsString( $name, $html );
+		$this->assertStringContainsString( esc_html( $name ), $html );
+	}
 }


### PR DESCRIPTION
## Summary

`gp_link_get()` / `gp_link()` emitted their `$text` argument unescaped, even
though they are registered as auto-escaping in `phpcs.xml.dist`. This makes
them escape `$text` with `esc_html()` so the output is safe by default, and
removes the now-redundant `esc_html()` calls from the call sites.

Existing entities in the text (e.g. `&nbsp;`, `&rarr;`) are preserved
(`_wp_specialchars()` runs with `$double_encode = false`) and `esc_html()` is
idempotent, so callers that already escaped their text are unaffected.

## Behavior change (heads-up for themes/extensions)

`gp_link_get()` / `gp_link()` are public template functions (`@since 1.0.0`).
Their `$text` argument is now escaped, so a caller that intentionally passed
HTML markup as link text will have it rendered as literal text. No in-plugin
caller does this, and there is no opt-out.

## Changes

- `gp_link_get()` escapes `$text`; the derived helpers (`gp_link_project*`,
  `gp_link_set_*`, `gp_link_with_ays*`, …) inherit it. `gp_link_user()` is
  unaffected (it does its own escaping).
- Removed the redundant `esc_html()` from the `gp_link*` call sites.
- Escaped the two name outputs that do **not** go through `gp_link_get()`:
  the final crumb in `gp_breadcrumb_project()` and the translations-page
  breadcrumb. `GP_Translation_Set::name_with_locale()` escapes the set name
  it embeds.
- Incidental fixes on touched lines: an operator-precedence bug in the
  translation-set edit/delete breadcrumb, and a double-escaped `<title>` on
  the import screen.

## Tests

- `test_gp_link_get_escape` asserts the link text is escaped and existing
  entities are preserved.
- Added coverage that project and translation-set names are escaped in the
  project breadcrumb, glossary view, translations page, and
  `name_with_locale()`.
- Full suite green; `phpcs` clean.
