### PR TITLE
Authorize translation set edits against the set's current project

### DIFF
--- a/gp-includes/routes/translation-set.php
+++ b/gp-includes/routes/translation-set.php
@@ -92,8 +92,16 @@ class GP_Route_Translation_Set extends GP_Route_Main {
 
 		list( $set, ,  ) = $items;
 
+		// Editing the set requires write access to the project it currently
+		// belongs to, independent of any project supplied in the request.
+		if ( $this->cannot_edit_set_and_redirect( $set ) ) {
+			return;
+		}
+
 		$new_set = new GP_Translation_Set( gp_post( 'set', array() ) );
 
+		// Moving the set to another project additionally requires write access
+		// to the destination project.
 		if ( $this->cannot_edit_set_and_redirect( $new_set ) ) {
 			return;
 		}

--- a/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation_set.php
@@ -173,4 +173,60 @@ class GP_Test_Route_Translation_Set extends GP_UnitTestCase_Route {
 		$this->assertNotAllowedRedirect();
 	}
 
+	private function grant_project_write( $user_id, $project_id ) {
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $project_id,
+			)
+		);
+	}
+
+	function test_edit_post_requires_write_on_the_sets_current_project() {
+		$user_id = $this->set_normal_user_as_current();
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$target  = $this->factory->project->create();
+
+		$original_project_id = $set->project_id;
+
+		// The user can write the destination project, but not the set's own project.
+		$this->grant_project_write( $user_id, $target->id );
+
+		$_POST['set']                = array(
+			'name'       => 'Renamed',
+			'slug'       => $set->slug,
+			'locale'     => $set->locale,
+			'project_id' => $target->id,
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-translation-set_' . $set->id );
+		$this->route->edit_post( $set->id );
+
+		$set->reload();
+		$this->assertEquals( $original_project_id, $set->project_id, 'The set must not move without write on its current project.' );
+		$this->assertNotEquals( 'Renamed', $set->name, 'The set must not be edited without write on its current project.' );
+	}
+
+	function test_edit_post_can_move_a_set_when_the_user_can_write_both_projects() {
+		$user_id = $this->set_normal_user_as_current();
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$target  = $this->factory->project->create();
+
+		$this->grant_project_write( $user_id, $set->project_id );
+		$this->grant_project_write( $user_id, $target->id );
+
+		$_POST['set']                = array(
+			'name'       => $set->name,
+			'slug'       => $set->slug,
+			'locale'     => $set->locale,
+			'project_id' => $target->id,
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'edit-translation-set_' . $set->id );
+		$this->route->edit_post( $set->id );
+
+		$set->reload();
+		$this->assertEquals( (int) $target->id, (int) $set->project_id, 'A user with write on both projects can move the set.' );
+	}
+
 }


### PR DESCRIPTION
## Summary

`GP_Route_Translation_Set::edit_post()` checked write permission against the
`project_id` supplied in the request (`cannot_edit_set_and_redirect($new_set)`),
not against the project the set currently belongs to. `edit_get()` already
checks the set's own project, so the two were inconsistent — the edit was
authorized against a request-controlled field rather than the object being
edited.

## Changes

- `edit_post()` now requires `write` on the set's **current** project
  (`$set->project_id`, matching `edit_get()`). Because a set can be moved to
  another project through the form's project dropdown, it *additionally*
  requires `write` on the **destination** project when one is supplied.
- `new_post()` is unchanged — checking the destination project on create is
  already correct.

The set-edit nonce is only ever rendered by `edit_get()`, which already gates on
the set's own project, so this is primarily a defense-in-depth / consistency
fix: the authorization no longer depends on a request field or on the nonce
flow.

## Tests

`tests_routes/test_route_translation_set.php`:

- a user with write on only the destination project cannot edit or move a set
  that belongs to a project they cannot write;
- a user with write on both the current and destination projects can move the
  set.

Full suite green; `phpcs` clean.
