### PR TITLE
Normalize string-array names in the Android XML export

### DIFF
--- a/gp-includes/formats/format-android.php
+++ b/gp-includes/formats/format-android.php
@@ -86,7 +86,7 @@ class GP_Format_Android extends GP_Format {
 				$entry->context = $entry->singular;
 			}
 
-			$id = preg_replace( '/[^a-zA-Z0-9_]/U', '_', $entry->context );
+			$id = $this->normalize_resource_name( $entry->context );
 
 			$this->line( '<string name="' . $id . '">' . $this->escape( $entry->translations[0] ) . '</string>', 1 );
 		}
@@ -355,7 +355,9 @@ class GP_Format_Android extends GP_Format {
 
 		// Loop through all of the single entries add them to a mapping array.
 		foreach ( $entries as $entry ) {
-			// Make sure the array name is sanitized.
+			// Group by the raw array name (the context without its index suffix)
+			// so arrays with distinct names are never merged. The name is
+			// normalized only on output below.
 			$array_name = preg_replace( '/\[\d+\]$/', '', $entry->context );
 
 			// Initialize the mapping array entry if this is the first time.
@@ -378,8 +380,10 @@ class GP_Format_Android extends GP_Format {
 
 		// Now do the actual output to the class variable.
 		foreach ( array_keys( $mapping ) as $array_name ) {
-			// Open the string array tag.
-			$this->line( '<string-array name="' . $array_name . '">', 1 );
+			// Open the string array tag. The name is normalized to the
+			// characters Android allows (matching the <string> export) so it
+			// can't break out of the name attribute.
+			$this->line( '<string-array name="' . $this->normalize_resource_name( $array_name ) . '">', 1 );
 
 			// Output each item in the array.
 			foreach ( $mapping[ $array_name ] as $item ) {
@@ -389,6 +393,19 @@ class GP_Format_Android extends GP_Format {
 			// Close the string array tag.
 			$this->line( '</string-array>', 1 );
 		}
+	}
+
+	/**
+	 * Normalizes a context into an Android resource name.
+	 *
+	 * Replaces every character Android does not allow in a resource name with an
+	 * underscore, so the value is safe to write into a `name` attribute.
+	 *
+	 * @param string $name The raw context.
+	 * @return string The normalized resource name.
+	 */
+	private function normalize_resource_name( $name ) {
+		return preg_replace( '/[^a-zA-Z0-9_]/U', '_', $name );
 	}
 
 	/**

--- a/tests/phpunit/testcases/tests_formats/test_format_android.php
+++ b/tests/phpunit/testcases/tests_formats/test_format_android.php
@@ -39,6 +39,54 @@ class GP_Test_Format_Android extends GP_UnitTestCase {
 		$this->assertEquals( $file_contents, $this->android->print_exported_file( $project, $locale, $set, $entries_for_export ) );
 	}
 
+	function test_export_normalizes_string_array_names() {
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$project = $set->project;
+		$locale  = $this->factory->locale->create();
+
+		// The array name (the context minus its [index] suffix) contains
+		// characters that would break out of the name attribute if written raw.
+		$entries_for_export = array(
+			(object) array(
+				'context'      => 'x"><y[0]',
+				'singular'     => 'a',
+				'translations' => array( 'a' ),
+			),
+		);
+
+		$xml = $this->android->print_exported_file( $project, $locale, $set, $entries_for_export );
+
+		$this->assertStringContainsString( '<string-array name="x___y">', $xml );
+		$this->assertStringNotContainsString( 'x"><y', $xml );
+	}
+
+	function test_export_does_not_merge_arrays_with_distinct_names() {
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$project = $set->project;
+		$locale  = $this->factory->locale->create();
+
+		// Two arrays whose raw names differ but normalize to the same value must
+		// stay separate; normalization happens only for the output attribute.
+		$entries_for_export = array(
+			(object) array(
+				'context'      => 'a.b[0]',
+				'singular'     => 'one',
+				'translations' => array( 'one' ),
+			),
+			(object) array(
+				'context'      => 'a_b[0]',
+				'singular'     => 'two',
+				'translations' => array( 'two' ),
+			),
+		);
+
+		$xml = $this->android->print_exported_file( $project, $locale, $set, $entries_for_export );
+
+		$this->assertSame( 2, substr_count( $xml, '<string-array name="a_b">' ), 'Arrays with distinct raw names must not be merged.' );
+		$this->assertStringContainsString( '<item>one</item>', $xml );
+		$this->assertStringContainsString( '<item>two</item>', $xml );
+	}
+
 
 	function test_read_originals() {
 		$translations = $this->android->read_originals_from_file( GP_DIR_TESTDATA . '/originals.android.xml' );


### PR DESCRIPTION
## Summary

The Android XML exporter normalizes the resource name for `<string>` entries
(any character outside `[a-zA-Z0-9_]` is replaced with `_`), but the
`<string-array>` export only stripped the `[index]` suffix from the context and
wrote the remaining name straight into the `name` attribute.

A context whose array-name part contains characters like `"`, `<` or `>` — which
can enter through an imported Android XML file, where SimpleXML decodes entities
in the `name` and GlotPress stores the decoded value as the context — was
therefore written unescaped, letting extra resource nodes be injected into the
exported file.

## Changes

- `GP_Format_Android::string_arrays()` normalizes the `<string-array>` name only
  when writing the `name` attribute, so it contains only Android-valid resource
  characters and can't break out of the attribute. Grouping still keys on the
  raw name, so arrays with distinct names are never merged.
- The normalization shared by the `<string>` and `<string-array>` exports is now
  a single `normalize_resource_name()` helper, so the two paths can't drift.

## Tests

- `test_export_normalizes_string_array_names`: a string-array context whose name
  contains attribute-breaking characters is normalized in the exported
  `<string-array name="…">`.
- `test_export_does_not_merge_arrays_with_distinct_names`: two arrays whose raw
  names differ but normalize to the same value stay separate (no items merged or
  lost).

Both tests are in `test_format_android.php`.

Full suite green; `phpcs` clean.
