### PR TITLE
Compare translation sets by locale and slug in set_difference_from()

### DIFF
--- a/gp-includes/things/project.php
+++ b/gp-includes/things/project.php
@@ -358,7 +358,7 @@ class GP_Project extends GP_Thing {
 	}
 
 	public function _compare_set_item( $set, $this_set ) {
-		return ( $set->locale == $this_set->locale && $set->slug = $this_set->slug );
+		return ( $set->locale === $this_set->locale && $set->slug === $this_set->slug );
 	}
 
 	public function copy_sets_and_translations_from( $source_project_id ) {

--- a/tests/phpunit/testcases/tests_things/test_thing_project.php
+++ b/tests/phpunit/testcases/tests_things/test_thing_project.php
@@ -174,6 +174,20 @@ class GP_Test_Project extends GP_UnitTestCase {
 		$this->assertEquals( $s1->id, $difference['removed'][0]->id );
 	}
 
+	function test_set_difference_from_distinguishes_sets_by_slug() {
+		$locale = $this->factory->locale->create();
+		$target = $this->factory->project->create( array( 'name' => 'Target' ) );
+		$source = $this->factory->project->create( array( 'name' => 'Source' ) );
+
+		$target_set = $this->factory->translation_set->create( array( 'project_id' => $target->id, 'locale' => $locale->slug, 'slug' => 'default' ) );
+		$source_set = $this->factory->translation_set->create( array( 'project_id' => $source->id, 'locale' => $locale->slug, 'slug' => 'formal' ) );
+
+		$difference = $target->set_difference_from( $source );
+
+		$this->assertEquals( $source_set->id, $difference['added'][0]->id );
+		$this->assertEquals( $target_set->id, $difference['removed'][0]->id );
+	}
+
 	function test_copy_originals_from() {
 		$s1 = $this->factory->translation_set->create_with_project_and_locale( array( 'locale' => 'bg' ), array( 'name' => 'P1' ) );
 		$s2 = $this->factory->translation_set->create_with_project_and_locale( array( 'locale' => 'nl' ), array( 'name' => 'P2' ) );


### PR DESCRIPTION
## Summary

`GP_Project::_compare_set_item()` used `$set->slug = $this_set->slug` (a `=`
assignment, not `==`), so the slug half of the comparison always evaluated truthy
and also mutated `$set->slug` as a side effect. As a result `set_difference_from()`
compared translation sets by locale alone: two sets in the same locale but with
different slugs were treated as identical, and the compared set's slug was
silently overwritten.

This surfaces in mass-create-sets and any other set-diff consumer: sets that
differ only by slug were neither added nor removed as they should be.

## Changes

- Compare both `locale` and `slug` with strict equality, so sets are matched by
  their real identity and the comparison no longer mutates its argument.

## Tests

- `tests_things/test_thing_project.php`: `set_difference_from()` treats two sets
  with the same locale but different slugs as an addition and a removal.

Full suite green.
