### PR TITLE
Verify a bulk row's original belongs to the authorized project

### DIFF
--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -262,16 +262,22 @@ class GP_Route_Translation extends GP_Route_Main {
 
 		$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $project->id, $translation_set_slug, $locale_slug );
 
-		$this->can_or_forbidden( 'edit', 'translation-set', $translation_set->id );
-
 		if ( ! $translation_set ) {
 			return $this->die_with_404();
 		}
+
+		$this->can_or_forbidden( 'edit', 'translation-set', $translation_set->id );
 
 		$glossary = $this->get_extended_glossary( $translation_set, $project );
 
 		$output = array();
 		foreach ( gp_post( 'translation', array() ) as $original_id => $translations ) {
+			$original = GP::$original->get( $original_id );
+
+			if ( ! $this->original_belongs_to_project( $original, $project ) ) {
+				continue;
+			}
+
 			$data                       = compact( 'original_id' );
 			$data['user_id']            = get_current_user_id();
 			$data['translation_set_id'] = $translation_set->id;
@@ -297,7 +303,6 @@ class GP_Route_Translation extends GP_Route_Main {
 				$set_status = 'waiting';
 			}
 
-			$original         = GP::$original->get( $original_id );
 			$data['warnings'] = GP::$translation_warnings->check( $original->singular, $original->plural, $translations, $locale );
 			$errors           = GP::$translation_errors->check( $original, $translations, $locale );
 			if ( $errors ) {
@@ -461,21 +466,33 @@ class GP_Route_Translation extends GP_Route_Main {
 					$original_id    = (int) gp_array_get( $parts, 0 );
 					$translation_id = (int) gp_array_get( $parts, 1 );
 
+					$original = GP::$original->get( $original_id );
+					if ( ! $this->original_belongs_to_project( $original, $project ) ) {
+						return false;
+					}
+
 					if ( $translation_id ) {
-						// A translated row must be a genuine (original, translation) pair of this set,
-						// which in turn guarantees the original belongs to the set's project.
 						$translation = GP::$translation->get( $translation_id );
 						return $translation
 							&& (int) $translation->translation_set_id === (int) $translation_set->id
 							&& (int) $translation->original_id === $original_id;
 					}
 
-					// An untranslated row (e.g. set-priority) must reference an original of this project.
-					$original = GP::$original->get( $original_id );
-					return $original && (int) $original->project_id === (int) $project->id;
+					return true;
 				}
 			)
 		);
+	}
+
+	/**
+	 * Whether an original exists and belongs to a project.
+	 *
+	 * @param GP_Original|false $original The original to check.
+	 * @param GP_Project        $project  The project it must belong to.
+	 * @return bool
+	 */
+	private function original_belongs_to_project( $original, $project ) {
+		return $original && (int) $original->project_id === (int) $project->id;
 	}
 
 	private function _bulk_approve( $bulk ) {

--- a/tests/phpunit/testcases/tests_routes/test_route_translation.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_translation.php
@@ -121,4 +121,80 @@ class GP_Test_Route_Translation extends GP_UnitTestCase_Route {
 
 		$this->assertEquals( 'current', GP::$translation->get( $translation_b->id )->status );
 	}
+
+	/**
+	 * A translation whose set is authorized but whose original belongs to another project (a
+	 * "phantom" pairing) must not let a bulk action reach that foreign original.
+	 */
+	function test_bulk_set_priority_cannot_target_a_cross_project_original_via_a_phantom_translation() {
+		$authorized_set = $this->factory->translation_set->create_with_project_and_locale();
+		$other_set      = $this->factory->translation_set->create_with_project_and_locale();
+
+		$victim_original = $this->factory->original->create( array( 'project_id' => $other_set->project->id, 'status' => '+active', 'singular' => 'Victim', 'priority' => 0 ) );
+
+		// A translation in the authorized set that points at the other project's original.
+		$phantom = $this->factory->translation->create( array( 'translation_set_id' => $authorized_set->id, 'original_id' => $victim_original->id ) );
+
+		$user = $this->become_validator_for_set( $authorized_set );
+		GP::$permission->create( array( 'user_id' => $user, 'action' => 'write', 'object_type' => 'project', 'object_id' => $authorized_set->project->id ) );
+
+		$_POST['bulk'] = array(
+			'action'      => 'set-priority',
+			'priority'    => -2,
+			'row-ids'     => $victim_original->id . '-' . $phantom->id,
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $authorized_set->project->path, $authorized_set->locale, $authorized_set->slug );
+
+		$this->assertEquals( 0, (int) GP::$original->get( $victim_original->id )->priority, 'A cross-project original must not be reachable through a phantom translation.' );
+	}
+
+	/**
+	 * Submitting a translation for an original that belongs to another project must not create it,
+	 * so a translation's set and original can never span two projects.
+	 */
+	function test_translations_post_ignores_an_original_from_another_project() {
+		$set   = $this->factory->translation_set->create_with_project_and_locale();
+		$other = $this->factory->translation_set->create_with_project_and_locale();
+
+		$foreign_original = $this->factory->original->create( array( 'project_id' => $other->project->id, 'status' => '+active', 'singular' => 'Foreign' ) );
+
+		$this->set_normal_user_as_current();
+
+		$_POST['original_id']        = $foreign_original->id;
+		$_POST['translation']        = array( $foreign_original->id => array( 'anything' ) );
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-translation_' . $foreign_original->id );
+
+		$this->do_route_request(
+			function () use ( $set ) {
+				$this->route->translations_post( $set->project->path, $set->locale, $set->slug );
+			}
+		);
+
+		$this->assertFalse( GP::$translation->find_one( array( 'original_id' => $foreign_original->id ) ), 'A translation must not be created for another project\'s original.' );
+	}
+
+	/**
+	 * The tightened filter must still act on a legitimate in-project translated row.
+	 */
+	function test_bulk_fuzzy_marks_a_translation_of_the_authorized_set() {
+		$set = $this->factory->translation_set->create_with_project_and_locale();
+		$this->become_validator_for_set( $set );
+
+		$original    = $this->factory->original->create( array( 'project_id' => $set->project->id, 'status' => '+active', 'singular' => 'Hello' ) );
+		$translation = $this->factory->translation->create( array( 'translation_set_id' => $set->id, 'original_id' => $original->id, 'status' => 'current' ) );
+
+		$_POST['bulk'] = array(
+			'action'      => 'fuzzy',
+			'row-ids'     => $original->id . '-' . $translation->id,
+			'redirect_to' => '/',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'bulk-actions' );
+
+		$this->route->bulk_post( $set->project->path, $set->locale, $set->slug );
+
+		$this->assertEquals( 'fuzzy', GP::$translation->get( $translation->id )->status, 'A legitimate in-project translated row must still be acted on.' );
+	}
 }


### PR DESCRIPTION
## Summary

`GP_Route_Translation::filter_bulk_row_ids_for_set()` (added in #2057) validated a
bulk row that includes a translation ID by checking the translation's
`translation_set_id` and `original_id`, assuming a matching translation proved
the row's original belonged to the authorized project. That invariant is not
enforced: `translations_post()` lets any logged-in user create a translation
whose `translation_set_id` is their own set while its `original_id` points at an
original in another project.

Such a "phantom" translation satisfies the filter by construction, so a bulk
`set-priority` row pairing another project's original with the phantom passed the
filter, and `_bulk_set_priority()` then modified that foreign original.

## Changes

- `filter_bulk_row_ids_for_set()` now always resolves the row's original and
  requires it to belong to the authorized project, independent of any paired
  translation. A translation row must *additionally* be a genuine
  `(original, translation)` pair of the set.
- `translations_post()` skips an `original_id` that does not belong to the set's
  project, so a translation's set and original can never span two projects (also
  guarding a null from an unknown `original_id`).
- Both ownership checks share a small `original_belongs_to_project()` helper.
- Incidental: `translations_post()` returns a 404 for an unknown translation set
  before the permission check, instead of reading a property on a non-object.

Either of the two ownership changes alone closes the issue; both are included as
defense in depth.

## Tests

`tests_routes/test_route_translation.php`:

- a bulk `set-priority` row that pairs another project's original with a phantom
  translation in the authorized set leaves the foreign original untouched;
- submitting a translation for an original in another project creates nothing;
- a legitimate in-project row is still acted on (a bulk `fuzzy` marks a
  translation of the authorized set).

Full suite green; `phpcs` clean.
