### PR TITLE
Require delete permission to remove translation sets via mass-create

### DIFF
--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -485,7 +485,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;t found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		$changes = $project->set_difference_from( $other_project );
@@ -519,7 +519,7 @@ class GP_Route_Project extends GP_Route_Main {
 				}
 			}
 		} elseif ( ! empty( $changes['removed'] ) ) {
-			$this->errors[] = __( 'You are not allowed to remove translation sets, so only additions were applied.', 'glotpress' );
+			$this->errors[] = __( 'You are not allowed to remove translation sets.', 'glotpress' );
 		}
 		if ( empty( $this->errors ) ) {
 			$this->notices[] = __( 'Translation sets were added and removed successfully', 'glotpress' );
@@ -542,7 +542,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;t found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		header( 'Content-Type: application/json' );

--- a/gp-includes/routes/project.php
+++ b/gp-includes/routes/project.php
@@ -485,10 +485,12 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, __esc_html__( 'Not found', 'glotpress' ), '404' );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		$changes = $project->set_difference_from( $other_project );
+
+		$can_delete = $this->can( 'delete', 'project', $project->id );
 
 		foreach ( $changes['added'] as $to_add ) {
 			if ( ! GP::$translation_set->create(
@@ -506,14 +508,18 @@ class GP_Route_Project extends GP_Route_Main {
 				);
 			}
 		}
-		foreach ( $changes['removed'] as $to_remove ) {
-			if ( ! $to_remove->delete() ) {
-				$this->errors[] = sprintf(
-					/* translators: %s: Translation set name. */
-					__( 'Couldn&#8217;t delete translation set named %s', 'glotpress' ),
-					esc_html( $to_remove->name )
-				);
+		if ( $can_delete ) {
+			foreach ( $changes['removed'] as $to_remove ) {
+				if ( ! $to_remove->delete() ) {
+					$this->errors[] = sprintf(
+						/* translators: %s: Translation set name. */
+						__( 'Couldn&#8217;t delete translation set named %s', 'glotpress' ),
+						esc_html( $to_remove->name )
+					);
+				}
 			}
+		} elseif ( ! empty( $changes['removed'] ) ) {
+			$this->errors[] = __( 'You are not allowed to remove translation sets, so only additions were applied.', 'glotpress' );
 		}
 		if ( empty( $this->errors ) ) {
 			$this->notices[] = __( 'Translation sets were added and removed successfully', 'glotpress' );
@@ -536,7 +542,7 @@ class GP_Route_Project extends GP_Route_Main {
 		$other_project = GP::$project->get( gp_post( 'project_id' ) );
 
 		if ( ! $other_project ) {
-			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, __esc_html__( 'Not found', 'glotpress' ), '404' );
+			return $this->die_with_error( esc_html__( 'Project wasn&#8217;found', 'glotpress' ), 404, esc_html__( 'Not found', 'glotpress' ), '404' );
 		}
 
 		header( 'Content-Type: application/json' );

--- a/tests/phpunit/testcases/tests_routes/test_route_project.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_project.php
@@ -97,4 +97,91 @@ class GP_Test_Route_Project extends GP_UnitTestCase_Route {
 		$this->assertSame( (int) $parent->id, (int) $project->parent_project_id );
 		$this->assertSame( 'parent/child', $project->path );
 	}
+
+	private function mass_create_sets( $target, $source ) {
+		$_POST['project_id']         = $source->id;
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'mass-create-transation-sets_' . $target->id );
+		$this->route->mass_create_sets_post( $target->path );
+	}
+
+	public function test_mass_create_does_not_remove_a_set_without_delete_permission() {
+		$user_id = $this->set_normal_user_as_current();
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$source  = $this->factory->project->create();
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $set->project->id,
+			)
+		);
+
+		$this->mass_create_sets( $set->project, $source );
+
+		$this->assertNotFalse( GP::$translation_set->get( $set->id ), 'A writer without delete permission must not remove an existing set.' );
+	}
+
+	public function test_mass_create_removes_a_set_with_delete_permission() {
+		$user_id = $this->set_normal_user_as_current();
+		$set     = $this->factory->translation_set->create_with_project_and_locale();
+		$source  = $this->factory->project->create();
+
+		foreach ( array( 'write', 'delete' ) as $action ) {
+			GP::$permission->create(
+				array(
+					'user_id'     => $user_id,
+					'action'      => $action,
+					'object_type' => 'project',
+					'object_id'   => $set->project->id,
+				)
+			);
+		}
+
+		$this->mass_create_sets( $set->project, $source );
+
+		$this->assertFalse( GP::$translation_set->get( $set->id ), 'A user with delete permission can remove sets via mass-create.' );
+	}
+
+	public function test_mass_create_still_adds_a_set_for_a_writer() {
+		$user_id    = $this->set_normal_user_as_current();
+		$target     = $this->factory->project->create();
+		$source_set = $this->factory->translation_set->create_with_project_and_locale();
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $target->id,
+			)
+		);
+
+		$this->mass_create_sets( $target, $source_set->project );
+
+		$this->assertCount( 1, GP::$translation_set->by_project_id( $target->id ), 'A writer can still add sets when nothing is removed.' );
+	}
+
+	public function test_mass_create_applies_additions_but_skips_removals_without_delete_permission() {
+		$user_id    = $this->set_normal_user_as_current();
+		$target_set = $this->factory->translation_set->create_with_project_and_locale();
+		$source_set = $this->factory->translation_set->create_with_project_and_locale();
+
+		GP::$permission->create(
+			array(
+				'user_id'     => $user_id,
+				'action'      => 'write',
+				'object_type' => 'project',
+				'object_id'   => $target_set->project->id,
+			)
+		);
+
+		// The source has a locale the target lacks (an addition) and lacks the
+		// target's locale (a removal), so the diff contains both.
+		$this->mass_create_sets( $target_set->project, $source_set->project );
+
+		$this->assertNotFalse( GP::$translation_set->get( $target_set->id ), 'The existing set must survive without delete permission.' );
+		$this->assertCount( 2, GP::$translation_set->by_project_id( $target_set->project->id ), 'The addition is applied while the removal is skipped.' );
+	}
 }


### PR DESCRIPTION
## Summary

`GP_Route_Project::mass_create_sets_post()` authorized the whole operation with
only the project `write` permission, then deleted every set in the computed
`removed` diff via `$to_remove->delete()`, with no `delete` check. The standalone
translation-set delete route requires `delete` on the project, so the two paths
enforced different boundaries: a user with project write but not delete could
remove existing sets (and their translations) by running mass-create against an
empty or unrelated source project.

## Changes

- `mass_create_sets_post()`: gate the removal step on `delete` permission. A
  writer without it still gets the additions; the removals are skipped and a
  notice is shown, instead of performing an unauthorized deletion.
- Also fixes a pre-existing fatal on the invalid-source-project path: a typo'd
  `__esc_html__()` (undefined) is corrected to `esc_html__()` in the POST and
  preview handlers, so that path returns its intended 404 instead of a 500.

## Tests

`tests_routes/test_route_project.php`:

- a writer without delete permission cannot remove an existing set via mass-create;
- a user with an explicit delete permission still can;
- a writer can still add sets when nothing is removed;
- a mixed diff applies the additions but skips the removals without delete permission.

Full suite green.
