### PR TITLE
Escape formula-leading cells in the glossary CSV export

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -14,6 +14,13 @@
  */
 class GP_Route_Glossary_Entry extends GP_Route_Main {
 
+	/**
+	 * Leading characters that make a spreadsheet interpret a cell as a formula.
+	 *
+	 * @var string[]
+	 */
+	private const FORMULA_TRIGGERS = array( '=', '+', '-', '@' );
+
 	public function glossary_entries_get( $project_path, $locale_slug, $translation_set_slug ) {
 		$project = GP::$project->by_path( $project_path );
 		$locale  = GP_Locales::by_slug( $locale_slug );
@@ -312,11 +319,58 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		fputcsv( $outstream, array( 'en', $locale_slug, 'pos', 'description' ), ',', '"', '' );
 
 		foreach ( $entries as $entry ) {
-			$values = array( $entry->term, $entry->translation, $entry->part_of_speech, $entry->comment );
+			$values = array_map(
+				array( $this, 'escape_csv_value' ),
+				array( $entry->term, $entry->translation, $entry->part_of_speech, $entry->comment )
+			);
 			fputcsv( $outstream, $values, ',', '"', '' );
 		}
 
 		fclose( $outstream );
+	}
+
+	/**
+	 * Prevents a cell value from being interpreted as a formula by spreadsheet
+	 * software.
+	 *
+	 * A value that begins with a formula trigger character is prefixed with a
+	 * tab. fputcsv() then wraps the field in double quotes, keeping the tab
+	 * inside the quoted field so the value is rendered as literal text. A tab is
+	 * used rather than a leading single quote because Microsoft Excel does not
+	 * preserve the latter across a save and reopen of the file.
+	 *
+	 * @see GP_Route_Glossary_Entry::unescape_csv_value() Reverses this on import.
+	 *
+	 * @param string $value Cell value.
+	 * @return string Value safe to write to a CSV cell.
+	 */
+	protected function escape_csv_value( $value ) {
+		if ( is_string( $value ) && '' !== $value && in_array( $value[0], self::FORMULA_TRIGGERS, true ) ) {
+			return "\t" . $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Reverses escape_csv_value() when a CSV file is read back in.
+	 *
+	 * Removes the leading tab that the export adds in front of a value that
+	 * starts with a formula trigger character, so a value survives an export and
+	 * a re-import unchanged. Only a tab that precedes such a character is
+	 * removed; the export never prefixes any other value.
+	 *
+	 * @see GP_Route_Glossary_Entry::escape_csv_value()
+	 *
+	 * @param string $value Cell value read from the CSV file.
+	 * @return string Value with an export-added tab prefix removed.
+	 */
+	protected function unescape_csv_value( $value ) {
+		if ( is_string( $value ) && isset( $value[1] ) && "\t" === $value[0] && in_array( $value[1], self::FORMULA_TRIGGERS, true ) ) {
+			return substr( $value, 1 );
+		}
+
+		return $value;
 	}
 
 	private function read_glossary_entries_from_file( $file, $glossary_id, $locale_slug ) {
@@ -340,10 +394,10 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 
 			$entry_data = array(
 				'glossary_id'    => $glossary_id,
-				'term'           => $data[0],
-				'translation'    => $data[1],
-				'part_of_speech' => $data[2],
-				'comment'        => $data[3],
+				'term'           => $this->unescape_csv_value( $data[0] ),
+				'translation'    => $this->unescape_csv_value( $data[1] ),
+				'part_of_speech' => $this->unescape_csv_value( $data[2] ),
+				'comment'        => $this->unescape_csv_value( $data[3] ),
 				'last_edited_by' => get_current_user_id(),
 			);
 

--- a/gp-includes/things/glossary-entry.php
+++ b/gp-includes/things/glossary-entry.php
@@ -122,7 +122,7 @@ class GP_Glossary_Entry extends GP_Thing {
 	 * @return string The last modified date on success, empty string on failure.
 	 */
 	public function last_modified( $glossary ) {
-		return (string) $this->value( "SELECT date_modified FROM {$this->table} WHERE glossary_id = %d ORDER BY date_modified DESC LIMIT 1", $glossary->id, 'current' );
+		return (string) $this->value( "SELECT date_modified FROM {$this->table} WHERE glossary_id = %d ORDER BY date_modified DESC LIMIT 1", $glossary->id );
 	}
 }
 

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_csv.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry_csv.php
@@ -1,0 +1,70 @@
+<?php
+
+class GP_Test_Route_Glossary_Entry_Csv extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Glossary_Entry';
+
+	function test_export_escapes_formula_leading_cells() {
+		$set      = $this->factory->translation_set->create_with_project_and_locale();
+		$glossary = GP::$glossary->create( array( 'translation_set_id' => $set->id ) );
+
+		GP::$glossary_entry->create(
+			array(
+				'glossary_id'    => $glossary->id,
+				'term'           => 'security',
+				'translation'    => '=danger',
+				'part_of_speech' => 'noun',
+				'comment'        => '@at',
+				'last_edited_by' => 1,
+			)
+		);
+		GP::$glossary_entry->create(
+			array(
+				'glossary_id'    => $glossary->id,
+				'term'           => 'plus',
+				'translation'    => '+plus',
+				'part_of_speech' => 'noun',
+				'comment'        => '-minus',
+				'last_edited_by' => 1,
+			)
+		);
+
+		ob_start();
+		$this->route->export_glossary_entries_get( $set->project->path, $set->locale, $set->slug );
+		$csv = ob_get_clean();
+
+		// Cells beginning with =, +, -, or @ get a leading tab, which fputcsv()
+		// keeps inside a quoted field so spreadsheets render them as text.
+		$this->assertStringContainsString( "security,\"\t=danger\",noun,\"\t@at\"", $csv );
+		$this->assertStringContainsString( "plus,\"\t+plus\",noun,\"\t-minus\"", $csv );
+
+		// Values that do not begin with such a character are written unchanged.
+		$this->assertStringNotContainsString( "\tsecurity", $csv );
+		$this->assertStringNotContainsString( "\tplus", $csv );
+	}
+
+	function test_import_reverses_the_formula_escape() {
+		$route = new Testable_GP_Route_Glossary_Entry_Csv();
+
+		// The tab added on export is stripped again on import.
+		$this->assertSame( '=danger', $route->testable_unescape_csv_value( "\t=danger" ) );
+		$this->assertSame( '-minus', $route->testable_unescape_csv_value( "\t-minus" ) );
+
+		// A value round-trips unchanged through export and import.
+		foreach ( array( '=danger', '+plus', '-minus', '@at', 'plain', '' ) as $value ) {
+			$this->assertSame( $value, $route->testable_unescape_csv_value( $route->testable_escape_csv_value( $value ) ) );
+		}
+
+		// A tab that is not part of the export escaping is left in place.
+		$this->assertSame( "\tplain", $route->testable_unescape_csv_value( "\tplain" ) );
+	}
+}
+
+class Testable_GP_Route_Glossary_Entry_Csv extends GP_Route_Glossary_Entry {
+	public function testable_escape_csv_value( $value ) {
+		return $this->escape_csv_value( $value );
+	}
+
+	public function testable_unescape_csv_value( $value ) {
+		return $this->unescape_csv_value( $value );
+	}
+}


### PR DESCRIPTION
## Summary

The glossary CSV export wrote each entry's fields to the file verbatim. When a
cell value begins with `=`, `+`, `-`, or `@`, spreadsheet applications (Excel,
LibreOffice Calc, Google Sheets) interpret it as a formula when the file is
opened — a class of issue commonly known as CSV / formula injection.

Formula-leading cells are now prefixed with a tab character on export.
`fputcsv()` wraps such a field in double quotes, so the tab stays *inside the
quoted field* and the application renders the value as literal text. The import
reader strips the tab again, so values round-trip unchanged.

## Why a tab and not a leading `'`

The historically common mitigation is to prefix the cell with a single quote.
Per OWASP that is unreliable: Microsoft Excel does not preserve the leading `'`
across a save and reopen of the file. OWASP recommends prefixing the cell with
a tab character (`0x09`) inside the quoted field instead, which is what this
change does.

- OWASP – CSV Injection: https://owasp.org/www-community/attacks/CSV_Injection

`fputcsv()` already quotes any field that contains a tab, so the "inside the
quoted field" requirement is met without building the CSV row by hand.

## Changes

- `GP_Route_Glossary_Entry::escape_csv_value()` prefixes a cell that starts
  with a formula trigger character with a tab; `print_export_file()` runs every
  exported cell through it.
- `GP_Route_Glossary_Entry::unescape_csv_value()` reverses it;
  `read_glossary_entries_from_file()` runs every imported cell through it, so an
  export followed by a re-import leaves values unchanged.
- The trigger set lives in a single `FORMULA_TRIGGERS` constant shared by both
  methods.
- Incidental fix: `GP_Glossary_Entry::last_modified()` passed a stray second
  argument to `value()`, so `wpdb::prepare()` received two arguments for a
  single placeholder (a "incorrect usage" notice). It sits on the export code
  path; the leftover argument is removed.

## Tests

- `test_export_escapes_formula_leading_cells` — formula-leading cells are
  tab-prefixed and quoted on export, ordinary values are unchanged.
- `test_import_reverses_the_formula_escape` — the tab is stripped on import and
  values round-trip unchanged through export and import.
- Full suite green; `phpcs` clean.
