### PR TITLE
Whitelist editable project fields and scope path updates to descendants

### DIFF
--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -192,6 +192,20 @@ class GP_Route_Project extends GP_Route_Main {
 		$this->tmpl( 'project-edit', get_defined_vars() );
 	}
 
+	/**
+	 * Returns the project fields a user is allowed to set from the request.
+	 *
+	 * The path is intentionally excluded: it is derived from the slug and the
+	 * parent project in GP_Project::update_path(), never taken from the client.
+	 *
+	 * @return array Whitelisted project input.
+	 */
+	private function editable_project_input() {
+		$editable_fields = array( 'name', 'slug', 'description', 'source_url_template', 'active', 'parent_project_id' );
+
+		return array_intersect_key( (array) gp_post( 'project' ), array_flip( $editable_fields ) );
+	}
+
 	public function edit_post( $project_path ) {
 		$project = GP::$project->by_path( $project_path );
 
@@ -207,14 +221,18 @@ class GP_Route_Project extends GP_Route_Main {
 			return;
 		}
 
-		$updated_project = new GP_Project( gp_post( 'project' ) );
+		$updated_project = new GP_Project( $this->editable_project_input() );
 		if ( $this->invalid_and_redirect( $updated_project, gp_url_project( $project, '-edit' ) ) ) {
 			return;
 		}
 
+		$new_parent_id = (int) $updated_project->parent_project_id;
+
 		// TODO: add id check as a validation rule
-		if ( $project->id == $updated_project->parent_project_id ) {
+		if ( $project->id == $new_parent_id ) {
 			$this->errors[] = __( 'The project cannot be parent of itself!', 'glotpress' );
+		} elseif ( $new_parent_id && $new_parent_id !== (int) $project->parent_project_id && ! $this->can( 'write', 'project', $new_parent_id ) ) {
+			$this->errors[] = __( 'You are not allowed to do that!', 'glotpress' );
 		} elseif ( $project->save( $updated_project ) ) {
 			$this->notices[] = __( 'The project was saved.', 'glotpress' );
 		} else {
@@ -308,7 +326,7 @@ class GP_Route_Project extends GP_Route_Main {
 			return;
 		}
 
-		$post              = gp_post( 'project' );
+		$post              = $this->editable_project_input();
 		$parent_project_id = gp_array_get( $post, 'parent_project_id', null );
 
 		if ( $this->cannot_and_redirect( 'write', 'project', $parent_project_id ) ) {
@@ -541,7 +559,7 @@ class GP_Route_Project extends GP_Route_Main {
 
 
 	public function branch_project_post( $project_path ) {
-		$post    = gp_post( 'project' );
+		$post    = $this->editable_project_input();
 		$project = GP::$project->by_path( $project_path );
 
 		if ( ! $project ) {

--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -249,10 +249,12 @@ class GP_Project extends GP_Thing {
 		if ( is_null( $res_self ) ) {
 			return $res_self;
 		}
-		// Update children's paths, too.
+		// Update children's paths, too. The trailing slash restricts the match
+		// to actual descendants (old_path/...) so a project whose path is merely
+		// a prefix of an unrelated project (e.g. "foo" vs "foobar") is untouched.
 		if ( $old_path ) {
 			$query = "UPDATE $this->table SET path = CONCAT(%s, SUBSTRING(path, %d)) WHERE path LIKE %s";
-			return $this->query( $query, $path, strlen( $old_path ) + 1, $wpdb->esc_like( $old_path ) . '%' );
+			return $this->query( $query, $path, strlen( $old_path ) + 1, $wpdb->esc_like( $old_path ) . '/%' );
 		} else {
 			return $res_self;
 		}

--- a/tests/phpunit/testcases/tests_routes/test_route_project.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_project.php
@@ -1,0 +1,100 @@
+<?php
+
+class GP_Test_Route_Project extends GP_UnitTestCase_Route {
+	public $route_class = 'GP_Route_Project';
+
+	private function edit_project( $project, $fields ) {
+		$_POST['project']            = $fields;
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-project_' . $project->id );
+		$this->route->edit_post( $project->path );
+	}
+
+	public function test_a_submitted_path_cannot_rewrite_another_project_subtree() {
+		$this->set_admin_user_as_current();
+		$other_parent = $this->factory->project->create( array( 'name' => 'Foo', 'slug' => 'foo' ) );
+		$other_child  = $this->factory->project->create( array( 'name' => 'Bar', 'slug' => 'bar', 'parent_project_id' => $other_parent->id ) );
+		$project      = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned' ) );
+
+		// A path submitted in the request that, if trusted, would match the "foo" subtree.
+		$this->edit_project(
+			$project,
+			array(
+				'name'              => 'Owned',
+				'slug'              => 'owned',
+				'path'              => 'foo',
+				'parent_project_id' => 0,
+			)
+		);
+
+		$other_child->reload();
+		$this->assertSame( 'foo/bar', $other_child->path, 'A path in the request must not rewrite an unrelated project subtree.' );
+	}
+
+	public function test_renaming_a_project_leaves_a_prefix_sibling_untouched() {
+		$this->set_admin_user_as_current();
+		$sibling = $this->factory->project->create( array( 'name' => 'Foobar', 'slug' => 'foobar' ) );
+		$project = $this->factory->project->create( array( 'name' => 'Foo', 'slug' => 'foo' ) );
+
+		$this->edit_project(
+			$project,
+			array(
+				'name'              => 'Foo',
+				'slug'              => 'foo2',
+				'parent_project_id' => 0,
+			)
+		);
+
+		$sibling->reload();
+		$this->assertSame( 'foobar', $sibling->path, 'A sibling sharing the path prefix must not be rewritten.' );
+
+		$project->reload();
+		$this->assertSame( 'foo2', $project->path, 'The renamed project should get its new derived path.' );
+	}
+
+	public function test_writer_cannot_reparent_under_a_project_without_write_permission() {
+		$user_id      = $this->set_normal_user_as_current();
+		$project      = $this->factory->project->create( array( 'name' => 'Owned', 'slug' => 'owned' ) );
+		$other_parent = $this->factory->project->create( array( 'name' => 'Other', 'slug' => 'other' ) );
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $project->id,
+			)
+		);
+
+		$this->edit_project(
+			$project,
+			array(
+				'name'              => 'Owned',
+				'slug'              => 'owned',
+				'parent_project_id' => $other_parent->id,
+			)
+		);
+
+		$project->reload();
+		$this->assertSame( 0, (int) $project->parent_project_id, 'A user without write on the destination parent must not reparent under it.' );
+		$this->assertSame( 'owned', $project->path );
+	}
+
+	public function test_admin_can_reparent_a_project() {
+		$this->set_admin_user_as_current();
+		$parent  = $this->factory->project->create( array( 'name' => 'Parent', 'slug' => 'parent' ) );
+		$project = $this->factory->project->create( array( 'name' => 'Child', 'slug' => 'child' ) );
+
+		$this->edit_project(
+			$project,
+			array(
+				'name'              => 'Child',
+				'slug'              => 'child',
+				'parent_project_id' => $parent->id,
+			)
+		);
+
+		$project->reload();
+		$this->assertSame( (int) $parent->id, (int) $project->parent_project_id );
+		$this->assertSame( 'parent/child', $project->path );
+	}
+}


### PR DESCRIPTION
## Summary

Editing or creating a project passed the whole `project[...]` request array into
`GP_Project`, including the internal `path` field. `GP_Project::update_path()`
then used that value as the prefix for a `LIKE` update of descendant paths — and
matched without a trailing-slash boundary — so a `path` supplied in the request
could rewrite the paths of *unrelated* projects that merely shared a prefix
(`root/victi` matching `root/victim`). Reparenting also didn't check permission
on the destination parent.

## Changes

- The three routes that build a project from request input — `edit_post()`,
  `new_post()` and `branch_project_post()` — now go through a shared
  `editable_project_input()` helper that keeps only user-editable fields
  (`name`, `slug`, `description`, `source_url_template`, `active`,
  `parent_project_id`). `path` is never taken from the request — it is derived
  from the slug and parent project. No form exposes a `path` field, so this
  changes no UI flow. (The edit path is the one that could actually rewrite
  another project; applying the same whitelist to create/branch keeps the input
  boundary consistent.)
- `GP_Project::update_path()` scopes the descendant update with a trailing slash
  (`old_path/%`), so a project whose path is merely a prefix of an unrelated one
  (`foo` vs `foobar`) is left untouched. This also fixes a latent data-integrity
  bug in ordinary renames.
- `edit_post()` requires `write` permission on the destination parent when a
  project is reparented.

## Tests

`tests_routes/test_route_project.php`:

- a `path` supplied in an edit request does not change an unrelated project's path;
- renaming a project leaves a sibling sharing its path prefix untouched, and the
  renamed project still gets its new derived path;
- a user without `write` on the destination parent cannot reparent under it;
- an admin can still reparent a project (path is re-derived).

Full suite green; `phpcs` clean.
