### PR TITLE
Pin the WordPress.org deploy action to a commit SHA

### DIFF
--- a/.github/workflows/deploy-wporg-plugin.yml
+++ b/.github/workflows/deploy-wporg-plugin.yml
@@ -35,7 +35,7 @@ jobs:
           git commit -m "Build" || true
 
       - name: WordPress.org plugin update
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}


### PR DESCRIPTION
## Summary

The `WordPress.org plugin update` step in `deploy-wporg-plugin.yml` runs
`10up/action-wordpress-plugin-deploy` from the mutable `@stable` ref while that
step receives `WORDPRESSORG_SVN_USERNAME` / `WORDPRESSORG_SVN_PASSWORD`. Whoever
can move that ref controls the code that reads the release credentials.

Pin the action to a full commit SHA, matching how the sibling
`deploy-wporg-assets.yml` already pins its 10up action. The existing Dependabot
`github-actions` entry keeps the pin current.

## Changes

- Pin `10up/action-wordpress-plugin-deploy` to `54bd289b8525fd23a5c365ec369185f2966529c2` (2.3.0).
