### PR TITLE
Fix dynamic property creation for GP_Translation_Set::$last_modified

### DIFF
--- a/gp-includes/things/translation-set.php
+++ b/gp-includes/things/translation-set.php
@@ -147,6 +147,13 @@ class GP_Translation_Set extends GP_Thing {
 	public $wp_locale;
 
 	/**
+	 * The date of the last modified translation.
+	 *
+	 * @var string|false
+	 */
+	public $last_modified;
+
+	/**
 	 * Sets restriction rules for fields.
 	 *
 	 * @since 1.0.0

--- a/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_translation_set.php
@@ -331,4 +331,15 @@ class GP_Test_Thing_Translation_set extends GP_UnitTestCase {
 		$this->assertStringNotContainsString( $name, $html );
 		$this->assertStringContainsString( esc_html( $name ), $html );
 	}
+
+	function test_non_db_field_names_are_declared_properties() {
+		$set = new GP_Translation_Set();
+
+		foreach ( $set->non_db_field_names as $field ) {
+			$this->assertTrue(
+				property_exists( $set, $field ),
+				"Non-DB field '$field' must be a declared property so assigning it does not create a dynamic property."
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`GP_Translation_Set::$last_modified` is listed in `$non_db_field_names` but,
unlike every other computed field, was never declared as a class property.
`GP_Route_Project::translation_sets_get()` assigns it on the API path
(`gp-includes/routes/project.php`), which on PHP 8.2+ creates a dynamic property
and emits a `Creation of dynamic property … is deprecated` notice. With
`display_errors` on, that notice is written before the JSON `Content-Type`
header, producing a follow-on "Cannot modify header information - headers
already sent" warning.

## Changes

- Declare `public $last_modified;` on `GP_Translation_Set`, matching the other
  non-DB computed properties.

## Tests

- `tests_things/test_thing_translation_set.php`: assert every `$non_db_field_names`
  entry is a declared property, so assigning any of them never creates a dynamic
  property (guards the whole class of bug).
