### PR TITLE
Authorize glossary entry additions against the target glossary's set

### DIFF
--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -75,11 +75,6 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			return;
 		}
 
-		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $translation_set->id ) ) {
-			return;
-		}
-
-		// Derive the glossary from the authorized set; a client-supplied glossary_id must not target an unrelated glossary.
 		$glossary = GP::$glossary->by_set_or_parent_project( $translation_set, $project );
 		if ( ! $glossary ) {
 			return $this->die_with_404();

--- a/gp-includes/routes/glossary-entry.php
+++ b/gp-includes/routes/glossary-entry.php
@@ -52,7 +52,7 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 			}
 		}
 
-		$can_edit = $this->can( 'approve', 'translation-set', $translation_set->id );
+		$can_edit = $this->can( 'approve', 'translation-set', $glossary->translation_set_id );
 		$url      = gp_url_join( gp_url_project_locale( $project->path, $locale_slug, $translation_set_slug ), array( 'glossary' ) );
 
 		$this->tmpl( 'glossary-view', get_defined_vars() );
@@ -83,6 +83,10 @@ class GP_Route_Glossary_Entry extends GP_Route_Main {
 		$glossary = GP::$glossary->by_set_or_parent_project( $translation_set, $project );
 		if ( ! $glossary ) {
 			return $this->die_with_404();
+		}
+
+		if ( $this->cannot_and_redirect( 'approve', 'translation-set', $glossary->translation_set_id ) ) {
+			return;
 		}
 
 		$new_glossary_entry                 = new GP_Glossary_Entry( gp_post( 'new_glossary_entry' ) );

--- a/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
+++ b/tests/phpunit/testcases/tests_routes/test_route_glossary_entry.php
@@ -82,4 +82,67 @@ class GP_Test_Route_Glossary_Entry extends GP_UnitTestCase_Route {
 		$this->assertEquals( 'edited', $reloaded->term );
 		$this->assertCount( 0, GP::$glossary_entry->by_glossary_id( $other_glossary->id ) );
 	}
+
+	/**
+	 * A validator of a sub-project set must not add entries to a glossary
+	 * inherited from an ancestor project, which they hold no permission on.
+	 */
+	function test_add_entry_cannot_reach_a_parent_glossary_from_a_sub_project_set() {
+		$parent_set      = $this->factory->translation_set->create_with_project_and_locale();
+		$parent_glossary = GP::$glossary->create( array( 'translation_set_id' => $parent_set->id ) );
+
+		$child_project = $this->factory->project->create( array( 'parent_project_id' => $parent_set->project->id ) );
+		$child_set     = $this->factory->translation_set->create(
+			array(
+				'project_id' => $child_project->id,
+				'locale'     => $parent_set->locale,
+				'slug'       => $parent_set->slug,
+			)
+		);
+		$child_set->project = $child_project;
+
+		$this->become_validator_for_set( $child_set );
+
+		$_POST['new_glossary_entry'] = array(
+			'term'           => 'security',
+			'part_of_speech' => 'noun',
+			'translation'    => 'Sicherheit',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-glossary-entry_' . $child_project->path . $child_set->locale . $child_set->slug );
+
+		$this->route->glossary_entry_add_post( $child_project->path, $child_set->locale, $child_set->slug );
+
+		$this->assertCount( 0, GP::$glossary_entry->by_glossary_id( $parent_glossary->id ), 'A sub-project validator must not write into the parent project glossary.' );
+	}
+
+	/**
+	 * A validator of the parent project can still add entries to the parent
+	 * glossary through a sub-project that inherits it.
+	 */
+	function test_add_entry_reaches_a_parent_glossary_for_a_parent_validator() {
+		$parent_set      = $this->factory->translation_set->create_with_project_and_locale();
+		$parent_glossary = GP::$glossary->create( array( 'translation_set_id' => $parent_set->id ) );
+
+		$child_project = $this->factory->project->create( array( 'parent_project_id' => $parent_set->project->id ) );
+		$child_set     = $this->factory->translation_set->create(
+			array(
+				'project_id' => $child_project->id,
+				'locale'     => $parent_set->locale,
+				'slug'       => $parent_set->slug,
+			)
+		);
+
+		$this->become_validator_for_set( $parent_set );
+
+		$_POST['new_glossary_entry'] = array(
+			'term'           => 'security',
+			'part_of_speech' => 'noun',
+			'translation'    => 'Sicherheit',
+		);
+		$_REQUEST['_gp_route_nonce'] = wp_create_nonce( 'add-glossary-entry_' . $child_project->path . $child_set->locale . $child_set->slug );
+
+		$this->route->glossary_entry_add_post( $child_project->path, $child_set->locale, $child_set->slug );
+
+		$this->assertCount( 1, GP::$glossary_entry->by_glossary_id( $parent_glossary->id ), 'A parent validator can add to the parent glossary.' );
+	}
 }


### PR DESCRIPTION
## Summary

`GP_Route_Glossary_Entry::glossary_entry_add_post()` checked `approve` on the
translation set named in the URL, but the glossary it writes to is resolved with
`by_set_or_parent_project()`, which walks up the project tree when the URL set has
no glossary of its own. A validator scoped to a sub-project could therefore add
entries to an ancestor project's shared glossary (inherited by the parent and
every sibling sub-project, and included in the parent's CSV export) without any
permission on it.

## Changes

- `glossary_entry_add_post()`: after resolving the glossary, require `approve` on
  the glossary's own translation set, so an entry can only be added to a glossary
  the requester is authorized for.
- `glossary_entries_get()`: base `$can_edit` on the resolved glossary's set rather
  than the URL set, so the create/edit/delete UI is shown only when the user can
  actually modify the displayed glossary (no click-then-denied on an inherited
  glossary).

## Tests

`tests_routes/test_route_glossary_entry.php`:

- a sub-project validator cannot add entries to an inherited parent glossary;
- a parent validator can still add to the parent glossary through a sub-project;
- the existing "add targets the authorized set's own glossary" test still holds.

Full suite green.
