### PR TITLE
Require approve permission to approve your own translation

### DIFF
--- a/gp-includes/route-exit-exception.php
+++ b/gp-includes/route-exit-exception.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Route exit exception.
+ *
+ * @package GlotPress
+ */
+
+/**
+ * Exception thrown by GP_Route::exit_() while a faked request is running, so a
+ * route stops at the point where a real request would have exited instead of
+ * continuing to run the code that follows.
+ */
+class GP_Route_Exit_Exception extends Exception {}

--- a/gp-includes/route.php
+++ b/gp-includes/route.php
@@ -361,7 +361,9 @@ class GP_Route {
 		if ( $this->fake_request ) {
 			$this->exited       = true;
 			$this->exit_message = $message;
-			return;
+			// Halt the route the way a real request would, so a faked request
+			// does not keep running the code that follows a die or redirect.
+			throw new GP_Route_Exit_Exception();
 		}
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- May contain HTML.
 		exit( $message );

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -816,10 +816,18 @@ class GP_Route_Translation extends GP_Route_Main {
 	}
 
 	private function can_approve_translation_or_forbidden( $translation ) {
-		$can_reject_self = ( get_current_user_id() == $translation->user_id && 'waiting' == $translation->status );
-		if ( $can_reject_self ) {
+		$requested_status  = gp_post( 'status' );
+		$requires_approval = in_array( $requested_status, array( 'current', 'changesrequested' ), true );
+
+		// The author of a waiting translation may manage it (e.g. reject it or
+		// discard its warnings) without approval rights, but approving it or
+		// requesting changes on it still requires the approve permission.
+		$is_own_waiting_translation = get_current_user_id() === (int) $translation->user_id && 'waiting' === $translation->status;
+
+		if ( $is_own_waiting_translation && ! $requires_approval ) {
 			return;
 		}
+
 		$this->can_or_forbidden( 'approve', 'translation', $translation->id, null, array( 'translation' => $translation ) );
 	}
 

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -88,6 +88,7 @@ require_once GP_PATH . GP_INC . 'things/administrator-permission.php';
 require_once GP_PATH . GP_INC . 'things/glossary.php';
 require_once GP_PATH . GP_INC . 'things/glossary-entry.php';
 
+require_once GP_PATH . GP_INC . 'route-exit-exception.php';
 require_once GP_PATH . GP_INC . 'route.php';
 require_once GP_PATH . GP_INC . 'router.php';
 

--- a/tests/phpunit/lib/testcase-route.php
+++ b/tests/phpunit/lib/testcase-route.php
@@ -12,6 +12,20 @@ class GP_UnitTestCase_Route extends GP_UnitTestCase {
 		$this->route->notices = array();
 	}
 
+	/**
+	 * Runs a route request and catches the exit a faked request throws when the
+	 * route ends the request, so the response can be asserted afterwards.
+	 *
+	 * @param callable $request Callback that invokes the route method under test.
+	 */
+	function do_route_request( callable $request ) {
+		try {
+			$request();
+		} catch ( GP_Route_Exit_Exception $e ) {
+			// The route ended the request; its state is recorded on $this->route.
+		}
+	}
+
 	function assertRedirected() {
 		$this->assertTrue( $this->route->redirected, "Wasn't redirected" );
 	}

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
@@ -69,7 +69,11 @@ class GP_Test_Route_Glossary_Entry extends GP_UnitTestCase_Route {
 		);
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-glossary-entry_' . $entry->id );
 
-		$this->route->glossary_entries_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+		$this->do_route_request(
+			function () use ( $authorized_set ) {
+				$this->route->glossary_entries_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+			}
+		);
 
 		$reloaded = GP::$glossary_entry->get( $entry->id );
 

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_self_status.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_self_status.php
@@ -1,0 +1,72 @@
+<?php
+
+class GP_Test_Route_Translation_Self_Status extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Translation';
+
+	private function create_waiting_translation_for( $set, $user_id ) {
+		$original = $this->factory->original->create(
+			array(
+				'project_id' => $set->project->id,
+				'status'     => '+active',
+			)
+		);
+
+		return $this->factory->translation->create(
+			array(
+				'translation_set_id' => $set->id,
+				'original_id'        => $original->id,
+				'status'             => 'waiting',
+				'user_id'            => $user_id,
+			)
+		);
+	}
+
+	private function set_status( $set, $translation, $status ) {
+		$_POST['status']             = $status;
+		$_POST['translation_id']     = $translation->id;
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'update-translation-status-' . $status . '_' . $translation->id );
+
+		$this->route->set_status( $set->project->path, $set->locale, $set->slug );
+
+		return GP::$translation->get( $translation->id );
+	}
+
+	public function test_user_cannot_approve_their_own_waiting_translation() {
+		$set         = $this->factory->translation_set->create_with_project_and_locale();
+		$user_id     = $this->set_normal_user_as_current();
+		$translation = $this->create_waiting_translation_for( $set, $user_id );
+
+		$reloaded = $this->set_status( $set, $translation, 'current' );
+
+		$this->assertSame( 'waiting', $reloaded->status, 'A user without approval rights must not approve their own translation.' );
+	}
+
+	public function test_user_can_reject_their_own_waiting_translation() {
+		$set         = $this->factory->translation_set->create_with_project_and_locale();
+		$user_id     = $this->set_normal_user_as_current();
+		$translation = $this->create_waiting_translation_for( $set, $user_id );
+
+		$reloaded = $this->set_status( $set, $translation, 'rejected' );
+
+		$this->assertSame( 'rejected', $reloaded->status, 'A user may reject their own waiting translation.' );
+	}
+
+	public function test_validator_can_approve_their_own_waiting_translation() {
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$user_id = $this->set_normal_user_as_current();
+		GP::$validator_permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'approve',
+				'project_id'  => $set->project->id,
+				'locale_slug' => $set->locale,
+				'set_slug'    => $set->slug,
+			)
+		);
+		$translation = $this->create_waiting_translation_for( $set, $user_id );
+
+		$reloaded = $this->set_status( $set, $translation, 'current' );
+
+		$this->assertSame( 'current', $reloaded->status, 'A validator may approve, including their own translation.' );
+	}
+}

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_self_status.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_self_status.php
@@ -26,7 +26,11 @@ class GP_Test_Route_Translation_Self_Status extends GP_UnitTestCase_Route {
 		$_POST['translation_id']     = $translation->id;
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'update-translation-status-' . $status . '_' . $translation->id );
 
-		$this->route->set_status( $set->project->path, $set->locale, $set->slug );
+		$this->do_route_request(
+			function () use ( $set ) {
+				$this->route->set_status( $set->project->path, $set->locale, $set->slug );
+			}
+		);
 
 		return GP::$translation->get( $translation->id );
 	}
@@ -39,6 +43,18 @@ class GP_Test_Route_Translation_Self_Status extends GP_UnitTestCase_Route {
 		$reloaded = $this->set_status( $set, $translation, 'current' );
 
 		$this->assertSame( 'waiting', $reloaded->status, 'A user without approval rights must not approve their own translation.' );
+		$this->assertSame( 403, $this->route->http_status, 'The route should forbid the change instead of failing later.' );
+	}
+
+	public function test_user_cannot_request_changes_on_their_own_waiting_translation() {
+		$set         = $this->factory->translation_set->create_with_project_and_locale();
+		$user_id     = $this->set_normal_user_as_current();
+		$translation = $this->create_waiting_translation_for( $set, $user_id );
+
+		$reloaded = $this->set_status( $set, $translation, 'changesrequested' );
+
+		$this->assertSame( 'waiting', $reloaded->status, 'A user without approval rights must not request changes on their own translation.' );
+		$this->assertSame( 403, $this->route->http_status, 'The route should forbid the change instead of failing later.' );
 	}
 
 	public function test_user_can_reject_their_own_waiting_translation() {

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
@@ -9,7 +9,9 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 	}
 
 	function test_single_with_a_non_existent_set_gives_404() {
-		$this->route->single( 11123123 );
+		$this->do_route_request( function () {
+			$this->route->single( 11123123 );
+		} );
 		$this->assert404();
 	}
 
@@ -96,7 +98,9 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 	function test_edit_post_with_a_non_existent_set_gives_404() {
 		$this->set_admin_user_as_current();
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-translation-set_11' );
-		$this->route->edit_post( 11 );
+		$this->do_route_request( function () {
+			$this->route->edit_post( 11 );
+		} );
 		$this->assert404();
 	}
 
@@ -156,7 +160,9 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 
 	function test_delete_post_with_a_non_existent_set_gives_404() {
 		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'delete-translation-set_11' );
-		$this->route->delete_post( 11 );
+		$this->do_route_request( function () {
+			$this->route->delete_post( 11 );
+		} );
 		$this->assert404();
 	}
 


### PR DESCRIPTION
## Summary

`GP_Route_Translation::can_approve_translation_or_forbidden()` let the author of
a waiting translation skip the approve-permission check for *any* target status,
including approving it (`current`) or requesting changes (`changesrequested`).

The model layer (`GP_Translation::can_set_status()`) already refuses those
transitions without the `approve` permission, so the status is never actually
changed — but the route fell through to `set_status()`, which then failed and
returned a misleading `500` ("Error in saving the translation status!") instead
of a `403`.

The route pre-check now mirrors the model: the author self-exemption still covers
managing their own waiting translation (rejecting it, or discarding its
warnings), but approving it or requesting changes requires the `approve`
permission.

## Commits

1. **Require approve permission to approve your own translation** — the change to
   `can_approve_translation_or_forbidden()` plus behaviour tests.
2. **Halt faked route requests at `exit_()`** — a test-harness change so a faked
   request stops where a real one would (see below), which lets the response be
   asserted.

## Test harness

Previously `GP_Route::exit_()` only recorded that a route had exited during a
faked request and then kept running, so code after a `die_with_error()` /
`die_with_404()` still executed and could overwrite the response the route had
already produced. It now throws a catchable `GP_Route_Exit_Exception`, mirroring
how a real request stops. Route tests run the request through a new
`GP_UnitTestCase_Route::do_route_request()` helper that catches it and then
assert the recorded response; the existing 404 tests are moved to the helper.

Compatibility note: this changes `exit_()` only under `fake_request` (a
test-only mode; real requests still call `exit()` and are unchanged). Any test
extending `GP_UnitTestCase_Route` that invokes a route reaching an exit path
should wrap the call in `do_route_request()`.

## Tests

`tests_routes/test_route_translation_self_status.php`:

- a user without approval rights cannot approve their own waiting translation —
  it stays `waiting` and the route responds with `403`;
- the same holds for requesting changes (`changesrequested`);
- a user may still reject their own waiting translation;
- a validator may approve, including their own translation.

Full suite green; `phpcs` clean.
